### PR TITLE
feat: 添加DeepLX翻译服务支持，包含服务地址配置和令牌可选性检查

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -200,6 +200,20 @@
       </el-col>
     </el-row>
 
+    <!-- DeepLX URL 配置-->
+    <el-row v-show="compute.showDeepLX" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content="DeepLX API 服务地址，默认为本地地址。如果使用远程 DeepLX 服务，请修改为对应的服务地址" placement="top-start"
+          :show-after="500">
+          <span class="popup-text popup-vertical-left">服务地址</span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-input v-model="config.deeplx" placeholder="http://localhost:1188/translate" />
+      </el-col>
+    </el-row>
+
     <!-- 使用AkSk -->
     <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
@@ -454,13 +468,15 @@ let compute = ref({
   model: computed(() => models.get(config.value.service) || []),
   // 8、是否需要自定义接口
   showCustom: computed(() => servicesType.isCustom(config.value.service)),
-  // 9、是否自定义模型
+  // 9、是否显示 DeepLX URL 配置
+  showDeepLX: computed(() => config.value.service === 'deeplx'),
+  // 10、是否自定义模型
   showCustomModel: computed(() => servicesType.isAI(config.value.service) && config.value.model[config.value.service] === "自定义模型"),
-  // 10、判断是否为"双语模式"，控制一些翻译服务的显示
+  // 11、判断是否为"双语模式"，控制一些翻译服务的显示
   filteredServices: computed(() => options.services.filter((service: any) =>
     !([service.google].includes(service.value) && config.value.display !== 1))
   ),
-  // 11、判断是否为 coze
+  // 12、判断是否为 coze
   showRobotId: computed(() => servicesType.isCoze(config.value.service)),
 })
 

--- a/entrypoints/service/_service.ts
+++ b/entrypoints/service/_service.ts
@@ -1,6 +1,7 @@
 import {services} from "../utils/option";
 import microsoft from "./microsoft";
 import deepl from "./deepl";
+import deeplx from "./deeplx";
 import custom from "./custom";
 import tongyi from "./tongyi";
 import zhipu from "./zhipu";
