### PR TITLE
fix: restore Google translation without API key

### DIFF
--- a/entrypoints/service/google.ts
+++ b/entrypoints/service/google.ts
@@ -20,6 +20,28 @@ function createGoogleBatchRequest(text: string, fromLang: string, toLang: string
     return JSON.stringify([[[GOOGLE_TRANSLATE_RPC_ID, request, null, 'generic']]]);
 }
 
+function getArrayItem(value: unknown, index: number): unknown {
+    return Array.isArray(value) ? value[index] : undefined;
+}
+
+function joinTranslationSegments(value: unknown): string | null {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+
+    const translatedText = value
+        .map(segment => Array.isArray(segment) && typeof segment[0] === 'string' ? segment[0] : '')
+        .join('');
+    return translatedText.length > 0 ? translatedText : null;
+}
+
+function getGoogleBatchSegments(payload: unknown): unknown {
+    const translationGroups = getArrayItem(payload, 1);
+    const firstGroup = getArrayItem(translationGroups, 0);
+    const firstTranslation = getArrayItem(firstGroup, 0);
+    return getArrayItem(firstTranslation, 5);
+}
+
 export function parseGoogleBatchResponse(responseBody: string): string {
     const lines = responseBody
         .replace(/^\)\]\}'(?:\r?\n)?/, '')
@@ -59,15 +81,8 @@ export function parseGoogleBatchResponse(responseBody: string): string {
                 continue;
             }
 
-            const segments = (payload as any)?.[1]?.[0]?.[0]?.[5];
-            if (!Array.isArray(segments)) {
-                continue;
-            }
-
-            const translatedText = segments
-                .map(segment => Array.isArray(segment) && typeof segment[0] === 'string' ? segment[0] : '')
-                .join('');
-            if (translatedText.length > 0) {
+            const translatedText = joinTranslationSegments(getGoogleBatchSegments(payload));
+            if (translatedText !== null) {
                 return translatedText;
             }
         }
@@ -84,15 +99,8 @@ export function parseGoogleLegacyResponse(responseBody: string): string {
         throw new Error('返回的不是 JSON');
     }
 
-    const segments = (result as any)?.[0];
-    if (!Array.isArray(segments)) {
-        throw new Error('返回格式异常');
-    }
-
-    const translatedText = segments
-        .map(segment => Array.isArray(segment) && typeof segment[0] === 'string' ? segment[0] : '')
-        .join('');
-    if (translatedText.length === 0) {
+    const translatedText = joinTranslationSegments(getArrayItem(result, 0));
+    if (translatedText === null) {
         throw new Error('返回格式异常');
     }
     return translatedText;
@@ -108,6 +116,15 @@ function formatResponseBody(responseBody: string): string {
         return '';
     }
     return compactBody.slice(0, GOOGLE_ERROR_BODY_PREVIEW_LENGTH);
+}
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function createGoogleParseError(error: unknown, responseBody: string): Error {
+    const responsePreview = formatResponseBody(responseBody) || '空响应';
+    return new Error(`${getErrorMessage(error)}，响应摘要: ${responsePreview}`);
 }
 
 async function fetchGoogleResponse(
@@ -154,7 +171,11 @@ async function translateGoogleBatch(
             'f.req': createGoogleBatchRequest(text, fromLang, toLang),
         }).toString(),
     }, timeoutMs);
