### PR TITLE
添加设置并发数量的功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ web-ext.config.ts
 *.njsproj
 *.sln
 *.sw?
+.continue/

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -158,6 +158,29 @@
       </el-col>
     </el-row>
 
+    <!-- 并发翻译数量 -->
+    <el-row class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="控制同时进行的最大翻译任务数，数值越高翻译速度越快，但可能占用更多系统资源" placement="top-start"
+          :show-after="500">
+          <span class="popup-text popup-vertical-left">并发翻译数量<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-input-number 
+          v-model="config.maxConcurrentTranslations" 
+          :min="1" 
+          :max="20" 
+          :step="1"
+          size="small"
+          style="width: 100%"
+          @change="handleConcurrentChange"
+        />
+      </el-col>
+    </el-row>
+
     <!-- 目标语言 -->
     <el-row class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
@@ -632,6 +655,30 @@ const toggleFloatingBall = (val: boolean) => {
         });
       }
     });
+  });
+};
+
+// 处理并发数量变化
+const handleConcurrentChange = (value: number) => {
+  // 验证并发数量的有效性
+  if (value < 1 || value > 20) {
+    ElMessage({
+      message: '并发数量必须在 1-20 之间',
+      type: 'warning',
+      duration: 2000
+    });
+    // 恢复默认值
+    config.value.maxConcurrentTranslations = 6;
+    return;
+  }
+  
+  // 显示设置已更新的提示
+  showRefreshTip.value = true;
+  
+  ElMessage({
+    message: `并发数量已更新为 ${value}`,
+    type: 'success',
+    duration: 2000
   });
 };
 

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -177,6 +177,7 @@
           size="small"
           style="width: 100%"
           @change="handleConcurrentChange"
+          controls-position="right"
         />
       </el-col>
     </el-row>
@@ -420,7 +421,7 @@ import { models, options, servicesType, defaultOption } from "../entrypoints/uti
 import { Config } from "@/entrypoints/utils/model";
 import { storage } from '@wxt-dev/storage';
 import { ChatDotRound, Refresh } from '@element-plus/icons-vue'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessage, ElMessageBox, ElInputNumber } from 'element-plus'
 import browser from 'webextension-polyfill';
 
 // 初始化深色模式媒体查询
@@ -659,9 +660,9 @@ const toggleFloatingBall = (val: boolean) => {
 };
 
 // 处理并发数量变化
-const handleConcurrentChange = (value: number) => {
+const handleConcurrentChange = (currentValue: number | undefined, oldValue: number | undefined) => {
   // 验证并发数量的有效性
-  if (value < 1 || value > 20) {
+  if (currentValue === undefined || currentValue < 1 || currentValue > 20) {
     ElMessage({
       message: '并发数量必须在 1-20 之间',
       type: 'warning',
@@ -676,7 +677,7 @@ const handleConcurrentChange = (value: number) => {
   showRefreshTip.value = true;
   
   ElMessage({
-    message: `并发数量已更新为 ${value}`,
+    message: `并发数量已更新为 ${currentValue}`,
     type: 'success',
     duration: 2000
   });

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -174,7 +174,6 @@
           :min="1" 
           :max="20" 
           :step="1"
-          size="small"
           style="width: 100%"
           @change="handleConcurrentChange"
           controls-position="right"

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -38,6 +38,8 @@ export class Config {
     floatingBallPosition: 'left' | 'right'; // 悬浮球位置
     floatingBallHotkey: string; // 悬浮球快捷键
     disableSelectionTranslator: boolean; // 是否禁用划词翻译
+    maxConcurrentTranslations: number; // 最大并发翻译数量
+    deeplx: string; // DeepLX 服务地址
 
     constructor() {
         this.on = true;
@@ -68,6 +70,8 @@ export class Config {
         this.floatingBallPosition = 'right'; // 默认在右侧
         this.floatingBallHotkey = 'Alt+T'; // 默认快捷键为 Alt+T
         this.disableSelectionTranslator = false; // 默认不禁用划词翻译
+        this.maxConcurrentTranslations = 6; // 默认最大并发翻译数量
+        this.deeplx = 'http://localhost:1188/translate'; // DeepLX 默认服务地址
     }
 }
 

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -71,7 +71,7 @@ export class Config {
         this.floatingBallHotkey = 'Alt+T'; // 默认快捷键为 Alt+T
         this.disableSelectionTranslator = false; // 默认不禁用划词翻译
         this.maxConcurrentTranslations = 6; // 默认最大并发翻译数量
-        this.deeplx = 'http://localhost:1188/translate'; // DeepLX 默认服务地址
+        this.deeplx = ''; // DeepLX 默认服务地址
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       js-beautify:
         specifier: ^1.15.1
         version: 1.15.1
-      p-queue:
-        specifier: ^8.1.0
-        version: 8.1.0
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
@@ -626,51 +623,61 @@ packages:
     resolution: {integrity: sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.30.1':
     resolution: {integrity: sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.30.1':
     resolution: {integrity: sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.30.1':
     resolution: {integrity: sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
     resolution: {integrity: sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
     resolution: {integrity: sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.30.1':
     resolution: {integrity: sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.30.1':
     resolution: {integrity: sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.30.1':
     resolution: {integrity: sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.30.1':
     resolution: {integrity: sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.30.1':
     resolution: {integrity: sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==}
@@ -3031,10 +3038,6 @@ packages:
     resolution: {integrity: sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw==}
     engines: {node: '>=8'}
 
-  p-queue@8.1.0:
-    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
-    engines: {node: '>=18'}
-
   p-reduce@1.0.0:
     resolution: {integrity: sha512-3Tx1T3oM1xO/Y8Gj0sWyE78EIJZ+t+aEmXUdvQgvGmSMri7aPTHoovbXEreWKkL5j21Er60XAWLTzKbAKYOujQ==}
     engines: {node: '>=4'}
@@ -3046,10 +3049,6 @@ packages:
   p-timeout@2.0.1:
     resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
     engines: {node: '>=4'}
-
-  p-timeout@6.1.4:
-    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
-    engines: {node: '>=14.16'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -7214,11 +7213,6 @@ snapshots:
 
   p-pipe@3.1.0: {}
 
-  p-queue@8.1.0:
-    dependencies:
-      eventemitter3: 5.0.1
-      p-timeout: 6.1.4
-
   p-reduce@1.0.0: {}
 
   p-timeout@1.2.1:
@@ -7228,8 +7222,6 @@ snapshots:
   p-timeout@2.0.1:
     dependencies:
       p-finally: 1.0.0
-
-  p-timeout@6.1.4: {}
 
   package-json-from-dist@1.0.1: {}
 


### PR DESCRIPTION
默认六条时部分提供商提示频繁被拒绝了，部分提供商可以提供并发数量。
修复了deeplx在model中没有的问题。
<img width="700" height="1220" alt="图片" src="https://github.com/user-attachments/assets/2140803f-8307-456c-b4a1-9d53fa70a9c9" />

## Summary by Sourcery

Enable users to set the maximum number of concurrent translations through the UI and apply it dynamically in the queue, fix the missing deeplx configuration field, and clean up the pnpm lockfile by removing the unused p-queue dependency

New Features:
- Add UI input to configure maximum concurrent translation tasks
- Allow dynamic setting of concurrency limit in translation queue

Bug Fixes:
- Restore missing deeplx service address property in configuration model

Enhancements:
- Refactor translation queue logic to use configurable concurrency instead of a hardcoded value
- Remove unused p-queue dependency from lockfile