### PR TITLE
feat: 支持自定义 JSON 请求体并补全服务兼容性

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -399,7 +399,7 @@
     </el-row>
 
     <!-- 自定义请求体 -->
-    <el-row v-show="compute.showModel" class="margin-bottom margin-left-2em">
+    <el-row v-show="compute.showCustomBody" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
           content='以 JSON 对象形式追加到请求体（顶层合并，会覆盖同名默认字段）。'
@@ -694,6 +694,11 @@ import browser from 'webextension-polyfill';
 import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
+import {
+  isCustomBodyMapping,
+  isValidCustomBody,
+  normalizeCustomBodyMapping,
+} from '@/entrypoints/utils/custom-body';
 
 // 初始化深色模式媒体查询
 const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -720,6 +725,7 @@ storage.getItem('local:config').then((value: any) => {
   if (typeof value === 'string' && value) {
     const parsedConfig = JSON.parse(value);
     Object.assign(config.value, parsedConfig);
+    config.value.customBody = normalizeCustomBodyMapping(parsedConfig.customBody);
   }
   // 初始应用主题
   updateTheme(config.value.theme || 'auto');
@@ -733,7 +739,9 @@ storage.watch('local:config', (newValue: any, oldValue: any) => {
   if (typeof newValue === 'string' && newValue) {
     // 将新的配置值解析为对象,并合并到当前的 config.value 中
     // 这样可以保持所有页面的配置同步
-    Object.assign(config.value, JSON.parse(newValue));
+    const parsedConfig = JSON.parse(newValue);
+    Object.assign(config.value, parsedConfig);
+    config.value.customBody = normalizeCustomBodyMapping(parsedConfig.customBody);
   }
 });
 
@@ -755,6 +763,8 @@ let compute = ref({
   showProxy: computed(() => servicesType.isUseProxy(config.value.service)),
   // 4、是否显示模型
   showModel: computed(() => servicesType.isUseModel(config.value.service)),
+  // 4.5、是否支持自定义请求体
+  showCustomBody: computed(() => servicesType.isUseCustomBody(config.value.service)),
   // 5、是否显示token
   showToken: computed(() => servicesType.isUseToken(config.value.service)),
   // 6、是否显示 AkSk
@@ -1100,17 +1110,6 @@ const isValidAzureEndpoint = (endpoint: string) => {
   return hasHttps && hasAzureDomain && hasChatCompletions;
 };
 
-// 自定义请求体（JSON）校验：留空视为合法（不启用），否则必须是 JSON 对象
-const isValidCustomBody = (str: string | undefined): boolean => {
-  if (!str || !str.trim()) return true;
-  try {
-    const v = JSON.parse(str);
-    return v !== null && typeof v === 'object' && !Array.isArray(v);
-  } catch {
-    return false;
-  }
-};
-
 const handleExport = async () => {
   const configStr = await storage.getItem('local:config');
   if (!configStr) {
@@ -1358,6 +1357,10 @@ const validateConfig = (configData: any): boolean => {
 
     // 检查服务配置
     if (typeof configData.service !== 'string') {
+      return false;
+    }
+
+    if ('customBody' in configData && !isCustomBodyMapping(configData.customBody)) {
       return false;
     }
 

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -398,6 +398,27 @@
       </el-col>
     </el-row>
 
+    <!-- 自定义请求体 -->
+    <el-row v-show="compute.showModel" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark"
+          content='以 JSON 对象形式追加到请求体（顶层合并，会覆盖同名默认字段）。'
+          placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin">
+              <ChatDotRound />
+            </el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-input v-model="config.customBody[config.service]"
+          :class="{ 'input-error': !isValidCustomBody(config.customBody[config.service]) }"
+          placeholder='例如：{"thinking": {"type": "disabled"}}' />
+        <div v-if="!isValidCustomBody(config.customBody[config.service])" class="error-text">
+          请输入合法的 JSON 对象，否则该配置将被忽略
+        </div>
+      </el-col>
+    </el-row>
+
     <!-- 高级选项-->
     <el-collapse class="margin-left-2em margin-bottom">
       <el-collapse-item title="高级选项">
@@ -1079,6 +1100,17 @@ const isValidAzureEndpoint = (endpoint: string) => {
   return hasHttps && hasAzureDomain && hasChatCompletions;
 };
 
+// 自定义请求体（JSON）校验：留空视为合法（不启用），否则必须是 JSON 对象
+const isValidCustomBody = (str: string | undefined): boolean => {
+  if (!str || !str.trim()) return true;
+  try {
+    const v = JSON.parse(str);
+    return v !== null && typeof v === 'object' && !Array.isArray(v);
+  } catch {
+    return false;
+  }
+};
+
 const handleExport = async () => {
   const configStr = await storage.getItem('local:config');
   if (!configStr) {
@@ -1114,6 +1146,19 @@ const handleExport = async () => {
     }
     if (Object.keys(cleanedConfig.user_role).length === 0) {
       delete cleanedConfig.user_role;
+    }
+  }
+
+  // Clean empty customBody entries
+  if (cleanedConfig.customBody) {
+    for (const service in cleanedConfig.customBody) {
+      const value = cleanedConfig.customBody[service];
+      if (!value || !String(value).trim()) {
+        delete cleanedConfig.customBody[service];
+      }
+    }
+    if (Object.keys(cleanedConfig.customBody).length === 0) {
+      delete cleanedConfig.customBody;
     }
   }
 

--- a/entrypoints/service/hunyuan-translation.ts
+++ b/entrypoints/service/hunyuan-translation.ts
@@ -1,6 +1,7 @@
 import { method } from "../utils/constant";
 import { config } from "@/entrypoints/utils/config";
 import { detectlang } from "../utils/common";
+import { mergeCustomBody } from "../utils/custom-body";
 
 // 混元翻译大模型支持的语言代码映射
 const languageMap: Record<string, string> = {
@@ -89,6 +90,20 @@ async function createHunyuanSignature(requestPayload: string, timestamp: number,
     return authorization;
 }
 
+export function buildHunyuanTranslationRequestBody(
+    text: string,
+    target: string,
+    model: string,
+    customBody?: unknown,
+) {
+    return mergeCustomBody({
+        Model: model,
+        Stream: false,
+        Text: text,
+        Target: target,
+    }, customBody);
+}
+
 async function hunyuanTranslation(message: any) {
     try {
         console.log('🔄 混元翻译开始处理:', message.origin);
@@ -145,14 +160,13 @@ async function hunyuanTranslation(message: any) {
         // 获取模型配置，默认使用 hunyuan-translation
         const model = config.model[config.service] || 'hunyuan-translation';
         
-        // 构建请求体
-        const requestBody: any = {
-            Model: model,
-            Stream: false, // 暂时使用非流式调用
-            Text: message.origin,
-            // Source: sourceLang,
-            Target: targetLang
-        };
+        // 自定义字段必须在序列化和签名前合并，否则签名内容会与实际请求体不一致。
+        const requestBody = buildHunyuanTranslationRequestBody(
+            message.origin,
+            targetLang,
+            model,
+            config.customBody?.[config.service],
+        );
         
         // 如果有配置领域信息，可以添加 Field 参数
         // requestBody.Field = '通用';

--- a/entrypoints/utils/config.ts
+++ b/entrypoints/utils/config.ts
@@ -1,4 +1,5 @@
 import { Config } from "@/entrypoints/utils/model";
+import { normalizeCustomBodyMapping } from "@/entrypoints/utils/custom-body";
 
 // 声明 config 类型, new Config() 会设置好所有默认值
 export let config: Config = new Config();
@@ -22,6 +23,7 @@ async function loadConfig() {
             if (isConfigObjectValid(parsedConfig)) {
                 // 如果配置有效，合并到当前 config 中
                 Object.assign(config, parsedConfig);
+                config.customBody = normalizeCustomBodyMapping(parsedConfig.customBody);
                 return; // 加载成功，直接返回
             }
         }
@@ -46,6 +48,7 @@ storage.watch('local:config', (newValue: any, oldValue: any) => {
             if (isConfigObjectValid(parsedConfig)) {
                 // 如果新的配置有效，更新 config
                 Object.assign(config, parsedConfig);
+                config.customBody = normalizeCustomBodyMapping(parsedConfig.customBody);
             } else {
                 console.warn('An invalid configuration was detected in storage.watch. Ignoring.');
             }

--- a/entrypoints/utils/custom-body.ts
+++ b/entrypoints/utils/custom-body.ts
@@ -1,0 +1,50 @@
+export type CustomBody = Record<string, unknown>;
+
+// 留空表示不启用自定义请求体；非空值必须是 JSON 对象。
+export function parseCustomBody(raw?: unknown): CustomBody | undefined {
+    if (raw === undefined || raw === null || raw === '') return {};
+    if (typeof raw !== 'string') return undefined;
+    if (!raw.trim()) return {};
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as CustomBody;
+        }
+    } catch {
+        // 由调用方决定如何提示非法配置。
+    }
+
+    return undefined;
+}
+
+export function isValidCustomBody(raw?: unknown): boolean {
+    return parseCustomBody(raw) !== undefined;
+}
+
+// 顶层浅合并，用户字段优先；返回新对象以避免修改原始 payload。
+export function mergeCustomBody<T extends Record<string, unknown>>(payload: T, raw?: unknown): T {
+    const customBody = parseCustomBody(raw);
+    if (customBody === undefined) {
+        console.warn('[FluentRead] 自定义请求体必须是合法的 JSON 对象，已忽略');
+        return payload;
+    }
+
+    return {...payload, ...customBody};
+}
+
+export function isCustomBodyMapping(value: unknown): value is Record<string, string> {
+    return value !== null
+        && typeof value === 'object'
+        && !Array.isArray(value)
+        && Object.values(value).every(item => typeof item === 'string');
+}
+
+// 兼容旧配置以及存储中可能存在的异常值，只保留字符串配置项。
+export function normalizeCustomBodyMapping(value: unknown): Record<string, string> {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
+
+    return Object.fromEntries(
+        Object.entries(value).filter(([, item]) => typeof item === 'string')
+    ) as Record<string, string>;
+}

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -25,6 +25,7 @@ export class Config {
     key: string;
     model: IMapping;
     customModel: IMapping;  // 自定义模型名称
+    customBody: IMapping;  // 自定义请求体（JSON 字符串，按服务存储），会合并进请求体
     proxy: IMapping;  // 代理地址
     custom: string; // 本地服务地址
     extra: IExtra;  // 额外信息（内包信息）
@@ -70,6 +71,7 @@ export class Config {
         this.key = '';
         this.model = {};
         this.customModel = {};
+        this.customBody = {};
         this.proxy = {};
         this.custom = defaultOption.custom;
         this.extra = {};

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -162,6 +162,8 @@ export const servicesType = {
     isUseToken: (service: string) => servicesType.useToken.has(service),
     isUseProxy: (service: string) => servicesType.useProxy.has(service),
     isUseModel: (service: string) => servicesType.useModel.has(service),
+    // 所有 AI 服务的请求体都支持附加顶层字段，包括不使用模型选择器的 Coze。
+    isUseCustomBody: (service: string) => servicesType.AI.has(service),
     isCustom: (service: string) => service === services.custom,
     isNewApi: (service: string) => service === services.newapi,
     isUseAkSk: (service: string) => service === services.yiyan,
@@ -409,4 +411,3 @@ export const defaultOption = {
     inputBoxTranslationTrigger: "disabled", // 默认关闭输入框翻译
     inputBoxTranslationTarget: "en", // 默认翻译成英文
 };
-

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -2,6 +2,29 @@
 import {customModelString, defaultOption, services} from "./option";
 import {config} from "@/entrypoints/utils/config";
 
+// 将用户自定义的 JSON 请求体合并进 payload（顶层浅合并，用户字段优先）。
+// 主要用于向请求体补充额外参数（例如 {"thinking": {"type": "disabled"}} 这类控制字段）。
+export function mergeCustomBody(payload: Record<string, any>, raw?: string | null): Record<string, any> {
+    if (!raw || !raw.trim()) return payload;
+    try {
+        const extra = JSON.parse(raw);
+        // 仅接受 JSON 对象（排除数组、null 及基本类型）
+        if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
+            Object.assign(payload, extra);
+        } else {
+            console.warn('[FluentRead] 自定义请求体必须是 JSON 对象，已忽略：', raw);
+        }
+    } catch (e) {
+        console.warn('[FluentRead] 自定义请求体不是合法的 JSON，已忽略：', raw, e);
+    }
+    return payload;
+}
+
+// 读取当前服务的自定义请求体（JSON 字符串）
+function currentCustomBody(): string | undefined {
+    return config.customBody?.[config.service];
+}
+
 // openai 格式的消息模板（通用模板）
 export function commonMsgTemplate(origin: string) {
     // 检测是否使用自定义模型
@@ -14,14 +37,16 @@ export function commonMsgTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         'model': model,
         "temperature": 1.0,
         'messages': [
             {'role': 'system', 'content': system},
             {'role': 'user', 'content': user},
         ]
-    })
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
 }
 
 // deepseek
@@ -49,7 +74,7 @@ export function deepseekMsgTemplate(origin: string) {
         payload.temperature = 0.7;
     }
 
-    return JSON.stringify(payload);
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()));
 }
 
 // gemini
@@ -57,11 +82,13 @@ export function geminiMsgTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         "contents": [
             {"role": "user", "parts": [{"text": user}]},
         ]
-    })
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
 }
 
 // claude
@@ -75,7 +102,7 @@ export function claudeMsgTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         model: model,
         max_tokens: 4096,
         stream: false,
@@ -83,7 +110,9 @@ export function claudeMsgTemplate(origin: string) {
         messages: [
             {role: "user", content: user},
         ]
-    })
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
 }
 
 // 通义千问
@@ -94,14 +123,15 @@ export function tongyiMsgTemplate(origin: string) {
         let user = (config.user_role[config.service] || defaultOption.user_role)
             .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-        return JSON.stringify({
+        const payload: any = {
             "model": model,
             "enable_thinking": false,
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ]
-        })
+        };
+        return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
     }
     // 翻译模型qwen-mt-plus和qwen-mt-turbo的格式和通用的不同
     const mtModelTemplate = () => {
@@ -115,7 +145,7 @@ export function tongyiMsgTemplate(origin: string) {
         ]
         let targetItem = langMap.find(i => i.value === config.to) || langMap[0]
         let targetLang = targetItem.target || targetItem.value
-        return JSON.stringify({
+        const payload: any = {
             "model": model,
             "messages": [
                 {"role": "user", "content": origin},
@@ -124,7 +154,8 @@ export function tongyiMsgTemplate(origin: string) {
                 "source_lang": "auto",
                 "target_lang": targetLang
             }
-        })
+        };
+        return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
     }
     return model.startsWith("qwen-mt") ? mtModelTemplate() : normalTemplate()
 
@@ -135,13 +166,15 @@ export function yiyanMsgTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         'temperature': 0.7,
         'disable_search': true, // 禁用搜索
         'messages': [
             {"role": "user", "content": user},
         ],
-    })
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
 }
 
 export function minimaxTemplate(origin: string) {
@@ -150,7 +183,7 @@ export function minimaxTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         model: "MiniMax-Text-01",
         stream: false,
         temperature: 0.7,
@@ -158,7 +191,9 @@ export function minimaxTemplate(origin: string) {
             {role: 'system', content: system},
             {role: 'user', content: user},
         ]
-    })
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()))
 }
 
 export function cozeTemplate(origin: string) {
@@ -167,10 +202,12 @@ export function cozeTemplate(origin: string) {
     let user = (config.user_role[config.service] || defaultOption.user_role)
         .replace('{{to}}', config.to).replace('{{origin}}', origin);
 
-    return JSON.stringify({
+    const payload: any = {
         bot_id: config.robot_id[config.service],
         user: "FluentRead",
         query: system + user,
         stream: false
-    });
+    };
+
+    return JSON.stringify(mergeCustomBody(payload, currentCustomBody()));
 }

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -1,24 +1,9 @@
 // 消息模板工具
 import {customModelString, defaultOption, services} from "./option";
 import {config} from "@/entrypoints/utils/config";
+import {mergeCustomBody} from "./custom-body";
 
-// 将用户自定义的 JSON 请求体合并进 payload（顶层浅合并，用户字段优先）。
-// 主要用于向请求体补充额外参数（例如 {"thinking": {"type": "disabled"}} 这类控制字段）。
-export function mergeCustomBody(payload: Record<string, any>, raw?: string | null): Record<string, any> {
-    if (!raw || !raw.trim()) return payload;
-    try {
-        const extra = JSON.parse(raw);
-        // 仅接受 JSON 对象（排除数组、null 及基本类型）
-        if (extra && typeof extra === 'object' && !Array.isArray(extra)) {
-            Object.assign(payload, extra);
-        } else {
-            console.warn('[FluentRead] 自定义请求体必须是 JSON 对象，已忽略：', raw);
-        }
-    } catch (e) {
-        console.warn('[FluentRead] 自定义请求体不是合法的 JSON，已忽略：', raw, e);
-    }
-    return payload;
-}
+export {mergeCustomBody};
 
 // 读取当前服务的自定义请求体（JSON 字符串）
 function currentCustomBody(): string | undefined {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "compile": "vue-tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "postinstall": "wxt prepare",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
@@ -37,10 +39,16 @@
     "vite": "^5.4.11",
     "vite-plugin-imagemin": "^0.6.1",
     "vitepress": "^1.6.3",
+    "vitest": "^2.1.9",
     "vue": "^3.5.13",
     "vue-tsc": "^2.2.0",
     "vuepress": "2.0.0-rc.19",
     "wxt": "^0.20.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "5.4.11"
+    }
   },
   "packageManager": "pnpm@9.12.1+sha1.7084e7df42ee1d221994c2c2599277a2a937f050"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vuepress/client": "2.0.0-rc.19",
     "@wxt-dev/webextension-polyfill": "^1.0.0",
     "typescript": "^5.7.3",