-    return parseGoogleBatchResponse(responseBody);
+    try {
+        return parseGoogleBatchResponse(responseBody);
+    } catch (error) {
+        throw createGoogleParseError(error, responseBody);
+    }
 }
 
 async function translateGoogleLegacy(
@@ -173,11 +194,11 @@ async function translateGoogleLegacy(
     url.searchParams.set('q', text);
 
     const {responseBody} = await fetchGoogleResponse(url, {method: 'GET'}, timeoutMs);
-    return parseGoogleLegacyResponse(responseBody);
-}
-
-function getErrorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
+    try {
+        return parseGoogleLegacyResponse(responseBody);
+    } catch (error) {
+        throw createGoogleParseError(error, responseBody);
+    }
 }
 
 export async function translateGoogleText(

--- a/entrypoints/service/google.ts
+++ b/entrypoints/service/google.ts
@@ -1,26 +1,114 @@
-import {method} from "../utils/constant";
 import {config} from "@/entrypoints/utils/config";
 
-async function google(message: any) {
-    let params: any = {
-        client: 'gtx', sl: config.from, tl: config.to, dt: 't', strip: 1, nonced: 1,
-        'q': encodeURIComponent(message.origin),
-    };
-    let queryString = Object.keys(params).map((key: string) => key + '=' + params[key]).join('&');
+const GOOGLE_TRANSLATE_RPC_ID = 'MkEWBc';
+const GOOGLE_TRANSLATE_URL = `https://translate.google.com/_/TranslateWebserverUi/data/batchexecute?rpcids=${GOOGLE_TRANSLATE_RPC_ID}`;
+const GOOGLE_TRANSLATE_TIMEOUT_MS = 15_000;
 
-    const resp = await fetch('https://translate.googleapis.com/translate_a/single?' + queryString, {
-        method: method.GET,
-    });
+function createGoogleBatchRequest(text: string, fromLang: string, toLang: string): string {
+    const request = JSON.stringify([[text, fromLang, toLang, true], [null]]);
+    return JSON.stringify([[[GOOGLE_TRANSLATE_RPC_ID, request, null, 'generic']]]);
+}
 
-    if (resp.ok) {
-        let result = await resp.json();
-        let sentence = '';
-        result[0].forEach((e: any) => sentence += e[0]);
-        return sentence;
-    } else {
-        console.log(resp);
-        throw new Error(`翻译失败: ${resp.status} ${resp.statusText} body: ${await resp.text()}`);
+export function parseGoogleBatchResponse(responseBody: string): string {
+    const lines = responseBody
+        .replace(/^\)\]\}'(?:\r?\n)?/, '')
+        .split(/\r?\n/);
+
+    for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine.startsWith('[')) {
+            continue;
+        }
+
+        let records: unknown;
+        try {
+            records = JSON.parse(trimmedLine);
+        } catch {
+            continue;
+        }
+
+        if (!Array.isArray(records)) {
+            continue;
+        }
+
+        for (const record of records) {
+            if (
+                !Array.isArray(record)
+                || record[0] !== 'wrb.fr'
+                || record[1] !== GOOGLE_TRANSLATE_RPC_ID
+                || typeof record[2] !== 'string'
+            ) {
+                continue;
+            }
+
+            let payload: unknown;
+            try {
+                payload = JSON.parse(record[2]);
+            } catch {
+                continue;
+            }
+
+            const segments = (payload as any)?.[1]?.[0]?.[0]?.[5];
+            if (!Array.isArray(segments)) {
+                continue;
+            }
+
+            const translatedText = segments
+                .map(segment => Array.isArray(segment) && typeof segment[0] === 'string' ? segment[0] : '')
+                .join('');
+            if (translatedText.length > 0) {
+                return translatedText;
+            }
+        }
     }
+
+    throw new Error('谷歌翻译返回格式异常');
+}
+
+export async function translateGoogleText(
+    text: string,
+    fromLang: string,
+    toLang: string,
+): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), GOOGLE_TRANSLATE_TIMEOUT_MS);
+    let resp: Response;
+    let responseBody: string;
+
+    try {
+        resp = await fetch(GOOGLE_TRANSLATE_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+            },
+            body: new URLSearchParams({
+                'f.req': createGoogleBatchRequest(text, fromLang, toLang),
+            }).toString(),
+            signal: controller.signal,
+        });
+        responseBody = await resp.text();
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw new Error(`谷歌翻译请求超时（${GOOGLE_TRANSLATE_TIMEOUT_MS / 1000} 秒）`);
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`谷歌翻译网络请求失败: ${message}`);
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    if (!resp.ok) {
+        throw new Error(`翻译失败: ${resp.status} ${resp.statusText} body: ${responseBody}`);
+    }
+
+    return parseGoogleBatchResponse(responseBody);
+}
+
+async function google(message: {origin: string}) {
+    if (typeof message.origin !== 'string') {
+        throw new Error('谷歌翻译仅支持单条文本');
+    }
+    return translateGoogleText(message.origin, config.from, config.to);
 }
 
 export default google;

--- a/entrypoints/service/google.ts
+++ b/entrypoints/service/google.ts
@@ -1,8 +1,19 @@
 import {config} from "@/entrypoints/utils/config";
 
 const GOOGLE_TRANSLATE_RPC_ID = 'MkEWBc';
