### PR TITLE
feat: 整合 DeepSeek V4 迁移与 API 格式支持

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -402,7 +402,7 @@
     <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
-          content="自动：deepseek-v4-flash 走 Responses API，其余模型走 Chat Completion；如使用仅支持 OpenAI 格式的第三方代理，请选择 Chat Completion"
+          content="自动：使用 DeepSeek 官方 Chat Completion；仅当代理或网关明确支持 Responses API 时手动选择 Responses API"
           placement="top-start" :show-after="500">
           <span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin">
               <ChatDotRound />
@@ -413,6 +413,25 @@
         <el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式">
           <el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label"
                      :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
+    <!-- DeepSeek 思考模式 -->
+    <el-row v-show="compute.showDeepseekThinkingMode" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content="DeepSeek V4 Chat Completion 思考模式。翻译通常建议关闭以降低延迟；旧 deepseek-reasoner 配置会自动迁移为开启。"
+          placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">思考模式<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.deepseekThinkingMode" placeholder="请选择思考模式">
+          <el-option class="select-left" v-for="item in options.deepseekThinkingMode" :key="item.value"
+                     :label="item.label" :value="item.value" />
         </el-select>
       </el-col>
     </el-row>
@@ -684,7 +703,7 @@
 // Main 处理配置信息
 import { computed, ref, watch, onUnmounted } from 'vue'
 import { models, options, servicesType, defaultOption } from "../entrypoints/utils/option";
-import { Config } from "@/entrypoints/utils/model";
+import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 import { storage } from '@wxt-dev/storage';
 import { ChatDotRound, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox, ElInputNumber } from 'element-plus'
@@ -717,7 +736,7 @@ let config = ref(new Config());
 storage.getItem('local:config').then((value: any) => {
   if (typeof value === 'string' && value) {
     const parsedConfig = JSON.parse(value);
-    Object.assign(config.value, parsedConfig);
+    Object.assign(config.value, normalizeConfig(parsedConfig));
   }
   // 初始应用主题
   updateTheme(config.value.theme || 'auto');
@@ -731,7 +750,7 @@ storage.watch('local:config', (newValue: any, oldValue: any) => {
   if (typeof newValue === 'string' && newValue) {
     // 将新的配置值解析为对象,并合并到当前的 config.value 中
     // 这样可以保持所有页面的配置同步
-    Object.assign(config.value, JSON.parse(newValue));
+    Object.assign(config.value, normalizeConfig(JSON.parse(newValue)));
   }
 });
 
@@ -781,6 +800,7 @@ let compute = ref({
   showAzureOpenaiEndpoint: computed(() => servicesType.isAzureOpenai(config.value.service)),
   // 15、是否显示 DeepSeek API 格式配置
   showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
+  showDeepseekThinkingMode: computed(() => config.value.service === 'deepseek' && config.value.deepseekApiType !== 'responses'),
 })
 
 // 监听主题变化
@@ -1159,7 +1179,7 @@ const saveImport = async () => {
       });
       return;
     }
