### PR TITLE
添加对qwen-mt系列接口的支持

### DIFF
--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -153,7 +153,7 @@ export const models = new Map<string, Array<string>>([
     [services.openai, ["gpt-4.1","gpt-4.1-mini","gpt-4.1-nano","gpt-4o-mini", "gpt-4o", "o3", "o3-mini","o4-mini", customModelString]],
     [services.gemini, ["gemini-1.5-flash", "gemini-1.5-pro", "gemini-pro", "gemini-2.0-flash-exp", customModelString]],
     [services.yiyan, ["ERNIE-Bot 4.0", "ERNIE-Bot", "ERNIE-Speed-8K"]],
-    [services.tongyi, ["qwen-long", "qwen-turbo", "qwen-plus", "qwen-max", "qwen-max-longcontext", customModelString]],
+    [services.tongyi, ["qwen-long", "qwen-turbo", "qwen-plus", "qwen-max", "qwen-max-longcontext", "qwen-mt-plus", "qwen-mt-turbo", customModelString]],
     [services.zhipu, ["GLM-4-Flash", "glm-4-plus", "glm-4", "glm-4v", "glm-3-turbo", customModelString]],
     [services.moonshot, ["moonshot-v1-8k", "moonshot-v1-32k", customModelString]],
     [services.claude, ["claude-3-7-sonnet", "claude-3-5-haiku", "claude-3-5-sonnet", "claude-3-opus"]],


### PR DESCRIPTION
qwen-mt依赖`translation_options`属性，与现有模板不匹配，添加兼容。
同时`translation_options`对应的语言类型和项目中的部分类型不一致，添加转换逻辑。

## Summary by Sourcery

Provide support for qwen-mt translation models by adding them to the Tongyi service model list and introducing a dedicated message template with translation_options and language code mapping.

New Features:
- Add qwen-mt-plus and qwen-mt-turbo to the Tongyi service model list
- Implement a separate message template for qwen-mt models that includes translation_options

Enhancements:
- Introduce mapping logic to convert config.to values to valid translation_options target languages