-const GOOGLE_TRANSLATE_URL = `https://translate.google.com/_/TranslateWebserverUi/data/batchexecute?rpcids=${GOOGLE_TRANSLATE_RPC_ID}`;
-const GOOGLE_TRANSLATE_TIMEOUT_MS = 15_000;
+const GOOGLE_TRANSLATE_BATCH_URLS = [
+    `https://translate.google.com/_/TranslateWebserverUi/data/batchexecute?rpcids=${GOOGLE_TRANSLATE_RPC_ID}`,
+    `https://translate.google.co.uk/_/TranslateWebserverUi/data/batchexecute?rpcids=${GOOGLE_TRANSLATE_RPC_ID}`,
+] as const;
+const GOOGLE_TRANSLATE_LEGACY_URL = 'https://translate.googleapis.com/translate_a/single';
+const GOOGLE_TRANSLATE_TOTAL_TIMEOUT_MS = 15_000;
+const GOOGLE_TRANSLATE_ATTEMPT_TIMEOUT_MS = 8_000;
+const GOOGLE_ERROR_BODY_PREVIEW_LENGTH = 200;
+
+type GoogleProvider = {
+    name: string;
+    translate: (timeoutMs: number) => Promise<string>;
+};
 
 function createGoogleBatchRequest(text: string, fromLang: string, toLang: string): string {
     const request = JSON.stringify([[text, fromLang, toLang, true], [null]]);
@@ -62,7 +73,111 @@ export function parseGoogleBatchResponse(responseBody: string): string {
         }
     }
 
-    throw new Error('谷歌翻译返回格式异常');
+    throw new Error('返回格式异常');
+}
+
+export function parseGoogleLegacyResponse(responseBody: string): string {
+    let result: unknown;
+    try {
+        result = JSON.parse(responseBody);
+    } catch {
+        throw new Error('返回的不是 JSON');
+    }
+
+    const segments = (result as any)?.[0];
+    if (!Array.isArray(segments)) {
+        throw new Error('返回格式异常');
+    }
+
+    const translatedText = segments
+        .map(segment => Array.isArray(segment) && typeof segment[0] === 'string' ? segment[0] : '')
+        .join('');
+    if (translatedText.length === 0) {
+        throw new Error('返回格式异常');
+    }
+    return translatedText;
+}
+
+function formatResponseBody(responseBody: string): string {
+    if (/<!doctype html|<html[\s>]/i.test(responseBody)) {
+        return '收到 HTML 页面（可能触发了 CAPTCHA）';
+    }
+
+    const compactBody = responseBody.replace(/\s+/g, ' ').trim();
+    if (compactBody.length === 0) {
+        return '';
+    }
+    return compactBody.slice(0, GOOGLE_ERROR_BODY_PREVIEW_LENGTH);
+}
+
+async function fetchGoogleResponse(
+    url: string | URL,
+    init: RequestInit,
+    timeoutMs: number,
+): Promise<{responseBody: string}> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        const response = await fetch(url, {...init, signal: controller.signal});
+        const responseBody = await response.text();
+        if (!response.ok) {
+            const bodyPreview = formatResponseBody(responseBody);
+            throw new Error(
+                `HTTP ${response.status} ${response.statusText}${bodyPreview ? `，响应: ${bodyPreview}` : ''}`,
+            );
+        }
+        return {responseBody};
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw new Error(`请求超时（${timeoutMs / 1000} 秒）`);
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function translateGoogleBatch(
+    endpoint: string,
+    text: string,
+    fromLang: string,
+    toLang: string,
+    timeoutMs: number,
+): Promise<string> {
+    const {responseBody} = await fetchGoogleResponse(endpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
+        body: new URLSearchParams({
+            'f.req': createGoogleBatchRequest(text, fromLang, toLang),
+        }).toString(),
+    }, timeoutMs);
+    return parseGoogleBatchResponse(responseBody);
+}
+
+async function translateGoogleLegacy(
+    text: string,
+    fromLang: string,
+    toLang: string,
+    timeoutMs: number,
+): Promise<string> {
+    const url = new URL(GOOGLE_TRANSLATE_LEGACY_URL);
+    url.searchParams.set('client', 'gtx');
+    url.searchParams.set('sl', fromLang);
+    url.searchParams.set('tl', toLang);
+    url.searchParams.set('dt', 't');
+    url.searchParams.set('strip', '1');
+    url.searchParams.set('nonced', '1');
+    url.searchParams.set('q', text);
+
+    const {responseBody} = await fetchGoogleResponse(url, {method: 'GET'}, timeoutMs);
+    return parseGoogleLegacyResponse(responseBody);
+}
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
 }
 
 export async function translateGoogleText(
@@ -70,38 +185,45 @@ export async function translateGoogleText(
     fromLang: string,
     toLang: string,
 ): Promise<string> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), GOOGLE_TRANSLATE_TIMEOUT_MS);
