### PR TITLE
Add context menu for full page translation

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -9,11 +9,20 @@ export default defineBackground({
     },
     main() {
         // 创建右键菜单项
-        browser.contextMenus.create({
-            id: CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE,
-            title: 'FluentRead - 全文翻译',
-            contexts: ['page', 'selection'],
-        });
+        try {
+            browser.contextMenus.create({
+                id: CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE,
+                title: 'FluentRead - 全文翻译',
+                contexts: ['page', 'selection'],
+            }, () => {
+                // 检查是否有错误
+                if (browser.runtime.lastError) {
+                    console.error('Failed to create context menu:', browser.runtime.lastError.message);
+                }
+            });
+        } catch (error) {
+            console.error('Error setting up context menu:', error);
+        }
 
         // 监听右键菜单点击事件
         browser.contextMenus.onClicked.addListener((info, tab) => {
@@ -22,6 +31,8 @@ export default defineBackground({
                 browser.tabs.sendMessage(tab.id, {
                     type: 'contextMenuTranslate',
                     action: 'fullPage'
+                }).catch(error => {
+                    console.error('Failed to send message to content script:', error);
                 });
             }
         });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,6 +1,7 @@
 import {_service} from "@/entrypoints/service/_service";
 import {config} from "@/entrypoints/utils/config";
 import {reportTranslationCount} from "@/entrypoints/utils/influx-reporter";
+import {CONTEXT_MENU_IDS} from "@/entrypoints/utils/constant";
 
 export default defineBackground({
     persistent: {
@@ -9,14 +10,14 @@ export default defineBackground({
     main() {
         // 创建右键菜单项
         browser.contextMenus.create({
-            id: 'fluent-read-translate-full-page',
+            id: CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE,
             title: 'FluentRead - 全文翻译',
             contexts: ['page', 'selection'],
         });
 
         // 监听右键菜单点击事件
         browser.contextMenus.onClicked.addListener((info, tab) => {
-            if (info.menuItemId === 'fluent-read-translate-full-page' && tab?.id) {
+            if (info.menuItemId === CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE && tab?.id) {
                 // 发送消息到内容脚本触发全文翻译
                 browser.tabs.sendMessage(tab.id, {
                     type: 'contextMenuTranslate',

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -7,6 +7,24 @@ export default defineBackground({
         safari: false,
     },
     main() {
+        // 创建右键菜单项
+        browser.contextMenus.create({
+            id: 'fluent-read-translate-full-page',
+            title: 'FluentRead - 全文翻译',
+            contexts: ['page', 'selection'],
+        });
+
+        // 监听右键菜单点击事件
+        browser.contextMenus.onClicked.addListener((info, tab) => {
+            if (info.menuItemId === 'fluent-read-translate-full-page' && tab?.id) {
+                // 发送消息到内容脚本触发全文翻译
+                browser.tabs.sendMessage(tab.id, {
+                    type: 'contextMenuTranslate',
+                    action: 'fullPage'
+                });
+            }
+        });
+
         // 处理翻译请求
         browser.runtime.onMessage.addListener((message: any) => {
             return new Promise((resolve, reject) => {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -103,7 +103,6 @@ export default defineContentScript({
             if (message.type === 'contextMenuTranslate' && message.action === 'fullPage') {
                 // 检查插件是否已启用
                 if (config.on === false) {
-                    console.log('FluentRead is disabled, cannot translate');
                     sendResponse({ status: 'disabled' });
                     return true;
                 }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -98,6 +98,24 @@ export default defineContentScript({
             return false;
         });
         
+        // 处理右键菜单触发的全文翻译
+        browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: () => void) => {
+            if (message.type === 'contextMenuTranslate' && message.action === 'fullPage') {
+                // 检查插件是否已启用
+                if (config.on === false) {
+                    console.log('FluentRead is disabled, cannot translate');
+                    sendResponse({ status: 'disabled' });
+                    return true;
+                }
+                
+                // 触发全文翻译
+                autoTranslateEnglishPage();
+                sendResponse({ status: 'success' });
+                return true;
+            }
+            return false;
+        });
+        
         // 在页面卸载时清理资源
         window.addEventListener('beforeunload', () => {
             // 取消所有待处理的翻译任务

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -52,3 +52,8 @@ export const styles = {
     // 双语对照模式
     bilingualTranslation: 1,
 }
+
+// 右键菜单ID常量
+export const CONTEXT_MENU_IDS = {
+    TRANSLATE_FULL_PAGE: 'fluent-read-translate-full-page',
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         }
     }),
     manifest: {
-        permissions: ['storage'],
+        permissions: ['storage', 'contextMenus'],
     },
 
 });


### PR DESCRIPTION
Fixes https://github.com/Bistutu/FluentRead/issues/109

<img width="187" height="307" alt="image" src="https://github.com/user-attachments/assets/68b71ea7-78f0-4876-8ac2-e323dceda5e5" />

## Summary by Sourcery

Add a right-click context menu option to trigger full-page translation and enable message-based coordination between background and content scripts

New Features:
- Create a context menu item for full-page translation in the background script
- Send a translation request message to the content script on context menu click
- Handle the translation request in the content script to invoke full-page translation