### PR TITLE
feat: 更新 DeepSeek 模型并支持 Responses API

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -398,6 +398,25 @@
       </el-col>
     </el-row>
 
+    <!-- DeepSeek API 格式 -->
+    <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content="自动：deepseek-v4-flash 走 Responses API，其余模型走 Chat Completion；如使用仅支持 OpenAI 格式的第三方代理，请选择 Chat Completion"
+          placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式">
+          <el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label"
+                     :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
     <!-- 高级选项-->
     <el-collapse class="margin-left-2em margin-bottom">
       <el-collapse-item title="高级选项">
@@ -760,6 +779,8 @@ let compute = ref({
   showNewAPI: computed(() => servicesType.isNewApi(config.value.service)),
   // 14、是否显示Azure OpenAI端点配置
   showAzureOpenaiEndpoint: computed(() => servicesType.isAzureOpenai(config.value.service)),
+  // 15、是否显示 DeepSeek API 格式配置
+  showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
 })
 
 // 监听主题变化

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -48,7 +48,7 @@
 2. 点击设置图标，进入设置页面
 3. 选择 "翻译引擎" 选项卡
 4. 在引擎列表中选择 "DeepSeek"
-5. 选择 `deepseek-chat` 模型，并填入配置信息
+5. 选择 `deepseek-v4-flash` 模型，并填入配置信息
 
 <img src="/click-fluent_read.png" alt="点击流畅阅读图标" style="width: 80%; max-width: 100%;border: 1px solid #eee;border-radius: 4px;box-shadow: 0 1px 2px rgba(0,0,0,0.05);" />
 

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -1,7 +1,13 @@
 import { method, urls } from "../utils/constant";