-    let resp: Response;
-    let responseBody: string;
+    const providers: GoogleProvider[] = [
+        ...GOOGLE_TRANSLATE_BATCH_URLS.map((endpoint, index) => ({
+            name: index === 0 ? '主网页 RPC' : '备用网页 RPC',
+            translate: (timeoutMs: number) => translateGoogleBatch(
+                endpoint,
+                text,
+                fromLang,
+                toLang,
+                timeoutMs,
+            ),
+        })),
+        {
+            name: '旧版 gtx 接口',
+            translate: (timeoutMs: number) => translateGoogleLegacy(
+                text,
+                fromLang,
+                toLang,
+                timeoutMs,
+            ),
+        },
+    ];
+    const deadline = Date.now() + GOOGLE_TRANSLATE_TOTAL_TIMEOUT_MS;
+    const failures: string[] = [];
 
-    try {
-        resp = await fetch(GOOGLE_TRANSLATE_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-            },
-            body: new URLSearchParams({
-                'f.req': createGoogleBatchRequest(text, fromLang, toLang),
-            }).toString(),
-            signal: controller.signal,
-        });
-        responseBody = await resp.text();
-    } catch (error) {
-        if (controller.signal.aborted) {
-            throw new Error(`谷歌翻译请求超时（${GOOGLE_TRANSLATE_TIMEOUT_MS / 1000} 秒）`);
+    for (const provider of providers) {
+        const remainingTime = deadline - Date.now();
+        if (remainingTime <= 0) {
+            break;
         }
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`谷歌翻译网络请求失败: ${message}`);
-    } finally {
-        clearTimeout(timeout);
+
+        try {
+            return await provider.translate(Math.min(GOOGLE_TRANSLATE_ATTEMPT_TIMEOUT_MS, remainingTime));
+        } catch (error) {
+            failures.push(`${provider.name}: ${getErrorMessage(error)}`);
+        }
     }
 
-    if (!resp.ok) {
-        throw new Error(`翻译失败: ${resp.status} ${resp.statusText} body: ${responseBody}`);
-    }
-
-    return parseGoogleBatchResponse(responseBody);
+    const failureSummary = failures.length > 0 ? failures.join('；') : '总请求时间已耗尽';
+    throw new Error(`谷歌翻译所有匿名接口均失败：${failureSummary}`);
 }
 
 async function google(message: {origin: string}) {

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -60,6 +60,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
 });
 
@@ -137,20 +139,61 @@ describe('谷歌翻译适配器', () => {
         expect(init?.headers).toBeUndefined();
     });
 
