### PR TITLE
feat: 从悬浮球中将翻译快捷键解耦，允许用户在悬浮球被禁用时使用快捷键

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -84,8 +84,8 @@
       </el-col>
     </el-row>
 
-    <!-- 悬浮球快捷键选择 -->
-    <el-row v-if="config.on && floatingBallEnabled" class="margin-bottom margin-left-2em margin-top-1em">
+    <!-- 全文翻译快捷键选择（独立于悬浮球显示） -->
+    <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em">
       <el-col :span="14" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="（测试版）设置快捷键以便快速切换全文翻译状态，无需鼠标点击悬浮球" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">


### PR DESCRIPTION
参考issue #84 
用户体验会好很多

修改前：
<img width="309" height="449" alt="image" src="https://github.com/user-attachments/assets/6dc92acc-54a7-408a-bfa0-87ef080ef89a" />

修改后：
<img width="315" height="466" alt="image" src="https://github.com/user-attachments/assets/be89ee77-ee98-4e16-b66d-2e2c7e52c243" />