-import { deepseekMsgTemplate } from "../utils/template";
+import { deepseekMsgTemplate, deepseekResponsesMsgTemplate, getCurrentModel } from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
+
+// deepseek-v4-* 系列模型走官方的 Responses API（POST /responses）
+// 其他模型（含自定义模型）走 OpenAI 兼容的 chat completions 接口
+function useResponsesApi(model: string) {
+    return model.startsWith("deepseek-v4-");
+}
 
 async function deepseek(message: any) {
     try {
@@ -10,12 +16,21 @@ async function deepseek(message: any) {
             'Authorization': `Bearer ${config.token[config.service]}`
         });
 
-        const url = config.proxy[config.service] || urls[config.service];
+        const model = getCurrentModel();
+        const endpoint = config.proxy[config.service] || urls[config.service];
+
+        // Responses API 与 chat completions 的端点不同，把 /chat/completions 路径替换为 /responses
+        const isResponses = useResponsesApi(model);
+        const url = isResponses
+            ? endpoint.replace(/\/chat\/completions\/?$/, '/responses')
+            : endpoint;
 
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: deepseekMsgTemplate(message.origin)
+            body: isResponses
+                ? deepseekResponsesMsgTemplate(message.origin)
+                : deepseekMsgTemplate(message.origin)
         });
 
         if (!resp.ok) {
@@ -23,7 +38,29 @@ async function deepseek(message: any) {
         }
 
         const result = await resp.json();
-        return contentPostHandler(result.choices[0].message.content);
+
+        // Responses API: output 数组中的 message 类型内容；chat completions: choices[0].message.content
+        if (isResponses) {
+            if (typeof result.output_text === 'string' && result.output_text) {
+                return contentPostHandler(result.output_text);
+            }
+            const output = result.output || [];
+            const text = output
+                .filter((item: any) => item.type === 'message' && item.content)
+                .flatMap((item: any) => item.content)
+                .filter((part: any) => part.type === 'output_text')
+                .map((part: any) => part.text)
+                .join('');
+            if (text) {
+                return contentPostHandler(text);
+            }
+            throw new Error('翻译失败: 上游未返回内容');
+        }
+
+        if (result.choices && result.choices.length > 0) {
+            return contentPostHandler(result.choices[0].message.content);
+        }
+        throw new Error('翻译失败: 上游未返回内容');
     } catch (error) {
         console.error('API调用失败:', error);
         throw error;

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -5,8 +5,13 @@ import { contentPostHandler } from "@/entrypoints/utils/check";
 
 // deepseek-v4-* 系列模型走官方的 Responses API（POST /responses）
 // 其他模型（含自定义模型）走 OpenAI 兼容的 chat completions 接口
+// API 格式由设置中的 deepseekApiType 控制：'responses' 强制 Responses API，'chat' 强制 Chat Completion，'auto' 按模型支持情况自动选择
 function useResponsesApi(model: string) {
-    return model.startsWith("deepseek-v4-");
+    const apiType = config.deepseekApiType;
+    if (apiType === 'responses') return true;
+    if (apiType === 'chat') return false;
+    // auto: v4-flash 官方原生支持 Responses API；v4-pro 支持尚在灰度，走 chat completions 最稳
+    return model === 'deepseek-v4-flash';
 }
 
 async function deepseek(message: any) {

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -24,11 +24,13 @@ async function deepseek(message: any) {
         const model = getCurrentModel();
         const endpoint = config.proxy[config.service] || urls[config.service];
 
-        // Responses API 与 chat completions 的端点不同，把 /chat/completions 路径替换为 /responses
+        // 去掉可能存在的 /chat/completions 后缀得到 base URL，再按所选 API 格式拼接端点。
+        // 这样无论配置的是完整端点（.../chat/completions）还是 base URL（.../v1），
+        // payload 与端点都由同一个 isResponses 决定，不会出现格式错配。
         const isResponses = useResponsesApi(model);
-        const url = isResponses
-            ? endpoint.replace(/\/chat\/completions\/?$/, '/responses')
-            : endpoint;
+        // 去掉 /chat/completions 后缀和多余的尾斜杠，得到干净的 base URL
+        const baseUrl = endpoint.replace(/\/chat\/completions\/?$/, '').replace(/\/+$/, '');
+        const url = isResponses ? `${baseUrl}/responses` : `${baseUrl}/chat/completions`;
 
         const resp = await fetch(url, {
             method: method.POST,

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -1,5 +1,5 @@
 import { method, urls } from "../utils/constant";
-import {commonMsgTemplate, deepseekMsgTemplate} from "../utils/template";
+import {commonMsgTemplate} from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
 

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -53,6 +53,7 @@ export class Config {
     translationStatus: boolean; // 是否启用全文翻译进度面板
     inputBoxTranslationTrigger: string; // 输入框翻译触发方式
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
+    deepseekApiType: string; // DeepSeek API 格式: 'auto' | 'responses' | 'chat'
 
     constructor() {
         this.on = true;
@@ -98,6 +99,7 @@ export class Config {
         this.translationStatus = true; // 默认启用翻译进度面板
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
+        this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
     }
 }
 

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -220,6 +220,12 @@ export const options = {
         {value: false, label: "关闭"},
     ],
     form: [{value: "auto", label: "自动检测"}],
+    // DeepSeek API 格式（仅 DeepSeek 服务显示）
+    deepseekApiType: [
+        {value: "auto", label: "自动（推荐）"},
+        {value: "responses", label: "Responses API"},
+        {value: "chat", label: "Chat Completion"},
+    ],
     to: [
         {value: "zh-Hans", label: "中文"},
         {value: "en", label: "英语"},

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -186,7 +186,7 @@ export const models = new Map<string, Array<string>>([
     [services.infini, ["llama-2-13b-chat", "llama-3.3-70b-instruct", "qwen2.5-14b-instruct", "gemma-2-27b-it", "glm-4-9b-chat", customModelString]],
     [services.baichuan, ["Baichuan4-Air", "Baichuan4-Turbo", "Baichuan4", customModelString]],
     [services.lingyi, ["yi-lightning", customModelString]],
-    [services.deepseek, ["deepseek-chat", "deepseek-reasoner", customModelString]],
+    [services.deepseek, ["deepseek-v4-flash", "deepseek-v4-pro", customModelString]],
     [services.minimax, ["chatcompletion_v2"]],
     [services.jieyue, ["step-1-8k", customModelString]],
     [services.huanYuan, ["hunyuan-turbos-latest", "hunyuan-t1-latest", "hunyuan-a13b", "hunyuan-lite", "hunyuan-standard", customModelString]],

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -25,12 +25,32 @@ export function commonMsgTemplate(origin: string) {
 }
 
 // deepseek
-export function deepseekMsgTemplate(origin: string) {
+export function getCurrentModel() {
     // 检测是否使用自定义模型
     let model = config.model[config.service] === customModelString ? config.customModel[config.service] : config.model[config.service]
 
     // 删除模型名称中的中文括号及其内容，如"gpt-4（推荐）" -> "gpt-4"
-    model = model.replace(/（.*）/g, "");
+    return model.replace(/（.*）/g, "");
+}
+
+// DeepSeek Responses API 格式（POST /responses），仅 deepseek-v4-* 系列模型支持
+// 参考: https://api-docs.deepseek.com/guides/responses_api/
+export function deepseekResponsesMsgTemplate(origin: string) {
+    let system = config.system_role[config.service] || defaultOption.system_role;
+    let user = (config.user_role[config.service] || defaultOption.user_role)
+        .replace('{{to}}', config.to).replace('{{origin}}', origin);
+
+    return JSON.stringify({
+        'model': getCurrentModel(),
+        'instructions': system,
+        'input': user,
+        'temperature': 0.7,
+    })
+}
+
+// DeepSeek chat completions 格式（POST /chat/completions），兼容自定义模型与第三方 OpenAI 兼容端点
+export function deepseekMsgTemplate(origin: string) {
+    let model = getCurrentModel();
 
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -33,24 +33,37 @@ export function getCurrentModel() {
     return model.replace(/（.*）/g, "");
 }
 
+// DeepSeek 温度参数：thinking 模式（deepseek-reasoner）下 temperature 无效，不传；其余模型统一 0.7
+// 两种 API 格式共用同一逻辑，保证行为一致
+function deepseekTemperature(model: string): number | undefined {
+    return model === 'deepseek-reasoner' ? undefined : 0.7;
+}
+
 // DeepSeek Responses API 格式（POST /responses），仅 deepseek-v4-* 系列模型支持
 // 参考: https://api-docs.deepseek.com/guides/responses_api/
 export function deepseekResponsesMsgTemplate(origin: string) {
+    const model = getCurrentModel();
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
-        'model': getCurrentModel(),
+    const payload: any = {
+        'model': model,
         'instructions': system,
         'input': user,
-        'temperature': 0.7,
-    })
+    };
+
+    const temperature = deepseekTemperature(model);
+    if (temperature !== undefined) {
+        payload.temperature = temperature;
+    }
+
+    return JSON.stringify(payload);
 }
 
 // DeepSeek chat completions 格式（POST /chat/completions），兼容自定义模型与第三方 OpenAI 兼容端点
 export function deepseekMsgTemplate(origin: string) {
-    let model = getCurrentModel();
+    const model = getCurrentModel();
 
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)
@@ -64,9 +77,9 @@ export function deepseekMsgTemplate(origin: string) {
         ]
     };
 
-    // 如果不是 deepseek-reasoner 模型,则添加 temperature
-    if (model !== 'deepseek-reasoner') {
-        payload.temperature = 0.7;
+    const temperature = deepseekTemperature(model);
+    if (temperature !== undefined) {
+        payload.temperature = temperature;
     }
 
     return JSON.stringify(payload);


### PR DESCRIPTION
- 模型列表更新：`deepseek-chat` / `deepseek-reasoner`（已于 2026-07-24 弃用）→ `deepseek-v4-flash` / `deepseek-v4-pro`
- DeepSeek 服务新增"API 格式"设置（自动 / Responses API / Chat Completion）：
- 自动：`deepseek-v4-flash` 走官方 Responses API（`/responses`，`instructions` + `input` 格式），`deepseek-v4-pro` 及自定义模型走 Chat Completion
- 可手动强制任一种格式，兼容仅支持 OpenAI 格式的第三方代理
- 两种格式均已实测翻译通过
- 参考：https://api-docs.deepseek.com/guides/responses_api/（DeepSeek V4 Pro 支持 Responses API 后可再更新）

## Summary by Sourcery

Update DeepSeek integration to use the new v4 models and support both Responses and chat completion APIs with configurable selection.

New Features:
- Add support for DeepSeek Responses API for deepseek-v4-* models with appropriate request and response handling.
- Introduce a configurable DeepSeek API format option (auto / Responses API / Chat Completion) in the UI and config.
- Provide a shared helper to resolve the current DeepSeek model name without localized suffixes.

Enhancements:
- Refresh DeepSeek model list to use deepseek-v4-flash and deepseek-v4-pro instead of deprecated models.
- Adjust DeepSeek endpoint selection logic to automatically route v4-flash through Responses API while keeping other models on chat completions for stability.

Documentation:
- Update DeepSeek translation engine documentation to recommend the deepseek-v4-flash model by default.