### PR TITLE
fix: 修复空文本被翻译的问题

### DIFF
--- a/entrypoints/main/dom.ts
+++ b/entrypoints/main/dom.ts
@@ -33,7 +33,11 @@ export function grabAllNode(rootNode: Node): Element[] {
         NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
         {
             acceptNode: (node: Node): number => {
-                if (node instanceof Text) return NodeFilter.FILTER_ACCEPT;
+                if (node instanceof Text) {
+                    // 检查文本节点是否有实际内容（去除空白后）
+                    const textContent = node.textContent?.replace(/[\s\u3000]/g, '') || '';
+                    return textContent.length > 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+                }
 
                 if (!(node instanceof Element)) return NodeFilter.FILTER_SKIP;
 
@@ -59,13 +63,17 @@ export function grabAllNode(rootNode: Node): Element[] {
                 for (const child of node.childNodes) {
                     if (child.nodeType === Node.ELEMENT_NODE) {
                         hasElement = true;
-                        // 检查子元素是否包含文本
-                        if (child.textContent?.trim()) {
+                        // 检查子元素是否包含文本（去除空白后）
+                        const childText = child.textContent?.replace(/[\s\u3000]/g, '') || '';
+                        if (childText.length > 0) {
                             hasNonEmptyElement = true;
                         }
                     }
-                    if (child.nodeType === Node.TEXT_NODE && child.textContent?.trim()) {
-                        hasText = true;
+                    if (child.nodeType === Node.TEXT_NODE) {
+                        const textContent = child.textContent?.replace(/[\s\u3000]/g, '') || '';
+                        if (textContent.length > 0) {
+                            hasText = true;
+                        }
                     }
                 }
 

--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -252,7 +252,9 @@ export function handleSingleTranslation(node: any, slide: boolean) {
 
 
 function bilingualTranslate(node: any, nodeOuterHTML: any) {
-    if (detectlang(node.textContent.replace(/[\s\u3000]/g, '')) === config.to) return;
+    const cleanedText = node.textContent.replace(/[\s\u3000]/g, '');
+    if (!cleanedText || cleanedText.length === 0) return;
+    if (detectlang(cleanedText) === config.to) return;
 
     let origin = node.textContent;
     let spinner = insertLoadingSpinner(node);
@@ -272,7 +274,9 @@ function bilingualTranslate(node: any, nodeOuterHTML: any) {
 
 
 export function singleTranslate(node: any) {
-    if (detectlang(node.textContent.replace(/[\s\u3000]/g, '')) === config.to) return;
+    const cleanedText = node.textContent.replace(/[\s\u3000]/g, '');
+    if (!cleanedText || cleanedText.length === 0) return;
+    if (detectlang(cleanedText) === config.to) return;
 
     let origin = servicesType.isMachine(config.service) ? node.innerHTML : LLMStandardHTML(node);
     let spinner = insertLoadingSpinner(node);

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -30,6 +30,12 @@ export async function translateText(origin: string, context: string = document.t
     useCache = config.useCache,
   } = options;
 
+  // 检查 origin 是否为空或只有空白字符
+  const cleanedOrigin = origin?.replace(/[\s\u3000]/g, '') || '';
+  if (!cleanedOrigin || cleanedOrigin.length === 0) {
+    return origin || '';
+  }
+
   // 如果目标语言与当前文本语言相同，直接返回原文
   if (detectlang(origin.replace(/[\s\u3000]/g, '')) === config.to) {
     return origin;


### PR DESCRIPTION
在多处添加了trim并检查待翻译文本是否为空的判断，解决了reddit帖子、github 贡献者头像处等网站出现大量类似“请提供翻译文本”的bug

前：
<img width="2560" height="1228" alt="前1" src="https://github.com/user-attachments/assets/ce9420bd-280c-4fef-a15b-6bbec6659fe8" />

<img width="520" height="681" alt="前2" src="https://github.com/user-attachments/assets/5bea81a8-49f3-4f26-b503-cde7da030dbc" />


后：
<img width="2560" height="1226" alt="后1" src="https://github.com/user-attachments/assets/19a73a91-41ed-4166-86a4-f27bac0a62bc" />

<img width="432" height="294" alt="后2" src="https://github.com/user-attachments/assets/db0b1dd1-ebb7-41e6-81eb-7eb316e16e91" />

## Summary by Sourcery

Prevent translation logic from processing empty or whitespace-only text content across DOM scanning and translation entry points.

Bug Fixes:
- Ignore whitespace-only text nodes when collecting DOM nodes for translation to avoid translating placeholder or empty content.
- Skip translation in bilingual and single-translate flows when the cleaned text content is empty.
- Short-circuit the translateText API when the input string is empty or only whitespace, returning the original value without calling translation services.