-    it('所有接口失败时汇总原因并隐藏 CAPTCHA HTML', async () => {
+    it('所有接口失败时汇总原因、响应摘要并隐藏 CAPTCHA HTML', async () => {
         fetchMock
             .mockResolvedValueOnce(mockResponse('<!doctype html><html>captcha details</html>', {
                 ok: false,
                 status: 429,
                 statusText: 'Too Many Requests',
             }))
-            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(mockResponse(`)]}'\n\n[["unexpected", true]]`))
             .mockResolvedValueOnce(mockResponse('not-json'));
 
         await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
             .rejects.toThrow(
-                '谷歌翻译所有匿名接口均失败：主网页 RPC: HTTP 429 Too Many Requests，响应: 收到 HTML 页面（可能触发了 CAPTCHA）；备用网页 RPC: Failed to fetch；旧版 gtx 接口: 返回的不是 JSON',
+                `谷歌翻译所有匿名接口均失败：主网页 RPC: HTTP 429 Too Many Requests，响应: 收到 HTML 页面（可能触发了 CAPTCHA）；备用网页 RPC: 返回格式异常，响应摘要: )]}' [["unexpected", true]]；旧版 gtx 接口: 返回的不是 JSON，响应摘要: not-json`,
             );
+    });
+
+    it('读取响应体失败时继续故障转移并汇总错误', async () => {
+        fetchMock.mockResolvedValue(mockResponse('', {
+            text: vi.fn().mockRejectedValue(new Error('stream error')),
+        }));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .rejects.toThrow(
+                '谷歌翻译所有匿名接口均失败：主网页 RPC: stream error；备用网页 RPC: stream error；旧版 gtx 接口: stream error',
+            );
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('单接口超时后继续故障转移，并遵守 15 秒总预算', async () => {
+        vi.useFakeTimers();
+        const signals: AbortSignal[] = [];
+        fetchMock.mockImplementation((_input, init) => {
+            const signal = init?.signal;
+            if (!signal) {
+                return Promise.reject(new Error('缺少 AbortSignal'));
+            }
+            signals.push(signal);
+            return new Promise((_resolve, reject) => {
+                signal.addEventListener('abort', () => {
+                    reject(new DOMException('The operation was aborted.', 'AbortError'));
+                }, {once: true});
+            });
+        });
+
+        const translationPromise = translateGoogleText('hello', 'en', 'zh-Hans');
+        const assertion = expect(translationPromise).rejects.toThrow(
+            '谷歌翻译所有匿名接口均失败：主网页 RPC: 请求超时（8 秒）；备用网页 RPC: 请求超时（7 秒）',
+        );
+
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(signals).toHaveLength(2);
+        expect(signals.every(signal => signal.aborted)).toBe(true);
     });
 
     it('按网页 RPC 服务端片段原样拼接译文，不额外插入空格', () => {

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -1,0 +1,139 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {mockConfig} = vi.hoisted(() => ({
+    mockConfig: {
+        from: 'auto',
+        to: 'zh-Hans',
+    },
+}));
+
+vi.mock('@/entrypoints/utils/config', () => ({config: mockConfig}));
+
+import google, {
+    parseGoogleBatchResponse,
+    translateGoogleText,
+} from '@/entrypoints/service/google';
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function createBatchResponse(translations: string[]): string {
+    const payload = [
+        null,
+        [[[
+            null,
+            null,
+            null,
+            null,
+            null,
+            translations.map(text => [text]),
+        ]]],
+    ];
+    const records = [
+        ['wrb.fr', 'MkEWBc', JSON.stringify(payload), null, null, null, 'generic'],
+        ['di', 123],
+    ];
+    return `)]}'\n\n${JSON.stringify(records)}`;
+}
+
+function mockResponse(overrides: Partial<Response> = {}): Response {
+    return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: vi.fn().mockResolvedValue(createBatchResponse(['此域名仅用于文档中的示例。'])),
+        ...overrides,
+    } as unknown as Response;
+}
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('谷歌翻译适配器', () => {
+    it('通过无需 API Key 的 batchexecute 端点发送请求并返回译文', async () => {
+        fetchMock.mockResolvedValue(mockResponse());
+
+        await expect(google({origin: 'This domain is for use in documents.'}))
+            .resolves.toBe('此域名仅用于文档中的示例。');
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0]!;
+        expect(url).toBe('https://translate.google.com/_/TranslateWebserverUi/data/batchexecute?rpcids=MkEWBc');
+        expect(init).toMatchObject({
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+            },
+        });
+        expect(init?.headers).not.toHaveProperty('X-Goog-API-Key');
+
+        const requestBody = new URLSearchParams(String(init?.body)).get('f.req');
+        expect(requestBody).not.toBeNull();
+        const batchRequest = JSON.parse(requestBody!);
+        expect(batchRequest[0][0][0]).toBe('MkEWBc');
+        expect(batchRequest[0][0][2]).toBeNull();
+        expect(batchRequest[0][0][3]).toBe('generic');
+        expect(JSON.parse(batchRequest[0][0][1])).toEqual([
+            ['This domain is for use in documents.', 'auto', 'zh-Hans', true],
+            [null],
+        ]);
+    });
+
+    it('按服务端片段原样拼接译文，不额外插入空格', () => {
+        expect(parseGoogleBatchResponse(createBatchResponse(['第一句话。', '第二句话！'])))
+            .toBe('第一句话。第二句话！');
+    });
+
+    it('保留换行和普通文本中的 HTML 字符', async () => {
+        fetchMock.mockResolvedValue(mockResponse({
+            text: vi.fn().mockResolvedValue(createBatchResponse(['如果 x < 3 && y > 1\n', '下一行'])),
+        }));
+
+        await expect(translateGoogleText('if x < 3 && y > 1\nNext line', 'en', 'zh-Hans'))
+            .resolves.toBe('如果 x < 3 && y > 1\n下一行');
+    });
+
+    it('忽略防劫持前缀、长度行和无关记录', () => {
+        const response = createBatchResponse(['测试成功']).replace('\n\n', '\n\n1234\nnot-json\n');
+        expect(parseGoogleBatchResponse(response)).toBe('测试成功');
+    });
+
+    it('保留服务端错误状态和响应正文', async () => {
+        fetchMock.mockResolvedValue(mockResponse({
+            ok: false,
+            status: 429,
+            statusText: 'Too Many Requests',
+            text: vi.fn().mockResolvedValue('rate limited'),
+        }));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .rejects.toThrow('翻译失败: 429 Too Many Requests body: rate limited');
+    });
+
+    it('拒绝无法识别的响应结构', async () => {
+        fetchMock.mockResolvedValue(mockResponse({
+            text: vi.fn().mockResolvedValue(`)]}'\n\n[["unexpected", true]]`),
+        }));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .rejects.toThrow('谷歌翻译返回格式异常');
+    });
+
+    it('把网络异常转换为可读错误', async () => {
+        fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .rejects.toThrow('谷歌翻译网络请求失败: Failed to fetch');
+    });
+
+    it('拒绝批量文本输入', async () => {
+        await expect(google({origin: ['hello']} as unknown as {origin: string}))
+            .rejects.toThrow('谷歌翻译仅支持单条文本');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/entrypoints/utils/config', () => ({config: mockConfig}));
 
 import google, {
     parseGoogleBatchResponse,
+    parseGoogleLegacyResponse,
     translateGoogleText,
 } from '@/entrypoints/service/google';
 
@@ -35,12 +36,20 @@ function createBatchResponse(translations: string[]): string {
     return `)]}'\n\n${JSON.stringify(records)}`;
 }
 
-function mockResponse(overrides: Partial<Response> = {}): Response {
+function createLegacyResponse(translations: string[]): string {
+    return JSON.stringify([
+        translations.map(text => [text, null, null, null]),
+        null,
+        'en',
+    ]);
+}
+
+function mockResponse(responseBody: string, overrides: Partial<Response> = {}): Response {
     return {
         ok: true,
         status: 200,
         statusText: 'OK',
-        text: vi.fn().mockResolvedValue(createBatchResponse(['此域名仅用于文档中的示例。'])),
+        text: vi.fn().mockResolvedValue(responseBody),
         ...overrides,
     } as unknown as Response;
 }
@@ -55,8 +64,8 @@ afterEach(() => {
 });
 
 describe('谷歌翻译适配器', () => {
-    it('通过无需 API Key 的 batchexecute 端点发送请求并返回译文', async () => {
-        fetchMock.mockResolvedValue(mockResponse());
+    it('优先通过无需 API Key 的主网页 RPC 返回译文', async () => {
+        fetchMock.mockResolvedValue(mockResponse(createBatchResponse(['此域名仅用于文档中的示例。'])));
 
         await expect(google({origin: 'This domain is for use in documents.'}))
             .resolves.toBe('此域名仅用于文档中的示例。');
@@ -84,51 +93,105 @@ describe('谷歌翻译适配器', () => {
         ]);
     });
 
-    it('按服务端片段原样拼接译文，不额外插入空格', () => {
+    it('主网页 RPC 失败后切换到备用区域 RPC', async () => {
+        fetchMock
+            .mockResolvedValueOnce(mockResponse('temporarily unavailable', {
+                ok: false,
+                status: 503,
+                statusText: 'Service Unavailable',
+            }))
+            .mockResolvedValueOnce(mockResponse(createBatchResponse(['备用接口成功'])));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .resolves.toBe('备用接口成功');
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1]?.[0]).toBe(
+            'https://translate.google.co.uk/_/TranslateWebserverUi/data/batchexecute?rpcids=MkEWBc',
+        );
+    });
+
+    it('两个网页 RPC 都失败后使用旧版 gtx 接口', async () => {
+        fetchMock
+            .mockResolvedValueOnce(mockResponse('bad gateway', {
+                ok: false,
+                status: 502,
+                statusText: 'Bad Gateway',
+            }))
+            .mockResolvedValueOnce(mockResponse(`)]}'\n\n[["unexpected", true]]`))
+            .mockResolvedValueOnce(mockResponse(createLegacyResponse(['旧版', '接口成功'])));
+
+        await expect(translateGoogleText('hello & goodbye', 'en', 'zh-Hans'))
+            .resolves.toBe('旧版接口成功');
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        const [url, init] = fetchMock.mock.calls[2]!;
+        expect(url).toBeInstanceOf(URL);
+        const legacyUrl = url as URL;
+        expect(legacyUrl.origin + legacyUrl.pathname).toBe(
+            'https://translate.googleapis.com/translate_a/single',
+        );
+        expect(legacyUrl.searchParams.get('client')).toBe('gtx');
+        expect(legacyUrl.searchParams.get('q')).toBe('hello & goodbye');
+        expect(init).toMatchObject({method: 'GET'});
+        expect(init?.headers).toBeUndefined();
+    });
+
+    it('所有接口失败时汇总原因并隐藏 CAPTCHA HTML', async () => {
+        fetchMock
+            .mockResolvedValueOnce(mockResponse('<!doctype html><html>captcha details</html>', {
+                ok: false,
+                status: 429,
+                statusText: 'Too Many Requests',
+            }))
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(mockResponse('not-json'));
+
+        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
+            .rejects.toThrow(
+                '谷歌翻译所有匿名接口均失败：主网页 RPC: HTTP 429 Too Many Requests，响应: 收到 HTML 页面（可能触发了 CAPTCHA）；备用网页 RPC: Failed to fetch；旧版 gtx 接口: 返回的不是 JSON',
+            );
+    });
+
+    it('按网页 RPC 服务端片段原样拼接译文，不额外插入空格', () => {
         expect(parseGoogleBatchResponse(createBatchResponse(['第一句话。', '第二句话！'])))
             .toBe('第一句话。第二句话！');
     });
 
+    it('按旧版 gtx 服务端片段原样拼接译文', () => {
+        expect(parseGoogleLegacyResponse(createLegacyResponse(['第一句话。', '第二句话！'])))
+            .toBe('第一句话。第二句话！');
+    });
+
     it('保留换行和普通文本中的 HTML 字符', async () => {
-        fetchMock.mockResolvedValue(mockResponse({
-            text: vi.fn().mockResolvedValue(createBatchResponse(['如果 x < 3 && y > 1\n', '下一行'])),
-        }));
+        fetchMock.mockResolvedValue(mockResponse(
+            createBatchResponse(['如果 x < 3 && y > 1\n', '下一行']),
+        ));
 
         await expect(translateGoogleText('if x < 3 && y > 1\nNext line', 'en', 'zh-Hans'))
             .resolves.toBe('如果 x < 3 && y > 1\n下一行');
     });
 
-    it('忽略防劫持前缀、长度行和无关记录', () => {
+    it('忽略网页 RPC 的防劫持前缀、长度行和无关记录', () => {
         const response = createBatchResponse(['测试成功']).replace('\n\n', '\n\n1234\nnot-json\n');
         expect(parseGoogleBatchResponse(response)).toBe('测试成功');
     });
 
-    it('保留服务端错误状态和响应正文', async () => {
-        fetchMock.mockResolvedValue(mockResponse({
-            ok: false,
-            status: 429,
-            statusText: 'Too Many Requests',
-            text: vi.fn().mockResolvedValue('rate limited'),
-        }));
-
-        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
-            .rejects.toThrow('翻译失败: 429 Too Many Requests body: rate limited');
+    it('拒绝无法识别的网页 RPC 与旧版响应结构', () => {
+        expect(() => parseGoogleBatchResponse(`)]}'\n\n[["unexpected", true]]`))
+            .toThrow('返回格式异常');
+        expect(() => parseGoogleLegacyResponse('{"unexpected":true}'))
+            .toThrow('返回格式异常');
     });
 
-    it('拒绝无法识别的响应结构', async () => {
-        fetchMock.mockResolvedValue(mockResponse({
-            text: vi.fn().mockResolvedValue(`)]}'\n\n[["unexpected", true]]`),
-        }));
-
-        await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
-            .rejects.toThrow('谷歌翻译返回格式异常');
-    });
-
-    it('把网络异常转换为可读错误', async () => {
+    it('三个接口均发生网络异常时返回完整故障转移信息', async () => {
         fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
 
         await expect(translateGoogleText('hello', 'en', 'zh-Hans'))
-            .rejects.toThrow('谷歌翻译网络请求失败: Failed to fetch');
+            .rejects.toThrow(
+                '谷歌翻译所有匿名接口均失败：主网页 RPC: Failed to fetch；备用网页 RPC: Failed to fetch；旧版 gtx 接口: Failed to fetch',
+            );
+        expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
     it('拒绝批量文本输入', async () => {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
     }),
     manifest: {
         permissions: ['storage', 'contextMenus', 'offscreen'],
+        host_permissions: [
+            'https://translate.google.com/*',
+            'https://translate.google.co.uk/*',
+            'https://translate.googleapis.com/*',
+        ],
     },
 
 });


### PR DESCRIPTION
## 问题

原有 Google `translate_a/single` 匿名接口在实际浏览器中可能超时或触发限流验证，导致谷歌翻译不可用。单独依赖一个未公开网页接口也会形成单点故障。

进一步用正式构建包验证时发现，生产版 manifest 没有声明 Google 域名的 `host_permissions`。翻译请求由 background service worker 发出，因此即使开发态接口实现正确，正式扩展仍会被浏览器的跨域权限层阻止。

## 修复

- 谷歌翻译继续保持为一个用户可选服务，但内部按顺序故障转移：
  1. `translate.google.com` 网页端 `batchexecute` RPC
  2. `translate.google.co.uk` 区域网页端 `batchexecute` RPC
  3. `translate.googleapis.com/translate_a/single?client=gtx` 旧版接口
- 为上述三个域名添加最小范围的生产 `host_permissions`，使 background 请求在正式扩展中可用。
- 三个接口均无需用户 API Key，仓库也不内嵌 Google 网页客户端 Key。
- 单个接口最多等待 8 秒，整个适配器共享 15 秒总预算；只有失败、超时或响应无法解析时才尝试下一个接口。
- 解析网页 RPC 与旧版响应的多段译文，保持换行、标点和普通 HTML 字符。
- 所有接口失败时汇总故障原因；解析失败会附带截断后的响应摘要，并隐藏 CAPTCHA HTML 正文。
- 仍限制为单文本输入，不改变 FluentRead 其他翻译服务的行为，也不会自动改用微软翻译。

## 参考调研

阅读蛙和简约翻译的新 Google2 实现使用 `translateHtml` 并内嵌网页客户端 Key；本实现不使用该固定 Key，而是按 FluentRead 的 WXT、Vue、TypeScript 架构独立实现无 Key 网页接口故障转移。

## 验证

- Google 适配器测试：13/13 通过，覆盖主接口、区域备用、旧版备用、响应解析、错误汇总、响应流失败、单接口超时、15 秒总预算和批量输入拒绝。
- 全部 Vitest：43/43 通过。
- `vue-tsc --noEmit`：通过。
- WXT production build：通过，并确认生成的 manifest 包含三个 Google 域名权限。
- `git diff --check`：通过。
- 启动 `pnpm dev` 编译当前开发版；最终验证使用同一源码生成的 production 扩展包，在全新可见 Edge 配置中运行，服务为谷歌翻译、auto → zh-Hans、双语、加粗、Control。
- 故障注入测试将主接口强制设为 HTTP 503；浏览器随后两次实际请求区域备用接口并成功生成译文，三次切换为 `1 → 0 → 1`，相邻段落始终为 0，页面 URL 不变，旧版接口调用次数为 0。
- 最终译文：`该域可在文档示例中使用，无需许可。避免在操作中使用。`

## 稳定性说明

这些都是 Google 网页端的未公开匿名接口，因此不能提供官方 SLA，也可能受地区网络、限流或协议变化影响。本 PR 通过多接口、顺序故障转移、最小域名权限和统一时间预算降低单点故障，但若 Google 同时调整所有匿名接口，仍需后续维护；需要官方稳定性保证的场景应使用 Google Cloud Translation API。
