### PR TITLE
feat(service): 添加OpenRouter服务的HTTP请求头配置

### DIFF
--- a/entrypoints/service/common.ts
+++ b/entrypoints/service/common.ts
@@ -2,14 +2,21 @@ import {method, urls} from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
+import { services } from "../utils/option";
 
 async function common(message: any) {
     try {
+
         const headers = new Headers({
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${config.token[config.service]}`
         });
 
+        if(config.service === services.openrouter){
+            headers.append('HTTP-Referer', 'https://fluent.thinkstu.com');
+            headers.append('X-Title', 'FluentRead');
+        }
+                
         const url = config.proxy[config.service] || urls[config.service];
 
         const resp = await fetch(url, {


### PR DESCRIPTION
- 为OpenRouter服务添加必要的HTTP请求头
- 包括Referer和X-Title字段

效果在openroute中显示应用名称
<img width="2347" height="249" alt="图片" src="https://github.com/user-attachments/assets/68346c05-e114-48d4-8de7-873d9e0663d0" />
而不是Unknown
<img width="1559" height="150" alt="图片" src="https://github.com/user-attachments/assets/8771b115-08d0-41cd-821f-011471e92f52" />