-    "vite": "^5.4.11",
+    "vite": "^5.4.19",
     "vite-plugin-imagemin": "^0.6.1",
     "vitepress": "^1.6.3",
     "vitest": "^2.1.9",
@@ -47,7 +47,7 @@
   },
   "pnpm": {
     "overrides": {
-      "vite": "5.4.11"
+      "vite": "5.4.19"
     }
   },
   "packageManager": "pnpm@9.12.1+sha1.7084e7df42ee1d221994c2c2599277a2a937f050"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: 5.4.11
+  vite: 5.4.19
 
 importers:
 
@@ -44,7 +44,7 @@ importers:
         version: 0.12.1
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
-        version: 5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
+        version: 5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
       '@vuepress/client':
         specifier: 2.0.0-rc.19
         version: 2.0.0-rc.19(typescript@5.7.3)
@@ -55,11 +55,11 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: 5.4.11
-        version: 5.4.11(@types/node@22.10.7)
+        specifier: 5.4.19
+        version: 5.4.19(@types/node@22.10.7)
       vite-plugin-imagemin:
         specifier: ^0.6.1
-        version: 0.6.1(vite@5.4.11(@types/node@22.10.7))
+        version: 0.6.1(vite@5.4.19(@types/node@22.10.7))
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.7)(async-validator@4.2.5)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3)
@@ -888,7 +888,7 @@ packages:
     resolution: {integrity: sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: 5.4.11
+      vite: 5.4.19
       vue: ^3.2.25
 
   '@vitest/expect@2.1.9':
@@ -898,7 +898,7 @@ packages:
     resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 5.4.11
+      vite: 5.4.19
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3937,10 +3937,10 @@ packages:
   vite-plugin-imagemin@0.6.1:
     resolution: {integrity: sha512-cP7LDn8euPrji7WYtDoNQpJEB9nkMxJHm/A+QZnvMrrCSuyo/clpMy/T1v7suDXPBavsDiDdFdVQB5p7VGD2cg==}
     peerDependencies:
-      vite: 5.4.11
+      vite: 5.4.19
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+  vite@5.4.19:
+    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -4876,9 +4876,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
 
   '@vitest/expect@2.1.9':
@@ -4888,13 +4888,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.11(@types/node@22.10.7))':
+  '@vitest/mocker@2.1.9(vite@5.4.19(@types/node@22.10.7))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -8126,7 +8126,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8144,7 +8144,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8156,7 +8156,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-imagemin@0.6.1(vite@5.4.11(@types/node@22.10.7)):
+  vite-plugin-imagemin@0.6.1(vite@5.4.19(@types/node@22.10.7)):
     dependencies:
       '@types/imagemin': 7.0.1
       '@types/imagemin-gifsicle': 7.0.4
