### PR TITLE
feat: 新增视频字幕翻译功能，支持 YouTube 平台

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -167,6 +167,23 @@
     </el-row>
 
 
+    <!-- 视频字幕翻译 -->
+    <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em">
+      <el-col :span="20" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content="在 YouTube 等平台上，开启原生字幕后自动翻译并以双语形式叠加显示（需先在视频播放器中开启字幕）"
+          placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">
+            视频字幕翻译
+            <el-icon class="icon-margin"><ChatDotRound /></el-icon>
+          </span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="4" class="flex-end">
+        <el-switch v-model="config.enableVideoSubtitle" inline-prompt active-text="开" inactive-text="关" />
+      </el-col>
+    </el-row>
+
     <!-- 划词翻译模式选择 -->
     <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em">
       <el-col :span="14" class="lightblue rounded-corner">

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -9,7 +9,8 @@ import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoi
 import { cancelAllTranslations, translateText } from "@/entrypoints/utils/translateApi";
 import { createApp } from 'vue';
 import TranslationStatus from '@/components/TranslationStatus.vue';
-import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
+import { mountNewApiComponent } from "@/entrypoints/utils/newApi"
+import { initVideoSubtitle } from "@/entrypoints/video/manager";
 
 export default defineContentScript({
     matches: ['<all_urls>'],  // 匹配所有页面
@@ -54,6 +55,9 @@ export default defineContentScript({
         }
 
         mountNewApiComponent();
+
+        // 初始化视频字幕翻译（在支持的平台上注入拦截脚本）
+        initVideoSubtitle();
 
         cache.cleaner();    // 检测是否清理缓存
 

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -53,6 +53,7 @@ export class Config {
     translationStatus: boolean; // 是否启用全文翻译进度面板
     inputBoxTranslationTrigger: string; // 输入框翻译触发方式
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
+    enableVideoSubtitle: boolean; // 是否启用视频字幕翻译
 
     constructor() {
         this.on = true;
@@ -98,6 +99,7 @@ export class Config {
         this.translationStatus = true; // 默认启用翻译进度面板
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
+        this.enableVideoSubtitle = true; // 默认启用视频字幕翻译
     }
 }
 

--- a/entrypoints/video/manager.ts
+++ b/entrypoints/video/manager.ts
@@ -152,11 +152,11 @@ function mountQuickButton() {
             'vertical-align:top',
         ].join(';')
 
-        btn.innerHTML = buildBtnSvg(subtitleEnabled)
+        btn.appendChild(buildBtnSvg(subtitleEnabled))
 
         btn.addEventListener('click', () => {
             subtitleEnabled = !subtitleEnabled
-            btn.innerHTML = buildBtnSvg(subtitleEnabled)
+            btn.replaceChildren(buildBtnSvg(subtitleEnabled))
             btn.title = subtitleEnabled ? '流畅阅读：字幕翻译（开）' : '流畅阅读：字幕翻译（关）'
             if (subtitleEnabled) {
                 overlay.show()
@@ -170,11 +170,17 @@ function mountQuickButton() {
     })
 }
 
-function buildBtnSvg(active: boolean): string {
-    const color = active ? '#fff' : 'rgba(255,255,255,0.4)'
-    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="${color}">
-        <path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/>
-    </svg>`
+function buildBtnSvg(active: boolean): SVGElement {
+    const ns = 'http://www.w3.org/2000/svg'
+    const svg = document.createElementNS(ns, 'svg')
+    svg.setAttribute('viewBox', '0 0 24 24')
+    svg.setAttribute('width', '22')
+    svg.setAttribute('height', '22')
+    svg.setAttribute('fill', active ? '#fff' : 'rgba(255,255,255,0.4)')
+    const path = document.createElementNS(ns, 'path')
+    path.setAttribute('d', 'M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z')
+    svg.appendChild(path)
+    return svg
 }
 
 /** 轮询等待目标元素出现 */

--- a/entrypoints/video/manager.ts
+++ b/entrypoints/video/manager.ts
@@ -1,0 +1,259 @@
+import { detectPlatform, getAllSubtitlePatterns } from './platforms'
+import { detectSubtitleFormat, parseYouTubeXML, parseYouTubeJSON3, parseVTT, type SubtitleCue } from './parser'
+import { SubtitleOverlay } from './overlay'
+import { translateText } from '@/entrypoints/utils/translateApi'
+import { config } from '@/entrypoints/utils/config'
+
+// ── 常量 ──────────────────────────────────────────────────────────────────────
+const EVENT_TYPE = 'fr-subtitle-inject'
+const BATCH_SIZE = 15   // 每批翻译的字幕条数（合并成一次 API 请求）
+const SEP = '\n⌿\n'   // 字幕批量翻译分隔符（选用生僻字符减少歧义）
+const QUICK_BTN_ID = 'fr-subtitle-quick-btn'
+
+// ── 模块状态 ──────────────────────────────────────────────────────────────────
+const overlay = new SubtitleOverlay()
+let listenerAttached = false
+let processingUrl = ''   // 去重：同一字幕 URL 只翻译一次
+let subtitleEnabled = true
+
+// ── 公开入口 ──────────────────────────────────────────────────────────────────
+
+/** 由 content.ts 调用，初始化视频字幕翻译 */
+export function initVideoSubtitle() {
+    console.log('[FR] initVideoSubtitle called, enableVideoSubtitle=', config.enableVideoSubtitle, 'hostname=', window.location.hostname)
+    if (!config.enableVideoSubtitle) return
+    // 拦截脚本已由 WXT 以 MAIN world content script 形式在 document_start 注入，
+    // 此处只需推送动态配置并开始监听消息。
+    sendConfig()
+    attachMessageListener()
+    watchNavigation()
+    // 在 YouTube 上立即挂载快捷按钮，无需等待字幕捕获
+    if (window.location.hostname.includes('youtube.com')) {
+        console.log('[FR] on YouTube, calling mountQuickButton')
+        mountQuickButton()
+    }
+}
+
+// ── 私有实现 ──────────────────────────────────────────────────────────────────
+
+/** 向注入脚本发送字幕 URL 正则列表（动态更新，覆盖注入脚本内置的默认规则） */
+function sendConfig() {
+    window.postMessage({
+        eventType: EVENT_TYPE,
+        type: 'config',
+        patterns: getAllSubtitlePatterns(),
+    }, '*')
+}
+
+/** 监听来自注入脚本的 postMessage */
+function attachMessageListener() {
+    if (listenerAttached) return
+    listenerAttached = true
+
+    window.addEventListener('message', async (event) => {
+        if (event.source !== window) return
+        const msg = event.data
+        if (!msg || msg.eventType !== EVENT_TYPE) return
+
+        if (msg.type === 'subtitle-captured') {
+            const { url, data } = msg
+            if (!url || !data) return
+            if (!subtitleEnabled) return
+            // 同一 URL 不重复处理
+            if (url === processingUrl) return
+            processingUrl = url
+            try {
+                await handleSubtitleData(url, data)
+            } finally {
+                processingUrl = ''
+            }
+        }
+    })
+}
+
+/** 解析字幕 → 初始化 overlay → 批量翻译 */
+async function handleSubtitleData(url: string, rawData: string) {
+    const format = detectSubtitleFormat(url, rawData)
+    if (!format) return
+
+    const cues: SubtitleCue[] =
+        format === 'youtube-xml'   ? parseYouTubeXML(rawData) :
+        format === 'youtube-json3' ? parseYouTubeJSON3(rawData) :
+        parseVTT(rawData)
+
+    if (!cues.length) return
+
+    const video = findVideo()
+    if (!video) return
+
+    const mountTarget = findMountTarget(video)
+    overlay.mount(video, mountTarget)
+    overlay.setCues([...cues])   // 先用原文渲染，避免空白等待
+
+    hideNativeSubtitle()
+    mountQuickButton()
+
+    // 分批翻译，边翻译边更新 overlay
+    await translateCuesBatched(cues, () => overlay.setCues([...cues]))
+}
+
+/**
+ * 将字幕分批（每批 BATCH_SIZE 条），合并成一个字符串发给翻译服务，
+ * 再按分隔符拆分回逐条结果，大幅减少 API 调用次数。
+ */
+async function translateCuesBatched(cues: SubtitleCue[], onProgress: () => void) {
+    for (let i = 0; i < cues.length; i += BATCH_SIZE) {
+        const batch = cues.slice(i, i + BATCH_SIZE)
+        const joined = batch.map(c => c.text).join(SEP)
+
+        try {
+            const translated = await translateText(joined, document.title)
+            const parts = translated.split(SEP)
+            batch.forEach((cue, j) => {
+                cue.translatedText = parts[j]?.trim() || cue.text
+            })
+        } catch {
+            batch.forEach(cue => { cue.translatedText = cue.text })
+        }
+
+        onProgress()
+    }
+}
+
+// ── YouTube 工具栏快捷按钮 ─────────────────────────────────────────────────────
+
+/**
+ * 在 YouTube 播放器右侧控制栏注入一个翻译开关按钮。
+ * 点击可切换字幕翻译的显示/隐藏，不影响原生字幕。
+ */
+function mountQuickButton() {
+    console.log('[FR] mountQuickButton called, existing=', !!document.getElementById(QUICK_BTN_ID))
+    if (document.getElementById(QUICK_BTN_ID)) return
+
+    // YouTube 右侧控制栏，等待其出现
+    console.log('[FR] waiting for .ytp-right-controls, current=', document.querySelector('.ytp-right-controls'))
+    waitForElement('.ytp-right-controls', (controls) => {
+        console.log('[FR] .ytp-right-controls found, inserting button')
+        if (document.getElementById(QUICK_BTN_ID)) return
+
+        const btn = document.createElement('button')
+        btn.id = QUICK_BTN_ID
+        btn.title = '流畅阅读：字幕翻译'
+        btn.setAttribute('aria-label', '字幕翻译')
+        btn.style.cssText = [
+            'background:transparent',
+            'border:none',
+            'cursor:pointer',
+            'padding:0 6px',
+            'height:100%',
+            'display:inline-flex',
+            'align-items:center',
+            'opacity:0.9',
+            'vertical-align:top',
+        ].join(';')
+
+        btn.innerHTML = buildBtnSvg(subtitleEnabled)
+
+        btn.addEventListener('click', () => {
+            subtitleEnabled = !subtitleEnabled
+            btn.innerHTML = buildBtnSvg(subtitleEnabled)
+            btn.title = subtitleEnabled ? '流畅阅读：字幕翻译（开）' : '流畅阅读：字幕翻译（关）'
+            if (subtitleEnabled) {
+                overlay.show()
+            } else {
+                overlay.hide()
+            }
+        })
+
+        // 插入到右侧控制栏最左边
+        controls.prepend(btn)
+    })
+}
+
+function buildBtnSvg(active: boolean): string {
+    const color = active ? '#fff' : 'rgba(255,255,255,0.4)'
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="${color}">
+        <path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/>
+    </svg>`
+}
+
+/** 轮询等待目标元素出现 */
+function waitForElement(selector: string, callback: (el: Element) => void, maxMs = 10000) {
+    const el = document.querySelector(selector)
+    if (el) { callback(el); return }
+
+    const start = Date.now()
+    const timer = setInterval(() => {
+        const found = document.querySelector(selector)
+        if (found) {
+            clearInterval(timer)
+            callback(found)
+        } else if (Date.now() - start > maxMs) {
+            clearInterval(timer)
+        }
+    }, 300)
+}
+
+// ── DOM 工具 ──────────────────────────────────────────────────────────────────
+
+function findVideo(): HTMLVideoElement | null {
+    const platform = detectPlatform(window.location.hostname)
+    if (platform.videoSelector) {
+        const v = document.querySelector<HTMLVideoElement>(platform.videoSelector)
+        if (v) return v
+    }
+    return document.querySelector<HTMLVideoElement>('video')
+}
+
+function findMountTarget(video: HTMLVideoElement): HTMLElement {
+    const platform = detectPlatform(window.location.hostname)
+    if (platform.containerSelector) {
+        const el = document.querySelector<HTMLElement>(platform.containerSelector)
+        if (el) return el
+    }
+    return (video.parentElement as HTMLElement) || document.body
+}
+
+function hideNativeSubtitle() {
+    const platform = detectPlatform(window.location.hostname)
+    if (!platform.hideNativeSelector) return
+    // 用 display:none 彻底隐藏，visibility:hidden 仍占位且有时被 YouTube 重置
+    document.querySelectorAll<HTMLElement>(platform.hideNativeSelector)
+        .forEach(el => el.style.setProperty('display', 'none', 'important'))
+}
+
+function restoreNativeSubtitle() {
+    const platform = detectPlatform(window.location.hostname)
+    if (!platform.hideNativeSelector) return
+    document.querySelectorAll<HTMLElement>(platform.hideNativeSelector)
+        .forEach(el => el.style.removeProperty('display'))
+}
+
+// ── SPA 导航监听 ──────────────────────────────────────────────────────────────
+
+function watchNavigation() {
+    let lastUrl = location.href
+
+    const onUrlChange = () => {
+        const cur = location.href
+        if (cur !== lastUrl) {
+            lastUrl = cur
+            overlay.cleanup()
+            document.getElementById(QUICK_BTN_ID)?.remove()
+            processingUrl = ''
+            subtitleEnabled = true
+            restoreNativeSubtitle()
+            // SPA 导航到视频页时重新挂载按钮
+            if (window.location.hostname.includes('youtube.com')) {
+                mountQuickButton()
+            }
+        }
+    }
+
+    window.addEventListener('yt-navigate-finish', onUrlChange)
+
+    const titleEl = document.querySelector('title')
+    if (titleEl) {
+        new MutationObserver(onUrlChange).observe(titleEl, { childList: true })
+    }
+}

--- a/entrypoints/video/manager.ts
+++ b/entrypoints/video/manager.ts
@@ -159,9 +159,11 @@ function mountQuickButton() {
             btn.replaceChildren(buildBtnSvg(subtitleEnabled))
             btn.title = subtitleEnabled ? '流畅阅读：字幕翻译（开）' : '流畅阅读：字幕翻译（关）'
             if (subtitleEnabled) {
+                hideNativeSubtitle()
                 overlay.show()
             } else {
                 overlay.hide()
+                restoreNativeSubtitle()
             }
         })
 

--- a/entrypoints/video/overlay.ts
+++ b/entrypoints/video/overlay.ts
@@ -1,0 +1,134 @@
+import type { SubtitleCue } from './parser'
+import { config } from '@/entrypoints/utils/config'
+
+const OVERLAY_ID = 'fr-subtitle-overlay'
+
+export class SubtitleOverlay {
+    private container: HTMLElement | null = null
+    private video: HTMLVideoElement | null = null
+    private cues: SubtitleCue[] = []
+    private rafId: number | null = null
+    private lastCueKey: string | null = null  // 避免每帧重复 DOM 操作
+
+    /** 在视频容器内创建字幕层，开始时间轴循环 */
+    mount(video: HTMLVideoElement, mountTarget: HTMLElement) {
+        this.video = video
+        this.cleanup()
+
+        const overlay = document.createElement('div')
+        overlay.id = OVERLAY_ID
+        overlay.style.cssText = [
+            'position:absolute',
+            'bottom:8%',
+            'left:50%',
+            'transform:translateX(-50%)',
+            'z-index:2147483640',
+            'text-align:center',
+            'pointer-events:none',
+            'width:max-content',
+            'max-width:84%',
+        ].join(';')
+
+        // 确保挂载目标有定位上下文
+        const pos = window.getComputedStyle(mountTarget).position
+        if (pos === 'static') mountTarget.style.position = 'relative'
+
+        mountTarget.appendChild(overlay)
+        this.container = overlay
+        this.startLoop()
+    }
+
+    /** 更新全部字幕数据（解析完成 / 翻译进度更新时调用） */
+    setCues(cues: SubtitleCue[]) {
+        this.cues = cues
+        this.lastCueKey = null   // 强制刷新一次显示
+    }
+
+    show() {
+        if (this.container) this.container.style.display = ''
+    }
+
+    hide() {
+        if (this.container) this.container.style.display = 'none'
+    }
+
+    /** 停止渲染并移除 DOM */
+    cleanup() {
+        if (this.rafId !== null) {
+            cancelAnimationFrame(this.rafId)
+            this.rafId = null
+        }
+        document.getElementById(OVERLAY_ID)?.remove()
+        this.container = null
+        this.cues = []
+        this.lastCueKey = null
+    }
+
+    // ── 内部方法 ──────────────────────────────────────────────────────────────
+
+    private startLoop() {
+        const tick = () => {
+            if (!this.video || !this.container) return
+            const t = this.video.currentTime
+            const cue = this.findCue(t)
+            const key = cue ? `${cue.start}~${cue.end}` : ''
+
+            if (key !== this.lastCueKey) {
+                this.lastCueKey = key
+                this.render(cue)
+            }
+            this.rafId = requestAnimationFrame(tick)
+        }
+        this.rafId = requestAnimationFrame(tick)
+    }
+
+    private findCue(time: number): SubtitleCue | null {
+        for (const cue of this.cues) {
+            if (time >= cue.start && time < cue.end) return cue
+        }
+        return null
+    }
+
+    private render(cue: SubtitleCue | null) {
+        if (!this.container) return
+        if (!cue) { this.container.innerHTML = ''; return }
+
+        const isBilingual = config.display === 1   // 1 = 双语对照
+        const hasTranslation = !!cue.translatedText
+
+        const lineStyle = [
+            'display:block',
+            'background:rgba(8,8,8,0.80)',
+            'color:#fff',
+            'padding:4px 14px',
+            'border-radius:4px',
+            'font-size:18px',
+            'line-height:1.65',
+            'white-space:pre-wrap',
+            'word-break:break-word',
+            'text-align:center',
+            'margin-bottom:4px',
+        ].join(';')
+
+        const originalStyle = lineStyle + ';opacity:0.75;font-size:15px'
+
+        let html = ''
+        if (isBilingual && cue.text) {
+            html += `<div style="${originalStyle}">${esc(cue.text)}</div>`
+        }
+        if (hasTranslation) {
+            html += `<div style="${lineStyle}">${esc(cue.translatedText!)}</div>`
+        } else {
+            // 翻译尚未完成时，仍显示原文（避免空白）
+            html += `<div style="${lineStyle}">${esc(cue.text)}</div>`
+        }
+        this.container.innerHTML = html
+    }
+}
+
+function esc(s: string): string {
+    return s.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+}

--- a/entrypoints/video/overlay.ts
+++ b/entrypoints/video/overlay.ts
@@ -83,15 +83,25 @@ export class SubtitleOverlay {
     }
 
     private findCue(time: number): SubtitleCue | null {
-        for (const cue of this.cues) {
-            if (time >= cue.start && time < cue.end) return cue
+        let lo = 0, hi = this.cues.length - 1
+        while (lo <= hi) {
+            const mid = (lo + hi) >>> 1
+            const cue = this.cues[mid]
+            if (time < cue.start) {
+                hi = mid - 1
+            } else if (time >= cue.end) {
+                lo = mid + 1
+            } else {
+                return cue
+            }
         }
         return null
     }
 
     private render(cue: SubtitleCue | null) {
         if (!this.container) return
-        if (!cue) { this.container.innerHTML = ''; return }
+        this.container.replaceChildren()
+        if (!cue) return
 
         const isBilingual = config.display === 1   // 1 = 双语对照
         const hasTranslation = !!cue.translatedText
@@ -112,23 +122,16 @@ export class SubtitleOverlay {
 
         const originalStyle = lineStyle + ';opacity:0.75;font-size:15px'
 
-        let html = ''
         if (isBilingual && cue.text) {
-            html += `<div style="${originalStyle}">${esc(cue.text)}</div>`
+            const div = document.createElement('div')
+            div.style.cssText = originalStyle
+            div.textContent = cue.text
+            this.container.appendChild(div)
         }
-        if (hasTranslation) {
-            html += `<div style="${lineStyle}">${esc(cue.translatedText!)}</div>`
-        } else {
-            // 翻译尚未完成时，仍显示原文（避免空白）
-            html += `<div style="${lineStyle}">${esc(cue.text)}</div>`
-        }
-        this.container.innerHTML = html
-    }
-}
 
-function esc(s: string): string {
-    return s.replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
+        const mainDiv = document.createElement('div')
+        mainDiv.style.cssText = lineStyle
+        mainDiv.textContent = hasTranslation ? cue.translatedText! : cue.text
+        this.container.appendChild(mainDiv)
+    }
 }

--- a/entrypoints/video/overlay.ts
+++ b/entrypoints/video/overlay.ts
@@ -9,6 +9,8 @@ export class SubtitleOverlay {
     private cues: SubtitleCue[] = []
     private rafId: number | null = null
     private lastCueKey: string | null = null  // 避免每帧重复 DOM 操作
+    private mountTarget: HTMLElement | undefined
+    private originalMountPosition: string | undefined  // undefined = 未修改过
 
     /** 在视频容器内创建字幕层，开始时间轴循环 */
     mount(video: HTMLVideoElement, mountTarget: HTMLElement) {
@@ -29,11 +31,15 @@ export class SubtitleOverlay {
             'max-width:84%',
         ].join(';')
 
-        // 确保挂载目标有定位上下文
-        const pos = window.getComputedStyle(mountTarget).position
-        if (pos === 'static') mountTarget.style.position = 'relative'
+        // 确保挂载目标有定位上下文，记录原始内联 position 以便 cleanup 还原
+        const computedPos = window.getComputedStyle(mountTarget).position
+        if (computedPos === 'static') {
+            this.originalMountPosition = mountTarget.style.position
+            mountTarget.style.position = 'relative'
+        }
 
         mountTarget.appendChild(overlay)
+        this.mountTarget = mountTarget
         this.container = overlay
         this.startLoop()
     }
@@ -52,16 +58,21 @@ export class SubtitleOverlay {
         if (this.container) this.container.style.display = 'none'
     }
 
-    /** 停止渲染并移除 DOM */
+    /** 停止渲染并移除 DOM，还原挂载目标的原始 position */
     cleanup() {
         if (this.rafId !== null) {
             cancelAnimationFrame(this.rafId)
             this.rafId = null
         }
         document.getElementById(OVERLAY_ID)?.remove()
+        if (this.mountTarget !== undefined && this.originalMountPosition !== undefined) {
+            this.mountTarget.style.position = this.originalMountPosition
+        }
         this.container = null
         this.cues = []
         this.lastCueKey = null
+        this.mountTarget = undefined
+        this.originalMountPosition = undefined
     }
 
     // ── 内部方法 ──────────────────────────────────────────────────────────────

--- a/entrypoints/video/parser.ts
+++ b/entrypoints/video/parser.ts
@@ -1,0 +1,112 @@
+export interface SubtitleCue {
+    start: number           // 开始时间（秒）
+    end: number             // 结束时间（秒）
+    text: string            // 原文
+    translatedText?: string // 译文（翻译后填入）
+}
+
+// ── YouTube timedtext XML ─────────────────────────────────────────────────────
+// 格式：<transcript><text start="0.5" dur="2.3">Hello</text></transcript>
+export function parseYouTubeXML(xmlText: string): SubtitleCue[] {
+    try {
+        const doc = new DOMParser().parseFromString(xmlText, 'text/xml')
+        if (doc.querySelector('parsererror')) return []
+        const cues: SubtitleCue[] = []
+        doc.querySelectorAll('text').forEach(node => {
+            const start = parseFloat(node.getAttribute('start') || '0')
+            const dur   = parseFloat(node.getAttribute('dur')   || '0')
+            const text  = decodeEntities(node.textContent || '').trim()
+            if (text) cues.push({ start, end: start + dur, text })
+        })
+        return cues
+    } catch {
+        return []
+    }
+}
+
+// ── WebVTT ────────────────────────────────────────────────────────────────────
+export function parseVTT(vttText: string): SubtitleCue[] {
+    const cues: SubtitleCue[] = []
+    // 统一换行符，按空行分割 cue 块
+    const blocks = vttText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split(/\n\n+/)
+
+    for (const block of blocks) {
+        const lines = block.trim().split('\n')
+        // 找到包含 --> 的时间行
+        const timeLine = lines.find(l => l.includes('-->'))
+        if (!timeLine) continue
+
+        const [startStr, endStr] = timeLine.split('-->').map(s => s.trim().split(/\s/)[0])
+        const start = vttTimeToSeconds(startStr)
+        const end   = vttTimeToSeconds(endStr)
+
+        // 时间行之后的行为字幕文本（去掉 VTT 内联标签）
+        const textLines = lines
+            .slice(lines.indexOf(timeLine) + 1)
+            .map(l => stripVttTags(l))
+            .filter(l => l.trim())
+
+        const text = textLines.join(' ').trim()
+        if (text) cues.push({ start, end, text })
+    }
+    return cues
+}
+
+// ── 辅助函数 ──────────────────────────────────────────────────────────────────
+function vttTimeToSeconds(t: string): number {
+    if (!t) return 0
+    const parts = t.split(':')
+    if (parts.length === 3) {
+        return parseInt(parts[0]) * 3600 + parseInt(parts[1]) * 60 + parseFloat(parts[2])
+    } else if (parts.length === 2) {
+        return parseInt(parts[0]) * 60 + parseFloat(parts[1])
+    }
+    return parseFloat(t) || 0
+}
+
+function stripVttTags(text: string): string {
+    // 去掉 <c.color>, <00:00:00.000>, <i>, <b> 等 VTT 标签
+    return text.replace(/<[^>]+>/g, '').replace(/&amp;/g, '&')
+}
+
+function decodeEntities(text: string): string {
+    try {
+        const doc = new DOMParser().parseFromString(text, 'text/html')
+        return doc.documentElement.textContent || text
+    } catch {
+        return text.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#39;/g, "'").replace(/&quot;/g, '"')
+    }
+}
+
+// ── YouTube timedtext JSON3 ───────────────────────────────────────────────────
+// 格式：{"events":[{"tStartMs":0,"dDurationMs":5000,"segs":[{"utf8":"Hello"}]},...]}
+export function parseYouTubeJSON3(jsonText: string): SubtitleCue[] {
+    try {
+        const data = JSON.parse(jsonText)
+        if (!data.events) return []
+        const cues: SubtitleCue[] = []
+        for (const event of data.events) {
+            if (!event.segs) continue
+            const text = event.segs.map((s: { utf8?: string }) => s.utf8 || '').join('').trim()
+            if (!text || text === '\n') continue
+            const start = (event.tStartMs || 0) / 1000
+            const end   = start + (event.dDurationMs || 0) / 1000
+            cues.push({ start, end, text })
+        }
+        return cues
+    } catch {
+        return []
+    }
+}
+
+/**
+ * 自动检测字幕格式
+ */
+export function detectSubtitleFormat(url: string, data: string): 'youtube-xml' | 'youtube-json3' | 'vtt' | null {
+    if (data.trimStart().startsWith('WEBVTT')) return 'vtt'
+    if (url.match(/\.vtt(\?|#|$)/i)) return 'vtt'
+    if (data.trimStart().startsWith('{')) return 'youtube-json3'
+    if (data.includes('<transcript') || data.includes('<text ')) return 'youtube-xml'
+    if (url.includes('/api/timedtext')) return 'youtube-xml'
+    return null
+}

--- a/entrypoints/video/platforms.ts
+++ b/entrypoints/video/platforms.ts
@@ -1,0 +1,55 @@
+export interface PlatformConfig {
+    id: string
+    matches: string[]           // 匹配的 hostname 关键词
+    subtitleUrlPatterns: string[] // 字幕 URL 的正则字符串
+    format: 'youtube-xml' | 'vtt'
+    videoSelector: string       // <video> 元素选择器
+    containerSelector: string   // 字幕层挂载目标选择器
+    hideNativeSelector?: string // 需要隐藏的原生字幕容器
+}
+
+export const platforms: PlatformConfig[] = [
+    {
+        id: 'youtube',
+        matches: ['youtube.com', 'youtubekids.com'],
+        subtitleUrlPatterns: ['/api/timedtext'],
+        format: 'youtube-xml',
+        videoSelector: '.html5-video-player video',
+        containerSelector: '.html5-video-player',
+        hideNativeSelector: '.ytp-caption-window-container',
+    },
+    {
+        // 通用 WebVTT：覆盖 Udemy / Coursera / Khan Academy 等大多数学习平台
+        id: 'generic-vtt',
+        matches: ['*'],
+        subtitleUrlPatterns: ['\\.vtt(\\?|#|$)', 'subtitles?.*\\.vtt', '/captions/'],
+        format: 'vtt',
+        videoSelector: 'video',
+        containerSelector: '',  // 动态确定：video.parentElement
+    },
+]
+
+/**
+ * 根据当前 hostname 匹配平台配置。
+ * 优先返回精确平台，没有则返回通用 VTT 兜底。
+ */
+export function detectPlatform(hostname: string): PlatformConfig {
+    for (const platform of platforms) {
+        if (platform.id === 'generic-vtt') continue
+        if (platform.matches.some(m => hostname.includes(m))) {
+            return platform
+        }
+    }
+    return platforms.find(p => p.id === 'generic-vtt')!
+}
+
+/** 返回所有平台的字幕 URL 正则列表（去重），发送给注入脚本 */
+export function getAllSubtitlePatterns(): string[] {
+    const set = new Set<string>()
+    for (const platform of platforms) {
+        for (const pattern of platform.subtitleUrlPatterns) {
+            set.add(pattern)
+        }
+    }
+    return Array.from(set)
+}

--- a/public/video-subtitle-inject.js
+++ b/public/video-subtitle-inject.js
@@ -1,0 +1,92 @@
+(function () {
+  const EVENT_TYPE = 'fr-subtitle-inject';
+  // 默认 patterns，在 content script 发送配置前就能拦截常见字幕请求
+  let subtitlePatterns = ['/api/timedtext', '\\.vtt(\\?|#|$)', 'subtitles?.*\\.vtt', '/captions/'];
+
+  // 缓存最近一次捕获，用于内容脚本晚于字幕请求就绪时补发
+  var lastCapture = null;
+
+  // ── 工具函数 ──────────────────────────────────────────────
+  function isSubtitleUrl(url) {
+    if (!url || !subtitlePatterns.length) return false;
+    return subtitlePatterns.some(function (pattern) {
+      try { return new RegExp(pattern).test(url); } catch (_) { return false; }
+    });
+  }
+
+  function getUrl(input) {
+    if (!input) return '';
+    if (typeof input === 'string') return input;
+    if (input instanceof URL) return input.href;
+    if (input instanceof Request) return input.url;
+    return String(input);
+  }
+
+  function sendToContent(payload) {
+    window.postMessage(Object.assign({ eventType: EVENT_TYPE }, payload), '*');
+  }
+
+  // ── 接收 Content Script 发来的配置 ───────────────────────
+  window.addEventListener('message', function (event) {
+    if (event.source !== window) return;
+    var data = event.data;
+    if (!data || data.eventType !== EVENT_TYPE) return;
+    if (data.type === 'config') {
+      subtitlePatterns = data.patterns || [];
+      // 内容脚本刚就绪，把已缓存的字幕补发过去
+      if (lastCapture) {
+        sendToContent({ type: 'subtitle-captured', url: lastCapture.url, data: lastCapture.data });
+      }
+    }
+  });
+
+  // ── Hook XMLHttpRequest ───────────────────────────────────
+  var originalOpen = XMLHttpRequest.prototype.open;
+  var originalSend = XMLHttpRequest.prototype.send;
+
+  XMLHttpRequest.prototype.open = function () {
+    this._fr_url = typeof arguments[1] === 'string'
+      ? arguments[1]
+      : (arguments[1] && arguments[1].href) || '';
+    return originalOpen.apply(this, arguments);
+  };
+
+  XMLHttpRequest.prototype.send = function () {
+    var url = this._fr_url;
+    if (url && isSubtitleUrl(url)) {
+      var self = this;
+      self.addEventListener('load', function () {
+        if (self.status === 200 && self.responseText) {
+          lastCapture = { url: url, data: self.responseText };
+          sendToContent({ type: 'subtitle-captured', url: url, data: self.responseText });
+        }
+      });
+    }
+    return originalSend.apply(this, arguments);
+  };
+
+  // ── Hook fetch ────────────────────────────────────────────
+  var originalFetch = window.fetch;
+  if (originalFetch) {
+    window.fetch = function (input, init) {
+      var url = getUrl(input);
+      if (url && isSubtitleUrl(url)) {
+        return originalFetch.call(this, input, init).then(function (response) {
+          if (response.ok) {
+            response.clone().text().then(function (text) {
+              if (text) {
+                lastCapture = { url: url, data: text };
+                sendToContent({ type: 'subtitle-captured', url: url, data: text });
+              }
+            }).catch(function () {});
+          }
+          return response;
+        });
+      }
+      return originalFetch.apply(this, arguments);
+    };
+  }
+
+  // ── 通知 Content Script 注入脚本已就绪 ────────────────────
+  sendToContent({ type: 'ready' });
+})();

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -23,6 +23,17 @@ export default defineConfig({
     }),
     manifest: {
         permissions: ['storage', 'contextMenus', 'offscreen'],
+        // 直接在 manifest 中声明 MAIN world 脚本，绕开 WXT entrypoint 命名体系。
+        // public/video-subtitle-inject.js 会被 WXT 原样复制到扩展根目录。
+        // Chrome 加载 manifest content_scripts 时会绕过页面 CSP，不受 YouTube 等限制。
+        content_scripts: [
+            {
+                matches: ['<all_urls>'],
+                js: ['video-subtitle-inject.js'],
+                world: 'MAIN',
+                run_at: 'document_start',
+            } as any,
+        ],
     },
 
 });

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -28,7 +28,15 @@ export default defineConfig({
         // Chrome 加载 manifest content_scripts 时会绕过页面 CSP，不受 YouTube 等限制。
         content_scripts: [
             {
-                matches: ['<all_urls>'],
+                // 仅注入已支持的视频平台，避免在无关站点执行 XHR/fetch hook。
+                // 如需新增平台，在此同步添加对应域名。
+                matches: [
+                    '*://*.youtube.com/*',
+                    '*://*.youtubekids.com/*',
+                    '*://*.udemy.com/*',
+                    '*://*.coursera.org/*',
+                    '*://*.khanacademy.org/*',
+                ],
                 js: ['video-subtitle-inject.js'],
                 world: 'MAIN',
                 run_at: 'document_start',


### PR DESCRIPTION
- 添加视频字幕翻译开关（默认开启）
- 在 content.ts 中初始化视频字幕翻译模块
- 在 Config 中新增 enableVideoSubtitle 配置项
- 通过 manifest content_scripts 注入 MAIN world 脚本以绕过 YouTube CSP 限制

## Summary by Sourcery

Add a configurable video subtitle translation feature that works on YouTube and other platforms by capturing native subtitle streams, translating them in batches, and overlaying bilingual subtitles on top of the video.

New Features:
- Introduce a user-facing toggle in the main UI to enable or disable video subtitle translation.
- Add a configuration flag to persist whether video subtitle translation is enabled, defaulting to on.
- Implement a video subtitle manager that intercepts subtitle requests, parses multiple subtitle formats, and renders translated subtitles as an overlay on supported video platforms.
- Provide a YouTube-specific in-player quick toggle button to show or hide the translated subtitle overlay.

Enhancements:
- Register a MAIN world content script in the manifest to inject a subtitle interception script that bypasses CSP restrictions on sites like YouTube.