@@ -22,6 +23,7 @@ export const _service: ServiceMap = {
     // 传统机器翻译
     [services.microsoft]: microsoft,
     [services.deepL]: deepl,
+    [services.deeplx]: deeplx,
     [services.google]: google,
     [services.xiaoniu]: xiaoniu,
 

--- a/entrypoints/service/deeplx.ts
+++ b/entrypoints/service/deeplx.ts
@@ -1,0 +1,47 @@
+import {method} from "../utils/constant";
+import {services} from "../utils/option";
+import {config} from "@/entrypoints/utils/config";
+
+async function deeplx(message: any) {
+    // deeplx 不支持 zh-Hans，需要转换为 zh
+    let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
+    let sourceLang = config.from === 'auto' ? 'auto' : config.from;
+    
+    // 判断是否使用代理或自定义URL
+    let url: string = config.proxy[config.service] ? config.proxy[config.service] : config.deeplx || 'http://localhost:1188/translate';
+
+    // 构建请求头
+    let headers: HeadersInit = {
+        'Content-Type': 'application/json'
+    };
+
+    // 如果有 token，则添加 Authorization 头
+    if (config.token[services.deeplx] && config.token[services.deeplx].trim() !== '') {
+        headers['Authorization'] = `Bearer ${config.token[services.deeplx]}`;
+    }
+
+    const resp = await fetch(url, {
+        method: method.POST,
+        headers: headers,
+        body: JSON.stringify({
+            text: message.origin,
+            source_lang: sourceLang.toUpperCase(),
+            target_lang: targetLang.toUpperCase()
+        })
+    });
+
+    if (resp.ok) {
+        let result = await resp.json();
+        // DeepLX 返回格式通常是 { code: 200, data: "translated text" }
+        if (result.code === 200) {
+            return result.data;
+        } else {
+            throw new Error(`DeepLX 翻译失败: ${result.message || '未知错误'}`);
+        }
+    } else {
+        console.log("DeepLX 翻译失败：", resp);
+        throw new Error(`DeepLX 翻译失败: ${resp.status} ${resp.statusText} body: ${await resp.text()}`);
+    }
+}
+
+export default deeplx;

--- a/entrypoints/utils/check.ts
+++ b/entrypoints/utils/check.ts
@@ -10,8 +10,12 @@ export function checkConfig(): boolean {
 
     // 2. Check if the token is provided for services that require it
     if (servicesType.isUseToken(config.service) && !config.token[config.service]) {
-        sendErrorMessage("令牌尚未配置，请前往设置页配置");
-        return false;
+        // DeepLX 的令牌是可选的，不需要强制检查
+        if (config.service === services.deeplx) {
+        } else {
+            sendErrorMessage("令牌尚未配置，请前往设置页配置");
+            return false;
+        }
     }
     // Special case for YiYan service (requires both AK and SK)
     if (config.service === services.yiyan && (!config.ak || !config.sk)) {

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -3,6 +3,7 @@ import { services } from "./option";
 // 常量工具类
 export const urls: any = {
     [services.deepL]: "https://api-free.deepl.com/v2/translate",
+    [services.deeplx]: "http://localhost:1188/translate",
     [services.openai]: "https://api.openai.com/v1/chat/completions",
     [services.moonshot]: "https://api.moonshot.cn/v1/chat/completions",
     [services.custom]: "https://localhost:11434/v1/chat/completions",
@@ -26,7 +27,6 @@ export const urls: any = {
 
     // [services.baidufree]:"https://fanyi.baidu.com/transapi"
     // [services.baidu]: "https://fanyi-api.baidu.com/api/trans/vip/translate",
-    // [services.deepLx]: "http://localhost:1188/translate",
 }
 
 export const method = {POST: "POST", GET: "GET",};

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -2,6 +2,7 @@ export const services = {
     // 传统机器翻译
     microsoft: "microsoft",
     deepL: "deepL",
+    deeplx: "deeplx",
     google: "google",
     xiaoniu: "xiaoniu",
     // 大模型翻译
@@ -32,7 +33,7 @@ export const services = {
 
 export const servicesType = {
     // 阵营划分
-    machine: new Set([services.microsoft, services.deepL, services.google, services.xiaoniu,]),
+    machine: new Set([services.microsoft, services.deepL, services.deeplx, services.google, services.xiaoniu,]),
     AI: new Set([
         services.openai,
         services.gemini,
@@ -65,6 +66,7 @@ export const servicesType = {
         services.moonshot,
         services.claude,
         services.deepL,
+        services.deeplx,
         services.xiaoniu,
         services.infini,
         services.baichuan,
@@ -112,6 +114,7 @@ export const servicesType = {
         services.claude,
         services.google,
         services.deepL,
+        services.deeplx,
         services.moonshot,
         services.tongyi,
         services.xiaoniu,
@@ -128,6 +131,11 @@ export const servicesType = {
         services.openrouter,
         services.grok,
     ]),
+    // 支持自定义 URL 的服务
+    useCustomUrl: new Set([
+        services.custom,
+        services.deeplx,
+    ]),
 
     isMachine: (service: string) => servicesType.machine.has(service),
     isAI: (service: string) => servicesType.AI.has(service),
@@ -137,6 +145,7 @@ export const servicesType = {
     isCustom: (service: string) => service === services.custom,
     isUseAkSk: (service: string) => service === services.yiyan,
     isCoze: (service: string) => service === services.cozecom || service === services.cozecn,
+    isUseCustomUrl: (service: string) => servicesType.useCustomUrl.has(service),
 };
 
 export const customModelString = "自定义模型";
@@ -218,6 +227,7 @@ export const options = {
         {value: services.microsoft, label: "微软翻译"},
         {value: services.google, label: "谷歌翻译"},
         {value: services.deepL, label: "DeepL"},
+        {value: services.deeplx, label: "DeepLX"},
         {value: services.xiaoniu, label: "小牛翻译"},
         // 大模型翻译
         {value: "ai", label: "AI翻译", disabled: true},
@@ -324,6 +334,7 @@ export const defaultOption = {
     hotkey: "Control",
     service: services.microsoft,
     custom: "http://localhost:11434/v1/chat/completions",
+    deeplx: "http://localhost:1188/translate",
     system_role:
         "You are a professional, authentic machine translation engine.",
     user_role: `Translate the following text into {{to}}, If translation is unnecessary (e.g. proper nouns, codes, etc.), return the original text. NO explanations. NO notes:


### PR DESCRIPTION
这 PR 引入了对 DeepLX 翻译服务的支持，能够利用本地或自托管的 DeepLX 实例进行翻译。

**主要改动点：**

1.  **新增 DeepLX 翻译服务选项：**
    *   在翻译服务选择列表中加入了 "DeepLX" 选项，用户可以在设置中选择 DeepLX 作为翻译引擎。
    *   **（文件：** `entrypoints/utils/option.ts`, `components/Main.vue`**）**

2.  **可自定义的 DeepLX 服务地址：**
    *   在设置页面的“DeepLX URL 配置”部分新增了一个输入框，允许用户配置 DeepLX API 的服务地址。默认地址为 `http://localhost:1188/translate`。
    *   此配置项仅在选择 DeepLX 作为翻译服务时显示。
    *   **（文件：** `components/Main.vue`, `entrypoints/utils/constant.ts`, `entrypoints/utils/option.ts`**）**

3.  **可选的 API 令牌支持：**
    *   DeepLX 服务现在支持配置可选的 Bearer Token 进行认证，如果你的 DeepLX 实例需要令牌，可以在设置中填写。
    *   令牌配置在 DeepLX 服务中是非强制的，即使不配置令牌也能使用。
    *   **（文件：** `entrypoints/service/deeplx.ts`, `entrypoints/utils/check.ts`**）**

4.  **DeepLX 翻译逻辑：**
    *   参考了 deepl 的内容，新增 `deeplx.ts` 模块
    *   **（文件：** `entrypoints/service/deeplx.ts`, `entrypoints/service/_service.ts`**）**

## Summary by Sourcery

Add support for the DeepLX translation service, including selectable service option, configurable API endpoint, and optional authentication token.

New Features:
- Add DeepLX as a selectable translation engine
- Provide a customizable DeepLX API URL field in settings with a default endpoint
- Enable optional Bearer token authentication for DeepLX service

Bug Fixes:
- Skip mandatory token validation when using DeepLX

Enhancements:
- Integrate DeepLX into service type definitions and UI display logic