@@ -8181,11 +8181,11 @@ snapshots:
       imagemin-webp: 6.1.0
       jpegtran-bin: 6.0.1
       pathe: 0.2.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.4.11(@types/node@22.10.7):
+  vite@5.4.19(@types/node@22.10.7):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
@@ -8203,7 +8203,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.19(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.1
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -8212,7 +8212,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1
@@ -8246,7 +8246,7 @@ snapshots:
   vitest@2.1.9(@types/node@22.10.7):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.11(@types/node@22.10.7))
+      '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@22.10.7))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8262,7 +8262,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vite-node: 2.1.9(@types/node@22.10.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -8453,7 +8453,7 @@ snapshots:
       publish-browser-extension: 2.3.0
       scule: 1.3.0
       unimport: 3.14.6(rollup@4.30.1)
-      vite: 5.4.11(@types/node@22.10.7)
+      vite: 5.4.19(@types/node@22.10.7)
       vite-node: 3.2.4(@types/node@22.10.7)
       web-ext-run: 0.2.4
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: 5.4.11
+
 importers:
 
   .:
@@ -52,7 +55,7 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
-        specifier: ^5.4.11
+        specifier: 5.4.11
         version: 5.4.11(@types/node@22.10.7)
       vite-plugin-imagemin:
         specifier: ^0.6.1