-    await storage.setItem('local:config', JSON.stringify(parsedConfig));
+    await storage.setItem('local:config', JSON.stringify(normalizeConfig(parsedConfig)));
     ElMessage({
       message: '配置导入成功!',
       type: 'success',
@@ -1288,7 +1308,7 @@ const importConfig = async () => {
     );
 
     // 应用新配置
-    Object.assign(config.value, importedConfig);
+    Object.assign(config.value, normalizeConfig(importedConfig));
 
     // 保存到storage
     await storage.setItem('local:config', JSON.stringify(config.value));

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -398,6 +398,25 @@
       </el-col>
     </el-row>
 
+    <!-- DeepSeek API 格式 -->
+    <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content="自动：deepseek-v4-flash 走 Responses API，其余模型走 Chat Completion；如使用仅支持 OpenAI 格式的第三方代理，请选择 Chat Completion"
+          placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式">
+          <el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label"
+                     :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
     <!-- 高级选项-->
     <el-collapse class="margin-left-2em margin-bottom">
       <el-collapse-item title="高级选项">
@@ -760,6 +779,8 @@ let compute = ref({
   showNewAPI: computed(() => servicesType.isNewApi(config.value.service)),
   // 14、是否显示Azure OpenAI端点配置
   showAzureOpenaiEndpoint: computed(() => servicesType.isAzureOpenai(config.value.service)),
+  // 15、是否显示 DeepSeek API 格式配置
+  showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
 })
 
 // 监听主题变化

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -48,7 +48,7 @@
 2. 点击设置图标，进入设置页面
 3. 选择 "翻译引擎" 选项卡
 4. 在引擎列表中选择 "DeepSeek"
-5. 选择 `deepseek-chat` 模型，并填入配置信息
+5. 选择 `deepseek-v4-flash` 模型，并填入配置信息
 
 <img src="/click-fluent_read.png" alt="点击流畅阅读图标" style="width: 80%; max-width: 100%;border: 1px solid #eee;border-radius: 4px;box-shadow: 0 1px 2px rgba(0,0,0,0.05);" />
 

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -50,6 +50,12 @@
 4. 在引擎列表中选择 "DeepSeek"
 5. 选择 `deepseek-v4-flash` 模型，并填入配置信息
 
+旧版配置会自动迁移：`deepseek-chat` 会迁移为关闭思考模式的 `deepseek-v4-flash`，
+`deepseek-reasoner` 会迁移为开启思考模式的 `deepseek-v4-flash`。
+
+默认的 API 格式使用 DeepSeek 官方 Chat Completion。只有当自定义代理或网关明确支持
+Responses API 时，才需要在设置中手动切换；代理 URL 中已有的查询参数会被保留。
+
 <img src="/click-fluent_read.png" alt="点击流畅阅读图标" style="width: 80%; max-width: 100%;border: 1px solid #eee;border-radius: 4px;box-shadow: 0 1px 2px rgba(0,0,0,0.05);" />
 
 

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -1,7 +1,13 @@
 import { method, urls } from "../utils/constant";
-import { deepseekMsgTemplate } from "../utils/template";
+import { deepseekMsgTemplate, deepseekResponsesMsgTemplate, getCurrentModel } from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
+
+// deepseek-v4-* 系列模型走官方的 Responses API（POST /responses）
+// 其他模型（含自定义模型）走 OpenAI 兼容的 chat completions 接口
+function useResponsesApi(model: string) {
+    return model.startsWith("deepseek-v4-");
+}
 
 async function deepseek(message: any) {
     try {
@@ -10,12 +16,21 @@ async function deepseek(message: any) {
             'Authorization': `Bearer ${config.token[config.service]}`
         });
 
-        const url = config.proxy[config.service] || urls[config.service];
+        const model = getCurrentModel();
+        const endpoint = config.proxy[config.service] || urls[config.service];
+
+        // Responses API 与 chat completions 的端点不同，把 /chat/completions 路径替换为 /responses
+        const isResponses = useResponsesApi(model);
+        const url = isResponses
+            ? endpoint.replace(/\/chat\/completions\/?$/, '/responses')
+            : endpoint;
 
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: deepseekMsgTemplate(message.origin)
+            body: isResponses
+                ? deepseekResponsesMsgTemplate(message.origin)
+                : deepseekMsgTemplate(message.origin)
         });
 
         if (!resp.ok) {
@@ -23,7 +38,29 @@ async function deepseek(message: any) {
         }
 
         const result = await resp.json();
-        return contentPostHandler(result.choices[0].message.content);
+
+        // Responses API: output 数组中的 message 类型内容；chat completions: choices[0].message.content
+        if (isResponses) {
+            if (typeof result.output_text === 'string' && result.output_text) {
+                return contentPostHandler(result.output_text);
+            }
+            const output = result.output || [];
+            const text = output
+                .filter((item: any) => item.type === 'message' && item.content)
+                .flatMap((item: any) => item.content)
+                .filter((part: any) => part.type === 'output_text')
+                .map((part: any) => part.text)
+                .join('');
+            if (text) {
+                return contentPostHandler(text);
+            }
+            throw new Error('翻译失败: 上游未返回内容');
+        }
+
+        if (result.choices && result.choices.length > 0) {
+            return contentPostHandler(result.choices[0].message.content);
+        }
+        throw new Error('翻译失败: 上游未返回内容');
     } catch (error) {
         console.error('API调用失败:', error);
         throw error;

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -5,8 +5,13 @@ import { contentPostHandler } from "@/entrypoints/utils/check";
 
 // deepseek-v4-* 系列模型走官方的 Responses API（POST /responses）
 // 其他模型（含自定义模型）走 OpenAI 兼容的 chat completions 接口
+// API 格式由设置中的 deepseekApiType 控制：'responses' 强制 Responses API，'chat' 强制 Chat Completion，'auto' 按模型支持情况自动选择
 function useResponsesApi(model: string) {
-    return model.startsWith("deepseek-v4-");
+    const apiType = config.deepseekApiType;
+    if (apiType === 'responses') return true;
+    if (apiType === 'chat') return false;
+    // auto: v4-flash 官方原生支持 Responses API；v4-pro 支持尚在灰度，走 chat completions 最稳
+    return model === 'deepseek-v4-flash';
 }
 
 async function deepseek(message: any) {

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -23,11 +23,23 @@ async function deepseek(message: any) {
         }
 
         const result = await resp.json();
-        return contentPostHandler(result.choices[0].message.content);
+        return extractDeepSeekContent(result);
     } catch (error) {
         console.error('API调用失败:', error);
         throw error;
     }
+}
+
+function extractDeepSeekContent(result: any): string {
+    const content = result?.choices?.[0]?.message?.content;
+
+    if (typeof content !== 'string') {
+        throw new Error('DeepSeek 返回数据格式异常：缺少 choices[0].message.content');
+    }
+
+    // Only final message.content is rendered. DeepSeek thinking fields such as
+    // reasoning_content are intentionally ignored and must never reach the page.
+    return contentPostHandler(content);
 }
 
 export default deepseek;

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -24,11 +24,13 @@ async function deepseek(message: any) {
         const model = getCurrentModel();
         const endpoint = config.proxy[config.service] || urls[config.service];
 
-        // Responses API 与 chat completions 的端点不同，把 /chat/completions 路径替换为 /responses
+        // 去掉可能存在的 /chat/completions 后缀得到 base URL，再按所选 API 格式拼接端点。
+        // 这样无论配置的是完整端点（.../chat/completions）还是 base URL（.../v1），
+        // payload 与端点都由同一个 isResponses 决定，不会出现格式错配。
         const isResponses = useResponsesApi(model);
-        const url = isResponses
-            ? endpoint.replace(/\/chat\/completions\/?$/, '/responses')
-            : endpoint;
+        // 去掉 /chat/completions 后缀和多余的尾斜杠，得到干净的 base URL
+        const baseUrl = endpoint.replace(/\/chat\/completions\/?$/, '').replace(/\/+$/, '');
+        const url = isResponses ? `${baseUrl}/responses` : `${baseUrl}/chat/completions`;
 
         const resp = await fetch(url, {
             method: method.POST,

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -1,5 +1,5 @@
 import { method, urls } from "../utils/constant";
-import {commonMsgTemplate, deepseekMsgTemplate} from "../utils/template";
+import {commonMsgTemplate} from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
 

--- a/entrypoints/utils/check.ts
+++ b/entrypoints/utils/check.ts
@@ -98,8 +98,6 @@ export function searchClassName(node: Node, className: string): Node | null {
 }
 
 export function contentPostHandler(text: string) {
-    // 替换掉<think>与</think>之间的内容
-    let content = text;
-    content = content.replace(/^<think>[\s\S]*?<\/think>/, "");
-    return content;
+    // Never render model reasoning tags in translated page content.
+    return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
 }

--- a/entrypoints/utils/config.ts
+++ b/entrypoints/utils/config.ts
@@ -1,4 +1,4 @@
-import { Config } from "@/entrypoints/utils/model";
+import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 
 // 声明 config 类型, new Config() 会设置好所有默认值
 export let config: Config = new Config();
@@ -20,8 +20,11 @@ async function loadConfig() {
         if (typeof value === 'string' && value.trim().length > 0) {
             const parsedConfig = JSON.parse(value);
             if (isConfigObjectValid(parsedConfig)) {
-                // 如果配置有效，合并到当前 config 中
-                Object.assign(config, parsedConfig);
+                const normalizedConfig = normalizeConfig(parsedConfig);
+                Object.assign(config, normalizedConfig);
+                if (JSON.stringify(parsedConfig) !== JSON.stringify(normalizedConfig)) {
+                    await storage.setItem('local:config', JSON.stringify(normalizedConfig));
+                }
                 return; // 加载成功，直接返回
             }
         }
@@ -45,7 +48,7 @@ storage.watch('local:config', (newValue: any, oldValue: any) => {
             const parsedConfig = JSON.parse(newValue);
             if (isConfigObjectValid(parsedConfig)) {
                 // 如果新的配置有效，更新 config
-                Object.assign(config, parsedConfig);
+                Object.assign(config, normalizeConfig(parsedConfig));
             } else {
                 console.warn('An invalid configuration was detected in storage.watch. Ignoring.');
             }

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -1,5 +1,8 @@
 import { defaultOption, services } from "./option";
 
+export type DeepSeekApiType = 'auto' | 'responses' | 'chat';
+export type DeepSeekThinkingMode = 'enabled' | 'disabled';
+
 interface IMapping {
     [key: string]: string;
 }
@@ -53,7 +56,8 @@ export class Config {
     translationStatus: boolean; // 是否启用全文翻译进度面板
     inputBoxTranslationTrigger: string; // 输入框翻译触发方式
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
-    deepseekApiType: string; // DeepSeek API 格式: 'auto' | 'responses' | 'chat'
+    deepseekApiType: DeepSeekApiType; // DeepSeek API 格式
+    deepseekThinkingMode: DeepSeekThinkingMode; // DeepSeek Chat Completion 思考模式
 
     constructor() {
         this.on = true;
@@ -100,7 +104,45 @@ export class Config {
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
         this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
+        this.deepseekThinkingMode = 'disabled'; // 翻译默认关闭思考模式，降低延迟和输出噪音
     }
+}
+
+/**
+ * 将存储或导入的普通对象补齐为当前配置结构，并迁移已退役的 DeepSeek 模型名。
+ */
+export function normalizeConfig(value: unknown): Config {
+    const normalized = new Config();
+    const source = value && typeof value === 'object' ? value as Partial<Config> : {};
+    Object.assign(normalized, source);
+
+    normalized.model = isRecord(source.model) ? {...source.model} : {};
+    normalized.customModel = isRecord(source.customModel) ? {...source.customModel} : {};
+
+    const selectedModel = normalized.model[services.deepseek];
+    const configuredThinkingMode = source.deepseekThinkingMode;
+
+    if (selectedModel === 'deepseek-chat') {
+        normalized.model[services.deepseek] = 'deepseek-v4-flash';
+        normalized.deepseekThinkingMode = 'disabled';
+    } else if (selectedModel === 'deepseek-reasoner') {
+        // 官方迁移指南要求 reasoner 使用 v4-flash 并显式开启 thinking。
+        normalized.model[services.deepseek] = 'deepseek-v4-flash';
+        normalized.deepseekThinkingMode = 'enabled';
+    } else if (configuredThinkingMode !== 'enabled' && configuredThinkingMode !== 'disabled') {
+        // 兼容 #219 的早期配置：该实现把 v4-pro 作为默认思考模型。
+        normalized.deepseekThinkingMode = selectedModel === 'deepseek-v4-pro' ? 'enabled' : 'disabled';
+    }
+
+    if (!['auto', 'responses', 'chat'].includes(normalized.deepseekApiType)) {
+        normalized.deepseekApiType = 'auto';
+    }
+
+    return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, string> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 // 构建所有服务的 system_role

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -53,6 +53,7 @@ export class Config {
     translationStatus: boolean; // 是否启用全文翻译进度面板
     inputBoxTranslationTrigger: string; // 输入框翻译触发方式
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
+    deepseekApiType: string; // DeepSeek API 格式: 'auto' | 'responses' | 'chat'
 
     constructor() {
         this.on = true;
@@ -98,6 +99,7 @@ export class Config {
         this.translationStatus = true; // 默认启用翻译进度面板
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
+        this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
     }
 }
 

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -220,6 +220,12 @@ export const options = {
         {value: false, label: "关闭"},
     ],
     form: [{value: "auto", label: "自动检测"}],
+    // DeepSeek API 格式（仅 DeepSeek 服务显示）
+    deepseekApiType: [
+        {value: "auto", label: "自动（推荐）"},
+        {value: "responses", label: "Responses API"},
+        {value: "chat", label: "Chat Completion"},
+    ],
     to: [
         {value: "zh-Hans", label: "中文"},
         {value: "en", label: "英语"},

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -186,7 +186,7 @@ export const models = new Map<string, Array<string>>([
     [services.infini, ["llama-2-13b-chat", "llama-3.3-70b-instruct", "qwen2.5-14b-instruct", "gemma-2-27b-it", "glm-4-9b-chat", customModelString]],
     [services.baichuan, ["Baichuan4-Air", "Baichuan4-Turbo", "Baichuan4", customModelString]],
     [services.lingyi, ["yi-lightning", customModelString]],
-    [services.deepseek, ["deepseek-chat", "deepseek-reasoner", customModelString]],
+    [services.deepseek, ["deepseek-v4-flash", "deepseek-v4-pro", customModelString]],
     [services.minimax, ["chatcompletion_v2"]],
     [services.jieyue, ["step-1-8k", customModelString]],
     [services.huanYuan, ["hunyuan-turbos-latest", "hunyuan-t1-latest", "hunyuan-a13b", "hunyuan-lite", "hunyuan-standard", customModelString]],

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -222,9 +222,13 @@ export const options = {
     form: [{value: "auto", label: "自动检测"}],
     // DeepSeek API 格式（仅 DeepSeek 服务显示）
     deepseekApiType: [
-        {value: "auto", label: "自动（推荐）"},
+        {value: "auto", label: "自动（Chat Completion）"},
         {value: "responses", label: "Responses API"},
         {value: "chat", label: "Chat Completion"},
+    ],
+    deepseekThinkingMode: [
+        {value: "disabled", label: "关闭（推荐）"},
+        {value: "enabled", label: "开启"},
     ],
     to: [
         {value: "zh-Hans", label: "中文"},
@@ -415,4 +419,3 @@ export const defaultOption = {
     inputBoxTranslationTrigger: "disabled", // 默认关闭输入框翻译
     inputBoxTranslationTarget: "en", // 默认翻译成英文
 };
-

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -25,12 +25,32 @@ export function commonMsgTemplate(origin: string) {
 }
 
 // deepseek
-export function deepseekMsgTemplate(origin: string) {
+export function getCurrentModel() {
     // 检测是否使用自定义模型
     let model = config.model[config.service] === customModelString ? config.customModel[config.service] : config.model[config.service]
 
     // 删除模型名称中的中文括号及其内容，如"gpt-4（推荐）" -> "gpt-4"
-    model = model.replace(/（.*）/g, "");
+    return model.replace(/（.*）/g, "");
+}
+
+// DeepSeek Responses API 格式（POST /responses），仅 deepseek-v4-* 系列模型支持
+// 参考: https://api-docs.deepseek.com/guides/responses_api/
+export function deepseekResponsesMsgTemplate(origin: string) {
+    let system = config.system_role[config.service] || defaultOption.system_role;
+    let user = (config.user_role[config.service] || defaultOption.user_role)
+        .replace('{{to}}', config.to).replace('{{origin}}', origin);
+
+    return JSON.stringify({
+        'model': getCurrentModel(),
+        'instructions': system,
+        'input': user,
+        'temperature': 0.7,
+    })
+}
+
+// DeepSeek chat completions 格式（POST /chat/completions），兼容自定义模型与第三方 OpenAI 兼容端点
+export function deepseekMsgTemplate(origin: string) {
+    let model = getCurrentModel();
 
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -33,24 +33,37 @@ export function getCurrentModel() {
     return model.replace(/（.*）/g, "");
 }
 
+// DeepSeek 温度参数：thinking 模式（deepseek-reasoner）下 temperature 无效，不传；其余模型统一 0.7
+// 两种 API 格式共用同一逻辑，保证行为一致
+function deepseekTemperature(model: string): number | undefined {
+    return model === 'deepseek-reasoner' ? undefined : 0.7;
+}
+
 // DeepSeek Responses API 格式（POST /responses），仅 deepseek-v4-* 系列模型支持
 // 参考: https://api-docs.deepseek.com/guides/responses_api/
 export function deepseekResponsesMsgTemplate(origin: string) {
+    const model = getCurrentModel();
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
-        'model': getCurrentModel(),
+    const payload: any = {
+        'model': model,
         'instructions': system,
         'input': user,
-        'temperature': 0.7,
-    })
+    };
+
+    const temperature = deepseekTemperature(model);
+    if (temperature !== undefined) {
+        payload.temperature = temperature;
+    }
+
+    return JSON.stringify(payload);
 }
 
 // DeepSeek chat completions 格式（POST /chat/completions），兼容自定义模型与第三方 OpenAI 兼容端点
 export function deepseekMsgTemplate(origin: string) {
-    let model = getCurrentModel();
+    const model = getCurrentModel();
 
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)
@@ -64,9 +77,9 @@ export function deepseekMsgTemplate(origin: string) {
         ]
     };
 
-    // 如果不是 deepseek-reasoner 模型,则添加 temperature
-    if (model !== 'deepseek-reasoner') {
-        payload.temperature = 0.7;
+    const temperature = deepseekTemperature(model);
+    if (temperature !== undefined) {
+        payload.temperature = temperature;
     }
 
     return JSON.stringify(payload);

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -2,6 +2,13 @@
 import {customModelString, defaultOption, services} from "./option";
 import {config} from "@/entrypoints/utils/config";
 
+type DeepSeekThinkingMode = 'enabled' | 'disabled';
+
+interface DeepSeekModelConfig {
+    model: string;
+    thinking: DeepSeekThinkingMode;
+}
+
 // openai 格式的消息模板（通用模板）
 export function commonMsgTemplate(origin: string) {
     // 检测是否使用自定义模型
@@ -27,29 +34,49 @@ export function commonMsgTemplate(origin: string) {
 // deepseek
 export function deepseekMsgTemplate(origin: string) {
     // 检测是否使用自定义模型
-    let model = config.model[config.service] === customModelString ? config.customModel[config.service] : config.model[config.service]
+    const selectedModel = config.model[config.service] === customModelString ? config.customModel[config.service] : config.model[config.service]
 
-    // 删除模型名称中的中文括号及其内容，如"gpt-4（推荐）" -> "gpt-4"
-    model = model.replace(/（.*）/g, "");
+    const modelConfig = normalizeDeepSeekModel(selectedModel);
 
     let system = config.system_role[config.service] || defaultOption.system_role;
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
     const payload: any = {
-        'model': model,
+        'model': modelConfig.model,
         'messages': [
             {'role': 'system', 'content': system},
             {'role': 'user', 'content': user},
-        ]
+        ],
+        // DeepSeek OpenAI-format Chat Completion / Thinking Mode docs, checked 2026-06-20:
+        // direct REST requests use top-level {"thinking": {"type": "enabled" | "disabled"}}.
+        'thinking': {'type': modelConfig.thinking}
     };
 
-    // 如果不是 deepseek-reasoner 模型,则添加 temperature
-    if (model !== 'deepseek-reasoner') {
+    if (modelConfig.thinking === 'enabled') {
+        payload.reasoning_effort = 'high';
+    } else {
         payload.temperature = 0.7;
     }
 
     return JSON.stringify(payload);
+}
+
+function normalizeDeepSeekModel(model: string): DeepSeekModelConfig {
+    const normalizedModel = (model || '').replace(/（.*）/g, "");
+
+    // Legacy DeepSeek names are scheduled for deprecation on 2026-07-24.
+    // Keep saved configs working while preserving their semantics:
+    // deepseek-chat stays non-thinking; deepseek-reasoner stays thinking-capable.
+    if (normalizedModel === 'deepseek-chat') {
+        return {model: 'deepseek-v4-flash', thinking: 'disabled'};
+    }
+
+    if (normalizedModel === 'deepseek-reasoner') {
+        return {model: 'deepseek-v4-pro', thinking: 'enabled'};
+    }
+
+    return {model: normalizedModel, thinking: 'disabled'};
 }
 
 // gemini

--- a/package.json
+++ b/package.json
@@ -28,13 +28,14 @@
     "webextension-polyfill": "^0.12.0"
   },
   "devDependencies": {
+    "@types/chrome": "^0.2.0",
     "@types/crypto-js": "^4.2.2",
     "@types/webextension-polyfill": "^0.12.1",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vuepress/client": "2.0.0-rc.19",
     "@wxt-dev/webextension-polyfill": "^1.0.0",
     "typescript": "^5.7.3",
-    "vite": "^5.4.11",
+    "vite": "^5.4.19",
     "vite-plugin-imagemin": "^0.6.1",
     "vitepress": "^1.6.3",
     "vue": "^3.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
         specifier: ^0.12.0
         version: 0.12.0
     devDependencies:
+      '@types/chrome':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -41,7 +44,7 @@ importers:
         version: 0.12.1
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
+        version: 5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
       '@vuepress/client':
         specifier: 2.0.0-rc.19
         version: 2.0.0-rc.19(typescript@5.7.3)
@@ -52,11 +55,11 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        specifier: ^5.4.19
+        version: 5.4.19(@types/node@22.10.7)
       vite-plugin-imagemin:
         specifier: ^0.6.1
-        version: 0.6.1(vite@5.4.11(@types/node@22.10.7))
+        version: 0.6.1(vite@5.4.19(@types/node@22.10.7))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.7)(async-validator@4.2.5)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3)
@@ -766,6 +769,9 @@ packages:
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+
+  '@types/chrome@0.2.0':
+    resolution: {integrity: sha512-K/i7EKEVSpmyXXjE0ev5oASWBYMY6yM8LFSutG2PkM1DmxJUggZsoaTc0W1RsVwDDKrsZEjpHFAbqqxlRxGsSg==}
 
   '@types/crypto-js@4.2.2':
     resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
@@ -3842,68 +3848,6 @@ packages:
     peerDependencies:
       vite: '>=2.0.0'
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@5.4.14:
-    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4688,6 +4632,11 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/chrome@0.2.0':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/crypto-js@4.2.2': {}
 
   '@types/debug@4.1.12':
@@ -4811,14 +4760,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.11(@types/node@22.10.7)
-      vue: 3.5.13(typescript@5.7.3)
-
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
-    dependencies:
-      vite: 5.4.14(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
 
   '@volar/language-core@2.4.11':
@@ -8000,7 +7944,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-imagemin@0.6.1(vite@5.4.11(@types/node@22.10.7)):
+  vite-plugin-imagemin@0.6.1(vite@5.4.19(@types/node@22.10.7)):
     dependencies:
       '@types/imagemin': 7.0.1
       '@types/imagemin-gifsicle': 7.0.4
@@ -8025,27 +7969,9 @@ snapshots:
       imagemin-webp: 6.1.0
       jpegtran-bin: 6.0.1
       pathe: 0.2.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
     transitivePeerDependencies:
       - supports-color
-
-  vite@5.4.11(@types/node@22.10.7):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.30.1
-    optionalDependencies:
-      '@types/node': 22.10.7
-      fsevents: 2.3.3
-
-  vite@5.4.14(@types/node@22.10.7):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.30.1
-    optionalDependencies:
-      '@types/node': 22.10.7
-      fsevents: 2.3.3
 
   vite@5.4.19(@types/node@22.10.7):
     dependencies:
@@ -8065,7 +7991,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.1
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -8074,7 +8000,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.14(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1


### PR DESCRIPTION
## 说明

在独立 Worktree 分支中整合 PR #219 与 PR #228，并在合并冲突解决后补充兼容性修复。

## 主要改动

- 将 DeepSeek 模型迁移到 V4，并兼容旧 `deepseek-chat` / `deepseek-reasoner` 持久化配置
- 支持 Chat Completion 与手动选择 Responses API；自动模式使用 Chat Completion
- 增加 DeepSeek 思考模式设置，并保持旧 reasoner 配置的思考语义
- 修复代理 URL 切换 API 路径时查询参数和 hash 被破坏的问题
- 分离 Chat / Responses 返回结构解析，仅渲染最终文本并过滤 `<think>` 内容
- 补充设置页提示与翻译引擎文档

## 验证

- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm docs:build`
- `git diff --check origin/main...HEAD`
- 完整差异安全扫描：0 个发现

本 PR 包含 PR #219 和 PR #228 的完整提交历史，原 PR 未直接合并到 `main`。

## Summary by Sourcery

Migrate DeepSeek integration to V4, add API format and thinking mode controls, and ensure existing configurations and proxies remain compatible.

New Features:
- Add support for DeepSeek V4 Chat Completion and optional Responses API usage with selectable format in settings.
- Introduce configurable DeepSeek thinking mode for Chat Completion with behavior aligned to previous reasoner semantics.

Enhancements:
- Update DeepSeek model list to V4 variants and provide runtime/model migration helpers that normalize legacy configurations.
- Improve DeepSeek response handling by separating Chat and Responses parsing while consistently filtering out reasoning tags like <think>.
- Ensure DeepSeek proxy endpoints preserve existing query parameters and hashes when switching between API paths.
- Normalize imported and stored configuration objects to the current schema, including automatic DeepSeek model and thinking mode migration.

Build:
- Bump vite to 5.4.19 and add @types/chrome as a development dependency.

Documentation:
- Refresh DeepSeek translation engine documentation to reference V4 models, describe automatic migration from legacy models, and clarify API format usage.