### PR TITLE
feat: 添加New API支持，包含配置项、组件挂载和一键填充功能

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -272,6 +272,20 @@
       </el-col>
     </el-row>
 
+    <!-- NewAPI 配置 -->
+    <el-row v-show="compute.showNewAPI" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="填写 New API 的访问地址，如http://localhost:3000 " placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">NewAPI接口<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-input v-model="config.newApiUrl" placeholder="请输入您的New API接口地址" />
+      </el-col>
+    </el-row>
+
     <!--  模型 -->
     <el-row v-show="compute.showModel" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
@@ -478,6 +492,8 @@ let compute = ref({
   ),
   // 12、判断是否为 coze
   showRobotId: computed(() => servicesType.isCoze(config.value.service)),
+  // 13、是否显示New API配置
+  showNewAPI: computed(() => servicesType.isNewApi(config.value.service)),
 })
 
 // 监听主题变化

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -9,6 +9,7 @@ import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoi
 import { cancelAllTranslations } from "@/entrypoints/utils/translateApi";
 import { createApp } from 'vue';
 import TranslationStatus from '@/components/TranslationStatus.vue';
+import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
 
 export default defineContentScript({
     matches: ['<all_urls>'],  // 匹配所有页面
@@ -36,6 +37,8 @@ export default defineContentScript({
         
         // 挂载翻译状态组件
         mountTranslationStatusComponent();
+
+        mountNewApiComponent();
 
         cache.cleaner();    // 检测是否清理缓存
 

--- a/entrypoints/service/_service.ts
+++ b/entrypoints/service/_service.ts
@@ -15,6 +15,7 @@ import minimax from "@/entrypoints/service/minimax";
 import common from "@/entrypoints/service/common";
 import coze from "@/entrypoints/service/coze";
 import deepseek from "./deepseek";
+import newapi from "./newapi";
 
 type ServiceFunction = (message: any) => Promise<any>;
 type ServiceMap = {[key: string]: ServiceFunction;};
@@ -39,6 +40,7 @@ export const _service: ServiceMap = {
     [services.cozecom]: coze,
     [services.cozecn]: coze,
     [services.deepseek]: deepseek,
+    [services.newapi]: newapi,
     // openai schema
     [services.openai]: common,
     [services.moonshot]: common,

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -38,7 +38,12 @@ async function newapi(message: any) {
         }
 
         const result = await resp.json();
-        return contentPostHandler(result.choices[0].message.content);
+
+        if (result.choices && result.choices.length > 0) {
+            return contentPostHandler(result.choices[0].message.content);
+        }
+
+        throw new Error('翻译失败: 上游未返回内容');
     } catch (error) {
         console.error('API调用失败:', error);
         throw error;

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -1,0 +1,48 @@
+import { method, urls } from "../utils/constant";
+import {commonMsgTemplate, deepseekMsgTemplate} from "../utils/template";
+import { config } from "@/entrypoints/utils/config";
+import { contentPostHandler } from "@/entrypoints/utils/check";
+
+async function newapi(message: any) {
+    try {
+        const headers = new Headers({
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${config.token[config.service]}`
+        });
+
+        let url = config.newApiUrl
+
+        if (!url) {
+            throw new Error('New API地址未配置');
+        }
+
+        if (url.endsWith('/')) {
+            url = url.slice(0, -1); // 删除末尾的斜杠
+        }
+
+        // check has /v1
+        if (url.endsWith('/v1')) {
+            url += '/chat/completions';
+        } else if (!url.endsWith('/chat/completions')) {
+            url += '/v1/chat/completions';
+        }
+
+        const resp = await fetch(url, {
+            method: method.POST,
+            headers,
+            body: commonMsgTemplate(message.origin)
+        });
+
+        if (!resp.ok) {
+            throw new Error(`翻译失败: ${resp.status} ${resp.statusText} body: ${await resp.text()}`);
+        }
+
+        const result = await resp.json();
+        return contentPostHandler(result.choices[0].message.content);
+    } catch (error) {
+        console.error('API调用失败:', error);
+        throw error;
+    }
+}
+
+export default newapi;

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -38,6 +38,7 @@ export class Config {
     floatingBallPosition: 'left' | 'right'; // 悬浮球位置
     floatingBallHotkey: string; // 悬浮球快捷键
     disableSelectionTranslator: boolean; // 是否禁用划词翻译
+    newApiUrl: string; // NewAPI地址
 
     constructor() {
         this.on = true;
@@ -68,6 +69,7 @@ export class Config {
         this.floatingBallPosition = 'right'; // 默认在右侧
         this.floatingBallHotkey = 'Alt+T'; // 默认快捷键为 Alt+T
         this.disableSelectionTranslator = false; // 默认不禁用划词翻译
+        this.newApiUrl = ''; // NewAPI地址默认为空
     }
 }
 

--- a/entrypoints/utils/newApi.ts
+++ b/entrypoints/utils/newApi.ts
@@ -1,0 +1,66 @@
+import { config } from "@/entrypoints/utils/config";
+import {customModelString, services} from "@/entrypoints/utils/option";
+import { storage } from '@wxt-dev/storage';
+
+let containerEl: HTMLElement | null = null;
+
+/**
+ * 挂载New API 组件
+ */
+export function mountNewApiComponent() {
+  // 如果已存在实例或配置禁用了此功能，则不创建
+  if (containerEl) {
+    return;
+  }
+
+  // 创建容器元素
+  const container = document.createElement('div');
+  container.id = 'fluent-new-api-container';
+  document.body.appendChild(container);
+  containerEl = container;
+
+  container.addEventListener('fluent:prefill', async (e) => {
+    const customEvent = e as CustomEvent;
+    const payload = (customEvent?.detail) || {};
+
+    const id = payload.id || '';
+
+    if (id !== 'new-api') return; // 只处理 New API 的事件
+
+    const baseUrl = payload.baseUrl || '';
+    const apiKey = payload.apiKey || '';
+    const model = payload.model || '';
+    const maskedKey = apiKey ? apiKey.slice(0, 3) + '***' + apiKey.slice(-3) : '(空)';
+
+    const confirmed = window.confirm(
+      `检测到 New API 配置：\n- 接口地址: ${baseUrl || '(空)'}\n- API Key: ${maskedKey}\n- 模型: ${model || '(空)'}\n\n是否应用该配置并切换到 New API？`
+    );
+    if (!confirmed) return;
+
+    config.newApiUrl = baseUrl;
+    config.token[services.newapi] = apiKey;
+    config.service = services.newapi;
+    if (model && model !== '') {
+      config.model[config.service] = customModelString
+      config.customModel[config.service] = model;
+    }
+
+
+    try {
+      await storage.setItem('local:config', JSON.stringify(config));
+    } catch (error) {
+      console.error('Error saving config:', error);
+    }
+  });
+
+  return container;
+}
+
+/**
+ * 卸载New API 组件
+ */
+export function unmountNewApiComponent() {
+  const container = document.getElementById('fluent-new-api-container');
+  if (container) container.remove();
+  containerEl = null;
+}

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -29,6 +29,7 @@ export const services = {
     siliconCloud: "siliconCloud", // 硅流
     openrouter: "openrouter", // openrouter
     grok: "grok", // X.AI 的 Grok
+    newapi: "newapi", // New API 接口
 };
 
 export const servicesType = {
@@ -56,6 +57,7 @@ export const servicesType = {
         services.siliconCloud,
         services.openrouter,
         services.grok,
+        services.newapi,
     ]),
     // 需要 token
     useToken: new Set([
@@ -83,6 +85,7 @@ export const servicesType = {
         services.siliconCloud,
         services.openrouter,
         services.grok,
+        services.newapi,
     ]),
     // 需要 model
     useModel: new Set([
@@ -106,6 +109,7 @@ export const servicesType = {
         services.siliconCloud,
         services.openrouter,
         services.grok,
+        services.newapi,
     ]),
     // 支持代理
     useProxy: new Set([
@@ -135,6 +139,7 @@ export const servicesType = {
     useCustomUrl: new Set([
         services.custom,
         services.deeplx,
+        services.newapi,
     ]),
 
     isMachine: (service: string) => servicesType.machine.has(service),
@@ -143,6 +148,7 @@ export const servicesType = {
     isUseProxy: (service: string) => servicesType.useProxy.has(service),
     isUseModel: (service: string) => servicesType.useModel.has(service),
     isCustom: (service: string) => service === services.custom,
+    isNewApi: (service: string) => service === services.newapi,
     isUseAkSk: (service: string) => service === services.yiyan,
     isCoze: (service: string) => service === services.cozecom || service === services.cozecn,
     isUseCustomUrl: (service: string) => servicesType.useCustomUrl.has(service),
@@ -165,8 +171,7 @@ export const models = new Map<string, Array<string>>([
     [services.minimax, ["chatcompletion_v2"]],
     [services.jieyue, ["step-1-8k", customModelString]],
     [services.huanYuan, ["hunyuan-turbos-latest（推荐）","hunyuan-turbo", "hunyuan-lite", "hunyuan-standard", customModelString]],
-    [services.doubao, [customModelString]],
-    [services.grok, ["grok-3-beta", "grok-3-fast-beta", "grok-3-mini-beta", "grok-3-mini-fast-beta", customModelString]],
+    [services.newapi, ["gemini-2.5-flash-lite","gemini-2.0-flash", "gpt-4.1-mini","gpt-4.1-nano","gpt-4o-mini", customModelString]],
 
     // mix model
     [services.siliconCloud, ["Qwen/Qwen3-8B（免费）","THUDM/GLM-Z1-9B-0414（免费）","THUDM/GLM-4-9B-0414（免费）",
@@ -234,6 +239,7 @@ export const options = {
         {value: services.deepseek, label: "DeepSeek⭐️"},
         {value: services.siliconCloud, label: "硅基流动-SiliconFlow⭐️"},
         {value: services.huanYuan, label: "腾讯混元⭐"},
+        {value: services.newapi, label: "New API"},
         {value: services.grok, label: "Grok (X.AI)"},
         {value: services.openrouter, label: "OpenRouter"},
         {value: services.groq, label: "Groq"},


### PR DESCRIPTION
AI翻译新增服务：NewAPI
<img height="300" alt="QQ_1754730362016" src="https://github.com/user-attachments/assets/1c5528c9-522c-4749-a44c-e08dca9f2d38" />

在newapi中可以一键填充到fluent
<img height="876" alt="QQ_1754730297504" src="https://github.com/user-attachments/assets/c5616ee3-cec9-49fe-bc26-b585da9ca2bf" />

## Summary by Sourcery

Add end-to-end support for a new "New API" translation service by extending configuration, UI controls, event-driven auto-fill behavior, and service implementation.

New Features:
- Expose a New API URL input and associated model options in the main UI when New API is selected
- Inject a content-script component to listen for fluent:prefill events and prompt users to apply New API configuration
- Implement the newapi service module that resolves the endpoint path, sends chat/completion requests, and handles responses