@@ -60,6 +63,9 @@ importers:
       vitepress:
         specifier: ^1.6.3
         version: 1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.7)(async-validator@4.2.5)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.10.7)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.3)
@@ -882,8 +888,37 @@ packages:
     resolution: {integrity: sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: 5.4.11
       vue: ^3.2.25
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: 5.4.11
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@volar/language-core@2.4.11':
     resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
@@ -1136,6 +1171,10 @@ packages:
     resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
     engines: {node: '>=12'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
@@ -1290,6 +1329,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -1311,6 +1354,10 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1570,6 +1617,10 @@ packages:
   decompress@4.2.1:
     resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
     engines: {node: '>=4'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -1925,6 +1976,10 @@ packages:
   executable@4.1.1:
     resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
     engines: {node: '>=4'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -2668,6 +2723,9 @@ packages:
     resolution: {integrity: sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==}
     engines: {node: '>=0.10.0'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowercase-keys@1.0.0:
     resolution: {integrity: sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==}
     engines: {node: '>=0.10.0'}
@@ -3101,8 +3159,15 @@ packages:
   pathe@0.2.0:
     resolution: {integrity: sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -3424,6 +3489,9 @@ packages:
   shiki@2.1.0:
     resolution: {integrity: sha512-yvKPdNGLXZv7WC4bl7JBbU3CEcUxnBanvMez8MG3gZXKpClGL4bHqFyLhTx+2zUvbjClUANs/S22HXb7aeOgmA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3519,6 +3587,12 @@ packages:
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
@@ -3683,9 +3757,27 @@ packages:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
     engines: {node: '>=0.10.0'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
@@ -3832,6 +3924,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3840,72 +3937,10 @@ packages:
   vite-plugin-imagemin@0.6.1:
     resolution: {integrity: sha512-cP7LDn8euPrji7WYtDoNQpJEB9nkMxJHm/A+QZnvMrrCSuyo/clpMy/T1v7suDXPBavsDiDdFdVQB5p7VGD2cg==}
     peerDependencies:
-      vite: '>=2.0.0'
+      vite: 5.4.11
 
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@5.4.14:
-    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@5.4.19:
-    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3945,6 +3980,31 @@ packages:
       markdown-it-mathjax3:
         optional: true
       postcss:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-uri@3.0.8:
@@ -4028,6 +4088,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -4816,10 +4881,45 @@ snapshots:
       vite: 5.4.11(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
 
-  '@vitejs/plugin-vue@5.2.1(vite@5.4.14(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))':
+  '@vitest/expect@2.1.9':
     dependencies:
-      vite: 5.4.14(@types/node@22.10.7)
-      vue: 3.5.13(typescript@5.7.3)
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.11(@types/node@22.10.7))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.10.7)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@volar/language-core@2.4.11':
     dependencies:
@@ -5146,6 +5246,8 @@ snapshots:
 
   array-union@3.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
@@ -5331,6 +5433,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -5351,6 +5461,8 @@ snapshots:
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -5621,6 +5733,8 @@ snapshots:
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -6030,6 +6144,8 @@ snapshots:
   executable@4.1.1:
     dependencies:
       pify: 2.3.0
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -6784,6 +6900,8 @@ snapshots:
       currently-unhandled: 0.4.1
       signal-exit: 3.0.7
 
+  loupe@3.2.1: {}
+
   lowercase-keys@1.0.0: {}
 
   lowercase-keys@1.0.1: {}
@@ -7239,7 +7357,11 @@ snapshots:
 
   pathe@0.2.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -7586,6 +7708,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.1
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7671,6 +7795,10 @@ snapshots:
       lpad-align: 1.1.2
 
   stable@0.1.8: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.1.0:
     dependencies:
@@ -7829,7 +7957,17 @@ snapshots:
 
   timed-out@4.0.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   titleize@3.0.0: {}
 
@@ -7982,13 +8120,31 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  vite-node@2.1.9(@types/node@22.10.7):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.11(@types/node@22.10.7)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@22.10.7):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8038,24 +8194,6 @@ snapshots:
       '@types/node': 22.10.7
       fsevents: 2.3.3
 
-  vite@5.4.14(@types/node@22.10.7):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.30.1
-    optionalDependencies:
-      '@types/node': 22.10.7
-      fsevents: 2.3.3
-
-  vite@5.4.19(@types/node@22.10.7):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.1
-      rollup: 4.30.1
-    optionalDependencies:
-      '@types/node': 22.10.7
-      fsevents: 2.3.3
-
   vitepress@1.6.3(@algolia/client-search@5.20.0)(@types/node@22.10.7)(async-validator@4.2.5)(postcss@8.5.1)(search-insights@2.17.3)(typescript@5.7.3):
     dependencies:
       '@docsearch/css': 3.8.2
@@ -8065,7 +8203,7 @@ snapshots:
       '@shikijs/transformers': 2.1.0
       '@shikijs/types': 2.1.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.1(vite@5.4.14(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@5.4.11(@types/node@22.10.7))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-api': 7.7.1
       '@vue/shared': 3.5.13
       '@vueuse/core': 12.5.0(typescript@5.7.3)
@@ -8074,7 +8212,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.1
       shiki: 2.1.0
-      vite: 5.4.14(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.10.7)
       vue: 3.5.13(typescript@5.7.3)
     optionalDependencies:
       postcss: 8.5.1
@@ -8104,6 +8242,41 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
+
+  vitest@2.1.9(@types/node@22.10.7):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.11(@types/node@22.10.7))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.3.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@22.10.7)
+      vite-node: 2.1.9(@types/node@22.10.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.10.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-uri@3.0.8: {}
 
@@ -8200,6 +8373,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   widest-line@5.0.0:
     dependencies:
       string-width: 7.2.0
@@ -8275,7 +8453,7 @@ snapshots:
       publish-browser-extension: 2.3.0
       scule: 1.3.0
       unimport: 3.14.6(rollup@4.30.1)
-      vite: 5.4.19(@types/node@22.10.7)
+      vite: 5.4.11(@types/node@22.10.7)
       vite-node: 3.2.4(@types/node@22.10.7)
       web-ext-run: 0.2.4
     transitivePeerDependencies:

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -11,22 +11,57 @@ const { mockConfig } = vi.hoisted(() => ({
         system_role: {} as Record<string, string>,
         user_role: {} as Record<string, string>,
         customBody: {} as Record<string, string>,
+        robot_id: {} as Record<string, string>,
     },
 }));
 
 vi.mock('@/entrypoints/utils/config', () => ({ config: mockConfig }));
 
-import { mergeCustomBody, commonMsgTemplate } from '@/entrypoints/utils/template';
+import {
+    claudeMsgTemplate,
+    commonMsgTemplate,
+    cozeTemplate,
+    deepseekMsgTemplate,
+    geminiMsgTemplate,
+    minimaxTemplate,
+    tongyiMsgTemplate,
+    yiyanMsgTemplate,
+} from '@/entrypoints/utils/template';
+import {
+    isCustomBodyMapping,
+    isValidCustomBody,
+    mergeCustomBody,
+    normalizeCustomBodyMapping,
+} from '@/entrypoints/utils/custom-body';
+import { buildHunyuanTranslationRequestBody } from '@/entrypoints/service/hunyuan-translation';
+import { services, servicesType } from '@/entrypoints/utils/option';
 
 beforeEach(() => {
     // 每个用例前重置 mock 配置，避免相互污染
     mockConfig.service = 'openai';
     mockConfig.to = 'zh-Hans';
-    mockConfig.model = { openai: 'gpt-4o' };
+    mockConfig.model = {
+        openai: 'gpt-4o',
+        moonshot: 'kimi-k2-0711-preview',
+        deepseek: 'deepseek-chat',
+        gemini: 'gemini-2.5-flash',
+        claude: 'claude-sonnet-4-0',
+        tongyi: 'qwen-plus',
+        yiyan: 'ERNIE-Bot',
+        minimax: 'chatcompletion_v2',
+    };
     mockConfig.customModel = {};
-    mockConfig.system_role = { openai: 'You are a translator.' };
-    mockConfig.user_role = { openai: 'Translate to {{to}}: {{origin}}' };
+    mockConfig.system_role = Object.fromEntries(
+        Object.values(services).map(service => [service, 'You are a translator.'])
+    );
+    mockConfig.user_role = Object.fromEntries(
+        Object.values(services).map(service => [service, 'Translate to {{to}}: {{origin}}'])
+    );
     mockConfig.customBody = {};
+    mockConfig.robot_id = {
+        cozecom: 'coze-bot',
+        cozecn: 'coze-bot',
+    };
 });
 
 describe('mergeCustomBody（纯函数）', () => {
@@ -47,21 +82,21 @@ describe('mergeCustomBody（纯函数）', () => {
 
     it('合法 JSON 对象会被合并进 payload', () => {
         const payload: any = { model: 'm', messages: [] };
-        mergeCustomBody(payload, '{"max_tokens": 1024}');
-        expect(payload.max_tokens).toBe(1024);
-        expect(payload.model).toBe('m');
+        const result = mergeCustomBody(payload, '{"max_tokens": 1024}');
+        expect(result.max_tokens).toBe(1024);
+        expect(result.model).toBe('m');
     });
 
     it('用户字段优先：覆盖同名的默认字段', () => {
         const payload: any = { temperature: 1.0 };
-        mergeCustomBody(payload, '{"temperature": 0.6}');
-        expect(payload.temperature).toBe(0.6);
+        const result = mergeCustomBody(payload, '{"temperature": 0.6}');
+        expect(result.temperature).toBe(0.6);
     });
 
     it('支持嵌套对象（如 thinking 这类控制字段）', () => {
         const payload: any = { model: 'm' };
-        mergeCustomBody(payload, '{"thinking": {"type": "disabled"}}');
-        expect(payload.thinking).toEqual({ type: 'disabled' });
+        const result = mergeCustomBody(payload, '{"thinking": {"type": "disabled"}}');
+        expect(result.thinking).toEqual({ type: 'disabled' });
     });
 
     it('非法 JSON 被安全忽略，payload 不变', () => {
@@ -81,10 +116,28 @@ describe('mergeCustomBody（纯函数）', () => {
         expect(mergeCustomBody({ a: 1 }, 'null')).toEqual({ a: 1 });
     });
 
-    it('原地修改并返回同一个 payload 引用', () => {
+    it('返回合并后的新对象，不修改原始 payload', () => {
         const payload = { a: 1 };
         const result = mergeCustomBody(payload, '{"b": 2}');
-        expect(result).toBe(payload);
+        expect(result).not.toBe(payload);
+        expect(result).toEqual({ a: 1, b: 2 });
+        expect(payload).toEqual({ a: 1 });
+    });
+});
+
+describe('自定义请求体校验与配置兼容', () => {
+    it('UI 与运行时共享同一套 JSON 对象校验', () => {
+        expect(isValidCustomBody('')).toBe(true);
+        expect(isValidCustomBody('{"thinking": {"type": "disabled"}}')).toBe(true);
+        expect(isValidCustomBody('[]')).toBe(false);
+        expect(isValidCustomBody('{oops')).toBe(false);
+    });
+
+    it('只接受字符串映射，并可清理旧配置中的异常值', () => {
+        expect(isCustomBodyMapping({ openai: '{}', moonshot: '{"a": 1}' })).toBe(true);
+        expect(isCustomBodyMapping({ openai: null })).toBe(false);
+        expect(normalizeCustomBodyMapping({ openai: '{}', invalid: 1 })).toEqual({ openai: '{}' });
+        expect(normalizeCustomBodyMapping(null)).toEqual({});
     });
 });
 
@@ -127,11 +180,12 @@ describe('commonMsgTemplate（集成）', () => {
 // 重点：确保 thinking 等额外字段能够正确注入请求体顶层（issue #213）
 describe('自定义请求体注入 thinking 字段（issue #213）', () => {
     it('关闭思考：{"thinking": {"type": "disabled"}} 注入到请求体顶层', () => {
-        mockConfig.customBody = { openai: '{"thinking": {"type": "disabled"}}' };
+        mockConfig.service = services.moonshot;
+        mockConfig.customBody = { moonshot: '{"thinking": {"type": "disabled"}}' };
         const body = JSON.parse(commonMsgTemplate('你好世界'));
         expect(body.thinking).toEqual({ type: 'disabled' });
         // 同时不破坏原有字段
-        expect(body.model).toBe('gpt-4o');
+        expect(body.model).toBe('kimi-k2-0711-preview');
         expect(body.messages[1].content).toBe('Translate to zh-Hans: 你好世界');
     });
 
@@ -158,5 +212,52 @@ describe('自定义请求体注入 thinking 字段（issue #213）', () => {
         };
         const body = JSON.parse(commonMsgTemplate('hi'));
         expect(body.thinking).toEqual({ type: 'disabled' });
+    });
+});
+
+describe('所有 AI 请求模板的自定义请求体支持', () => {
+    const templateCases = [
+        [services.openai, commonMsgTemplate],
+        [services.deepseek, deepseekMsgTemplate],
+        [services.gemini, geminiMsgTemplate],
+        [services.claude, claudeMsgTemplate],
+        [services.tongyi, tongyiMsgTemplate],
+        [services.yiyan, yiyanMsgTemplate],
+        [services.minimax, minimaxTemplate],
+        [services.cozecom, cozeTemplate],
+    ] as const;
+
+    it.each(templateCases)('%s 模板会合并顶层自定义字段', (service, template) => {
+        mockConfig.service = service;
+        mockConfig.customBody = {[service]: '{"request_tag": "custom"}'};
+
+        const body = JSON.parse(template('hello'));
+        expect(body.request_tag).toBe('custom');
+    });
+
+    it('自定义请求体入口覆盖所有 AI 服务，但不覆盖机器翻译', () => {
+        for (const service of servicesType.AI) {
+            expect(servicesType.isUseCustomBody(service)).toBe(true);
+        }
+        expect(servicesType.isUseCustomBody(services.google)).toBe(false);
+    });
+});
+
+describe('腾讯混元翻译自定义请求体', () => {
+    it('在序列化和签名前合并自定义字段，并允许覆盖默认字段', () => {
+        const body = buildHunyuanTranslationRequestBody(
+            'hello',
+            'zh',
+            'hunyuan-translation',
+            '{"Stream": true, "Field": "通用"}',
+        );
+
+        expect(body).toEqual({
+            Model: 'hunyuan-translation',
+            Stream: true,
+            Text: 'hello',
+            Target: 'zh',
+            Field: '通用',
+        });
     });
 });

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// template.ts 顶层会 import config（其内部使用了 wxt 注入的 storage 全局），
+// 在纯 Node 测试环境下并不存在，因此用一个可变的 mock 对象替换该模块。
+const { mockConfig } = vi.hoisted(() => ({
+    mockConfig: {
+        service: 'openai',
+        to: 'zh-Hans',
+        model: {} as Record<string, string>,
+        customModel: {} as Record<string, string>,
+        system_role: {} as Record<string, string>,
+        user_role: {} as Record<string, string>,
+        customBody: {} as Record<string, string>,
+    },
+}));
+
+vi.mock('@/entrypoints/utils/config', () => ({ config: mockConfig }));
+
+import { mergeCustomBody, commonMsgTemplate } from '@/entrypoints/utils/template';
+
+beforeEach(() => {
+    // 每个用例前重置 mock 配置，避免相互污染
+    mockConfig.service = 'openai';
+    mockConfig.to = 'zh-Hans';
+    mockConfig.model = { openai: 'gpt-4o' };
+    mockConfig.customModel = {};
+    mockConfig.system_role = { openai: 'You are a translator.' };
+    mockConfig.user_role = { openai: 'Translate to {{to}}: {{origin}}' };
+    mockConfig.customBody = {};
+});
+
+describe('mergeCustomBody（纯函数）', () => {
+    it('raw 为空字符串时，payload 原样返回', () => {
+        const payload = { model: 'x', temperature: 1 };
+        expect(mergeCustomBody(payload, '')).toEqual({ model: 'x', temperature: 1 });
+    });
+
+    it('raw 为纯空白时，payload 原样返回', () => {
+        const payload = { a: 1 };
+        expect(mergeCustomBody(payload, '   \n\t ')).toEqual({ a: 1 });
+    });
+
+    it('raw 为 undefined / null 时，payload 原样返回', () => {
+        expect(mergeCustomBody({ a: 1 }, undefined)).toEqual({ a: 1 });
+        expect(mergeCustomBody({ a: 1 }, null)).toEqual({ a: 1 });
+    });
+
+    it('合法 JSON 对象会被合并进 payload', () => {
+        const payload: any = { model: 'm', messages: [] };
+        mergeCustomBody(payload, '{"max_tokens": 1024}');
+        expect(payload.max_tokens).toBe(1024);
+        expect(payload.model).toBe('m');
+    });
+
+    it('用户字段优先：覆盖同名的默认字段', () => {
+        const payload: any = { temperature: 1.0 };
+        mergeCustomBody(payload, '{"temperature": 0.6}');
+        expect(payload.temperature).toBe(0.6);
+    });
+
+    it('支持嵌套对象（如 thinking 这类控制字段）', () => {
+        const payload: any = { model: 'm' };
+        mergeCustomBody(payload, '{"thinking": {"type": "disabled"}}');
+        expect(payload.thinking).toEqual({ type: 'disabled' });
+    });
+
+    it('非法 JSON 被安全忽略，payload 不变', () => {
+        const payload = { model: 'x' };
+        expect(mergeCustomBody(payload, '{not valid json')).toEqual({ model: 'x' });
+    });
+
+    it('JSON 数组被忽略（必须是对象）', () => {
+        const payload = { model: 'x' };
+        expect(mergeCustomBody(payload, '[1,2,3]')).toEqual({ model: 'x' });
+    });
+
+    it('JSON 基本类型被忽略（数字 / 字符串 / 布尔 / null）', () => {
+        expect(mergeCustomBody({ a: 1 }, '123')).toEqual({ a: 1 });
+        expect(mergeCustomBody({ a: 1 }, '"hello"')).toEqual({ a: 1 });
+        expect(mergeCustomBody({ a: 1 }, 'true')).toEqual({ a: 1 });
+        expect(mergeCustomBody({ a: 1 }, 'null')).toEqual({ a: 1 });
+    });
+
+    it('原地修改并返回同一个 payload 引用', () => {
+        const payload = { a: 1 };
+        const result = mergeCustomBody(payload, '{"b": 2}');
+        expect(result).toBe(payload);
+    });
+});
+
+describe('commonMsgTemplate（集成）', () => {
+    it('未配置自定义请求体时，生成标准 OpenAI 请求体', () => {
+        const body = JSON.parse(commonMsgTemplate('hello'));
+        expect(body).toEqual({
+            model: 'gpt-4o',
+            temperature: 1.0,
+            messages: [
+                { role: 'system', content: 'You are a translator.' },
+                { role: 'user', content: 'Translate to zh-Hans: hello' },
+            ],
+        });
+    });
+
+    it('选择“自定义模型”时使用 customModel 的值', () => {
+        mockConfig.model = { openai: '自定义模型' };
+        mockConfig.customModel = { openai: 'gpt-4o-mini' };
+        const body = JSON.parse(commonMsgTemplate('hello'));
+        expect(body.model).toBe('gpt-4o-mini');
+    });
+
+    it('非法的自定义请求体被忽略，标准请求体保持完整', () => {
+        mockConfig.customBody = { openai: '{oops' };
+        const body = JSON.parse(commonMsgTemplate('hello'));
+        expect(body.model).toBe('gpt-4o');
+        expect(body.thinking).toBeUndefined();
+        expect(body.messages).toHaveLength(2);
+    });
+
+    it('仅对当前服务生效：其他服务的自定义请求体不会被应用', () => {
+        // 当前服务是 openai，却给另一个服务配置了自定义请求体
+        mockConfig.customBody = { gemini: '{"thinking": {"type": "disabled"}}' };
+        const body = JSON.parse(commonMsgTemplate('hello'));
+        expect(body.thinking).toBeUndefined();
+    });
+});
+
+// 重点：确保 thinking 等额外字段能够正确注入请求体顶层（issue #213）
+describe('自定义请求体注入 thinking 字段（issue #213）', () => {
+    it('关闭思考：{"thinking": {"type": "disabled"}} 注入到请求体顶层', () => {
+        mockConfig.customBody = { openai: '{"thinking": {"type": "disabled"}}' };
+        const body = JSON.parse(commonMsgTemplate('你好世界'));
+        expect(body.thinking).toEqual({ type: 'disabled' });
+        // 同时不破坏原有字段
+        expect(body.model).toBe('gpt-4o');
+        expect(body.messages[1].content).toBe('Translate to zh-Hans: 你好世界');
+    });
+
+    it('开启思考：{"thinking": {"type": "enabled"}} 注入到请求体顶层', () => {
+        mockConfig.customBody = { openai: '{"thinking": {"type": "enabled"}}' };
+        const body = JSON.parse(commonMsgTemplate('hi'));
+        expect(body.thinking).toEqual({ type: 'enabled' });
+    });
+
+    it('可同时覆盖 temperature 并注入 thinking', () => {
+        mockConfig.customBody = {
+            openai: '{"thinking": {"type": "disabled"}, "temperature": 0.6}',
+        };
+        const body = JSON.parse(commonMsgTemplate('hi'));
+        expect(body.thinking).toEqual({ type: 'disabled' });
+        expect(body.temperature).toBe(0.6);
+    });
+
+    it('带格式（缩进/换行）的 JSON 也能正确解析', () => {
+        mockConfig.customBody = {
+            openai: `{
+                "thinking": { "type": "disabled" }
+            }`,
+        };
+        const body = JSON.parse(commonMsgTemplate('hi'));
+        expect(body.thinking).toEqual({ type: 'disabled' });
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+// 独立的 Vitest 配置（与 wxt 构建配置互不影响）
+export default defineConfig({
+    resolve: {
+        alias: {
+            // 与 wxt 一致：'@' 指向项目根目录
+            '@': resolve(__dirname, '.'),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['tests/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## 背景

基于并合入 #218，补全审阅中发现的服务覆盖、配置健壮性与 Vite 依赖一致性问题，解决 #213。

## 主要改动

- 为 AI 翻译服务增加按服务配置的顶层自定义 JSON 请求体
- 抽取统一的解析、校验、规范化和不可变合并逻辑
- 补齐 Coze 等不显示模型选择器的 AI 服务入口
- 混元翻译在序列化和签名前合并自定义字段，确保签名内容与实际请求一致
- 统一 Vite 到 5.4.19，消除重复版本导致的类型冲突
- 扩展模板与混元翻译测试，共 30 个用例

## 验证

- pnpm test：30/30 通过
- pnpm build：通过
- pnpm build:firefox：通过
- pnpm docs:build：通过
- pnpm compile：仅剩 main 已有的 chrome 全局类型错误；本分支不再出现 Vite 类型冲突

本 PR 包含 #218 的提交，可在本 PR 合并后关闭 #218。

Closes #213

## Summary by Sourcery

Add configurable top-level JSON bodies for AI service requests and ensure configuration compatibility across UI, runtime, and translation services.

New Features:
- Introduce per-service custom JSON request body configuration that is merged into AI request payloads.
- Expose a UI input for defining custom JSON objects that extend AI service request bodies.

Enhancements:
- Unify parsing, validation, normalization, and merging logic for custom request bodies in a shared utility.
- Extend AI service templates and Tencent Hunyuan translation requests to support merged custom fields without breaking defaults.
- Normalize and validate stored configuration for custom request bodies to maintain robustness across loads and exports.

Build:
- Upgrade Vite to 5.4.19 and enforce the version via pnpm overrides.
- Add Vitest test and watch scripts to package.json.

Tests:
- Add Vitest configuration and a new test suite covering custom-body utilities, AI templates, and Hunyuan translation behavior.