### PR TITLE
feat: modernize popup and settings experience

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -1,6 +1,7 @@
 <template>
+  <section v-show="props.activeSection === 'settings-general'" id="settings-general" class="settings-section">
   <!-- 开关 -->
-  <el-row id="settings-general" class="margin-bottom margin-left-2em">
+  <el-row class="margin-bottom margin-left-2em">
     <el-col :span="20" class="lightblue rounded-corner">
       <span class="popup-text popup-vertical-left">插件状态</span>
     </el-col>
@@ -17,7 +18,7 @@
 
   <div v-show="config.on">
     <!--    翻译模式-->
-    <el-row id="settings-services" class="margin-bottom margin-left-2em">
+    <el-row class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <span class="popup-text popup-vertical-left">翻译模式</span>
       </el-col>
@@ -48,27 +49,27 @@
         </el-select>
       </el-col>
     </el-row>
+  </div>
+  </section>
+
+  <div v-if="!config.on && props.activeSection !== 'settings-general'" class="disabled-section">
+    <strong>插件当前已关闭</strong>
+    <p>请先在“通用设置”中启用插件，再调整该分类。</p>
+  </div>
+
+  <div v-show="config.on">
 
     <!-- 翻译服务 -->
-    <el-row class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="机器翻译：快速稳定，适合日常使用；AI翻译：更自然流畅，需要配置令牌" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">翻译服务<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <b>
-          <el-select v-model="config.service" aria-label="翻译服务" placeholder="请选择翻译服务">
-            <el-option class="select-left" v-for="item in compute.filteredServices" :key="item.value"
-              :label="item.label" :value="item.value" :disabled="item.disabled"
-              :class="{ 'select-divider': item.disabled }" />
-          </el-select>
-        </b>
-      </el-col>
-    </el-row>
+    <section v-show="props.activeSection === 'settings-services'" id="settings-services" class="settings-section">
+      <ServiceCatalog
+        :service="config.service"
+        :selected-model="config.model[config.service]"
+        :services="compute.filteredServices"
+        :model-options="compute.model"
+        :show-model="compute.showModel"
+        @update:service="config.service = $event"
+        @update:model="config.model[config.service] = $event"
+      />
 
     <!-- 免费翻译服务降级顺序 -->
     <el-row v-show="compute.showFreeTranslation" class="margin-bottom margin-left-2em">
@@ -98,11 +99,13 @@
         </el-select>
       </el-col>
     </el-row>
+    </section>
 
 
 
     <!-- 鼠标悬浮快捷键 -->
-    <el-row id="settings-shortcuts" class="margin-bottom margin-left-2em" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
+    <section v-show="props.activeSection === 'settings-shortcuts'" id="settings-shortcuts" class="settings-section">
+    <el-row class="margin-bottom margin-left-2em" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
       <el-col :span="14" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="按住指定快捷键并悬停在文本上进行翻译" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">
@@ -206,8 +209,14 @@
         </el-select>
       </el-col>
     </el-row>
+    </section>
 
     <!-- token -->
+    <section v-show="props.activeSection === 'settings-services'" class="settings-section service-connection-section">
+      <div class="subsection-heading">
+        <div><span>服务配置</span><strong>连接与请求参数</strong></div>
+        <p>这里只显示 {{ currentServiceLabel }} 实际需要的设置。</p>
+      </div>
     <el-row v-show="compute.showToken" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
@@ -411,18 +420,6 @@
       </el-col>
     </el-row>
 
-    <!--  模型 -->
-    <el-row v-show="compute.showModel" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <span class="popup-text popup-vertical-left">模型</span>
-      </el-col>
-      <el-col :span="12">
-        <el-select v-model="config.model[config.service]" placeholder="请选择模型">
-          <el-option class="select-left" v-for="item in compute.model" :key="item" :label="item" :value="item" />
-        </el-select>
-      </el-col>
-    </el-row>
-
     <el-row v-show="compute.showCustomModel" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
@@ -497,10 +494,10 @@
         </div>
       </el-col>
     </el-row>
+    </section>
 
     <!-- 高级选项-->
-    <el-collapse id="settings-advanced" class="margin-left-2em margin-bottom">
-      <el-collapse-item title="高级选项">
+    <section v-show="props.activeSection === 'settings-advanced'" id="settings-advanced" class="settings-section">
 
         <!-- 主题设置 -->
         <el-row class="margin-bottom margin-left-2em margin-top-2em">
@@ -694,8 +691,11 @@
           </el-col>
         </el-row>
 
+    </section>
+
+    <section v-show="props.activeSection === 'settings-data'" id="settings-data" class="settings-section data-section">
         <!-- 配置导入导出 -->
-        <el-row id="settings-data" class="margin-bottom margin-left-2em">
+        <el-row class="margin-bottom margin-left-2em">
           <el-col :span="24">
             <el-divider content-position="center">配置管理</el-divider>
           </el-col>
@@ -735,8 +735,7 @@
             </div>
           </el-col>
         </el-row>
-      </el-collapse-item>
-    </el-collapse>
+    </section>
     <!--    -->
   </div>
 
@@ -765,6 +764,7 @@
 // Main 处理配置信息
 import { computed, ref, watch, onUnmounted } from 'vue'
 import { models, options, services, servicesType, defaultOption } from "../entrypoints/utils/option";
+import { cleanServiceLabel } from '@/entrypoints/utils/serviceCatalog';
 import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 import { storage } from '@wxt-dev/storage';
 import { ChatDotRound, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
@@ -772,12 +772,19 @@ import { ElMessage, ElMessageBox, ElInputNumber } from 'element-plus'
 import browser from 'webextension-polyfill';
 import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
+const ServiceCatalog = defineAsyncComponent(() => import('@/components/ServiceCatalog.vue'));
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
 import {
   isCustomBodyMapping,
   isValidCustomBody,
 } from '@/entrypoints/utils/custom-body';
 import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
+
+const props = withDefaults(defineProps<{
+  activeSection?: string
+}>(), {
+  activeSection: 'settings-general',
+})
 
 // 初始化深色模式媒体查询
 const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -885,6 +892,11 @@ let compute = ref({
   // 15、是否显示 DeepSeek API 格式配置
   showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
   showDeepseekThinkingMode: computed(() => config.value.service === 'deepseek' && config.value.deepseekApiType !== 'responses'),
+})
+
+const currentServiceLabel = computed(() => {
+  const item = options.services.find((service: any) => service.value === config.value.service)
+  return item ? cleanServiceLabel(item.label) : config.value.service
 })
 
 // 监听主题变化
@@ -1467,6 +1479,72 @@ const validateConfig = (configData: any): boolean => {
 </script>
 
 <style scoped>
+
+.settings-section {
+  min-width: 0;
+}
+
+.disabled-section {
+  margin: 18px 12px 8px;
+  padding: 28px;
+  border: 1px dashed #d8dce6;
+  border-radius: 16px;
+  color: #677084;
+  background: #f8f9fb;
+  text-align: center;
+}
+
+.disabled-section strong {
+  color: #263044;
+  font-size: 15px;
+}
+
+.disabled-section p {
+  margin: 7px 0 0;
+  font-size: 11px;
+}
+
+.service-connection-section {
+  margin-top: 22px;
+  padding-top: 22px;
+  border-top: 1px solid #e8eaf0;
+}
+
+.subsection-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 0 12px 16px;
+}
+
+.subsection-heading > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.subsection-heading span {
+  color: #dc315f;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .08em;
+}
+
+.subsection-heading strong {
+  margin-top: 4px;
+  color: #172033;
+  font-size: 17px;
+}
+
+.subsection-heading p {
+  margin: 0;
+  color: #7c8495;
+  font-size: 10px;
+}
+
+.data-section {
+  min-height: 260px;
+}
 
 .select-left {
   text-align: left;

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -115,8 +115,8 @@
 
     <!-- 鼠标悬浮快捷键 -->
     <section v-show="props.activeSection === 'settings-shortcuts'" id="settings-shortcuts" class="settings-section">
-    <el-row class="margin-bottom margin-left-2em" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
-      <el-col :span="14" class="lightblue rounded-corner">
+    <el-row class="settings-control-row" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
+      <el-col :span="14" class="settings-control-label lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="按住指定快捷键并悬停在文本上进行翻译" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">
           鼠标悬浮快捷键
@@ -126,7 +126,7 @@
         </span>
         </el-tooltip>
       </el-col>
-      <el-col :span="10" class="flex-end">
+      <el-col :span="10" class="settings-control-field flex-end">
         <div class="hotkey-config">
           <el-select 
             v-model="config.hotkey" 
@@ -156,8 +156,8 @@
     </el-row>
 
     <!-- 全文翻译快捷键选择 -->
-    <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em" :class="{ 'custom-hotkey-row': config.floatingBallHotkey === 'custom' }">
-      <el-col :span="14" class="lightblue rounded-corner">
+    <el-row v-if="config.on" class="settings-control-row" :class="{ 'custom-hotkey-row': config.floatingBallHotkey === 'custom' }">
+      <el-col :span="14" class="settings-control-label lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="（测试版）设置快捷键以便快速切换全文翻译状态，无需鼠标点击悬浮球" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">
           <!-- <span class="new-feature-badge">新</span> -->
@@ -168,7 +168,7 @@
         </span>
         </el-tooltip>
       </el-col>
-      <el-col :span="10" class="flex-end">
+      <el-col :span="10" class="settings-control-field flex-end">
         <div class="hotkey-config">
           <el-select 
             v-model="config.floatingBallHotkey" 
@@ -199,8 +199,8 @@
 
 
     <!-- 划词翻译模式选择 -->
-    <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em">
-      <el-col :span="14" class="lightblue rounded-corner">
+    <el-row v-if="config.on" class="settings-control-row">
+      <el-col :span="14" class="settings-control-label lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="选中文本后显示红点，鼠标移到红点上查看翻译结果。可选择关闭、双语显示或只显示译文" placement="top-start" :show-after="500">
       <span class="popup-text popup-vertical-left">
         <!-- <span class="new-feature-badge">新</span> -->
@@ -211,7 +211,7 @@
       </span>
         </el-tooltip>
       </el-col>
-      <el-col :span="10" class="flex-end">
+      <el-col :span="10" class="settings-control-field flex-end">
         <el-select v-model="config.selectionTranslatorMode" aria-label="划词翻译模式" placeholder="选择模式" size="small" style="width: 100%">
           <el-option label="关闭" value="disabled" />
           <el-option label="双语显示" value="bilingual" />
@@ -226,11 +226,11 @@
     <section v-show="props.activeSection === 'settings-advanced'" id="settings-advanced" class="settings-section">
 
         <!-- 主题设置 -->
-        <el-row class="margin-bottom margin-left-2em margin-top-2em">
-          <el-col :span="12" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="12" class="settings-control-label lightblue rounded-corner">
             <span class="popup-text popup-vertical-left">主题设置</span>
           </el-col>
-          <el-col :span="12">
+          <el-col :span="12" class="settings-control-field">
             <el-select v-model="config.theme" placeholder="请选择主题模式">
               <el-option class="select-left" v-for="item in options.theme" :key="item.value" :label="item.label"
                          :value="item.value" />
@@ -239,8 +239,8 @@
         </el-row>
 
         <!-- 缓存开关 -->
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="20" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="20" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark" content="开启缓存可以提高翻译速度，减少重复请求，但可能导致翻译结果不是最新的" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">缓存翻译结果<el-icon class="icon-margin">
             <ChatDotRound />
@@ -248,14 +248,14 @@
             </el-tooltip>
           </el-col>
 
-          <el-col :span="4" class="flex-end">
-            <el-switch v-model="config.useCache" inline-prompt active-text="启用" inactive-text="禁用"/>
+          <el-col :span="4" class="settings-control-field flex-end">
+            <el-switch v-model="config.useCache" class="settings-toggle" aria-label="缓存翻译结果" />
           </el-col>
         </el-row>
 
         <!-- 悬浮球开关 -->
-      <el-row v-if="config.on" class="margin-bottom margin-left-2em margin-top-1em">
-        <el-col :span="20" class="lightblue rounded-corner">
+      <el-row v-if="config.on" class="settings-control-row">
+        <el-col :span="20" class="settings-control-label lightblue rounded-corner">
           <el-tooltip class="box-item" effect="dark" content="（测试版）控制是否显示屏幕边缘的即时翻译悬浮球，用于对整个网页进行翻译" placement="top-start" :show-after="500">
           <span class="popup-text popup-vertical-left">
             <!-- <span class="new-feature-badge">新</span> -->
@@ -267,15 +267,15 @@
           </el-tooltip>
         </el-col>
 
-        <el-col :span="4" class="flex-end">
-          <el-switch v-model="floatingBallEnabled" inline-prompt active-text="启用" inactive-text="禁用" />
+        <el-col :span="4" class="settings-control-field flex-end">
+          <el-switch v-model="floatingBallEnabled" class="settings-toggle" aria-label="全文翻译悬浮球" />
         </el-col>
       </el-row>
 
 
         <!-- 翻译进度面板 -->
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="20" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="20" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark"
                         content="翻译进度面板（默认关）：关闭后将不再显示右下角的全文翻译进度面板，适合移动端或希望更少打扰的用户。"
                         placement="top-start" :show-after="500">
@@ -284,14 +284,14 @@
             </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="4" class="flex-end">
-          <el-switch v-model="config.translationStatus" inline-prompt active-text="启动" inactive-text="禁用" />
+          <el-col :span="4" class="settings-control-field flex-end">
+          <el-switch v-model="config.translationStatus" class="settings-toggle" aria-label="翻译进度面板" />
           </el-col>
         </el-row>
 
         <!-- 禁用动画设置 -->
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="20" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="20" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark"
                         content="动画效果（默认开）：禁用后将关闭加载/悬浮等动画，以节省GPU资源和电量。适合低配置设备或希望节省资源的用户。"
                         placement="top-start" :show-after="500">
@@ -300,14 +300,14 @@
                 </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="4" class="flex-end">
-            <el-switch v-model="config.animations" inline-prompt active-text="启动" inactive-text="禁用" />
+          <el-col :span="4" class="settings-control-field flex-end">
+            <el-switch v-model="config.animations" class="settings-toggle" aria-label="动画效果" />
           </el-col>
         </el-row>
 
         <!-- 输入框翻译功能 -->
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="12" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="12" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark"
                         content="输入框翻译：在任何文本输入框中使用指定方式触发翻译当前输入的内容。"
                         placement="top-start" :show-after="500">
@@ -316,7 +316,7 @@
                 </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="12">
+          <el-col :span="12" class="settings-control-field">
             <el-select v-model="config.inputBoxTranslationTrigger" placeholder="请选择触发方式">
               <el-option class="select-left" v-for="item in options.inputBoxTranslationTrigger" :key="item.value" 
                          :label="item.label" :value="item.value" />
@@ -325,11 +325,11 @@
         </el-row>
 
         <!-- 输入框翻译目标语言 -->
-        <el-row v-if="config.inputBoxTranslationTrigger !== 'disabled'" class="margin-bottom margin-left-2em">
-          <el-col :span="12" class="lightblue rounded-corner">
+        <el-row v-if="config.inputBoxTranslationTrigger !== 'disabled'" class="settings-control-row">
+          <el-col :span="12" class="settings-control-label lightblue rounded-corner">
             <span class="popup-text popup-vertical-left">翻译目标语言</span>
           </el-col>
-          <el-col :span="12">
+          <el-col :span="12" class="settings-control-field">
             <el-select v-model="config.inputBoxTranslationTarget" placeholder="请选择目标语言">
               <el-option class="select-left" v-for="item in options.inputBoxTranslationTarget" :key="item.value" 
                          :label="item.label" :value="item.value" />
@@ -338,8 +338,8 @@
         </el-row>
 
         <!-- 翻译并发数 -->
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="12" class="lightblue rounded-corner">
+        <el-row class="settings-control-row">
+          <el-col :span="12" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark" content="控制同时进行的最大翻译任务数，数值越高翻译速度越快，但可能占用更多系统资源" placement="top-start"
                         :show-after="500">
           <span class="popup-text popup-vertical-left">翻译并发数<el-icon class="icon-margin">
@@ -347,7 +347,7 @@
             </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="12">
+          <el-col :span="12" class="settings-control-field">
             <el-input-number
                 v-model="config.maxConcurrentTranslations"
                 :min="1"
@@ -361,8 +361,8 @@
         </el-row>
 
         <!-- 使用代理转发 -->
-        <el-row v-show="compute.showProxy" class="margin-bottom margin-left-2em">
-          <el-col :span="8" class="lightblue rounded-corner">
+        <el-row v-show="compute.showProxy" class="settings-control-row">
+          <el-col :span="8" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark" content="使用代理可以解决网络无法访问的问题，如不熟悉代理设置请留空！" placement="top-start"
                         :show-after="500">
               <span class="popup-text popup-vertical-left">代理地址<el-icon class="icon-margin">
@@ -370,14 +370,14 @@
                 </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="16">
+          <el-col :span="16" class="settings-control-field">
             <el-input v-model="config.proxy[config.service]" placeholder="默认不使用代理" />
           </el-col>
         </el-row>
 
         <!-- 角色和模板 -->
-        <el-row v-show="compute.showAI" class="margin-bottom margin-left-2em">
-          <el-col :span="8" class="lightblue rounded-corner">
+        <el-row v-show="compute.showAI" class="settings-control-row">
+          <el-col :span="8" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark" content="以系统身份 system 发送的对话，常用于指定 AI 要扮演的角色"
               placement="top-start" :show-after="500">
               <span class="popup-text popup-vertical-left">system<el-icon class="icon-margin">
@@ -385,13 +385,13 @@
                 </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="16">
+          <el-col :span="16" class="settings-control-field">
             <el-input type="textarea" v-model="config.system_role[config.service]" maxlength="8192"
               placeholder="system message " />
           </el-col>
         </el-row>
-        <el-row v-show="compute.showAI" class="margin-bottom margin-left-2em">
-          <el-col :span="8" class="lightblue rounded-corner">
+        <el-row v-show="compute.showAI" class="settings-control-row">
+          <el-col :span="8" class="settings-control-label lightblue rounded-corner">
             <el-tooltip class="box-item" effect="dark"
               content="以用户身份 user 发送的对话，其中{{to}}表示目标语言，{{origin}}表示待翻译的文本内容，两者不可缺少。"
               placement="top-start" :show-after="500">
@@ -400,7 +400,7 @@
                 </el-icon></span>
             </el-tooltip>
           </el-col>
-          <el-col :span="16">
+          <el-col :span="16" class="settings-control-field">
             <el-input type="textarea" v-model="config.user_role[config.service]" maxlength="8192"
               placeholder="user message template" />
           </el-col>
@@ -1508,63 +1508,19 @@ const validateConfig = (configData: any): boolean => {
 
 /* 自定义快捷键行样式 */
 .custom-hotkey-row {
-  border-radius: 8px;
-  padding: 8px;
-  margin: 6px 0 !important;
-  background: linear-gradient(135deg, 
-    rgba(64, 158, 255, 0.03) 0%, 
-    rgba(64, 158, 255, 0.01) 50%, 
-    rgba(103, 194, 58, 0.02) 100%);
-  transition: all 0.3s ease;
-  position: relative;
-  border: 1px solid transparent;
-}
-
-.custom-hotkey-row::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, 
-    rgba(64, 158, 255, 0.2) 0%, 
-    rgba(64, 158, 255, 0.1) 30%,
-    rgba(103, 194, 58, 0.1) 70%,
-    rgba(103, 194, 58, 0.2) 100%);
-  border-radius: 8px;
-  z-index: -1;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.custom-hotkey-row::after {
-  content: '';
-  position: absolute;
-  top: -1px;
-  left: -1px;
-  right: -1px;
-  bottom: -1px;
-  background: linear-gradient(135deg, 
-    rgba(64, 158, 255, 0.3), 
-    rgba(103, 194, 58, 0.3));
-  border-radius: 8px;
-  z-index: -2;
-  opacity: 0.6;
+  border-color: #f2c2d0;
+  background: var(--brand-soft);
 }
 
 .custom-hotkey-row:hover {
-  background: linear-gradient(135deg, 
-    rgba(64, 158, 255, 0.05) 0%, 
-    rgba(64, 158, 255, 0.03) 50%, 
-    rgba(103, 194, 58, 0.04) 100%);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(64, 158, 255, 0.15);
+  border-color: #ef9ab1;
+  background: #fff;
+  transform: none;
+  box-shadow: 0 8px 22px rgba(239, 71, 118, .08);
 }
 
-.custom-hotkey-row:hover::before {
-  opacity: 0.1;
-}
+.custom-hotkey-row::before,
+.custom-hotkey-row::after { display: none; }
 
 /* 自定义标识徽章 */
 .custom-badge {

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -1,12 +1,12 @@
 <template>
   <!-- 开关 -->
-  <el-row class="margin-bottom margin-left-2em">
+  <el-row id="settings-general" class="margin-bottom margin-left-2em">
     <el-col :span="20" class="lightblue rounded-corner">
       <span class="popup-text popup-vertical-left">插件状态</span>
     </el-col>
 
     <el-col :span="4" class="flex-end">
-      <el-switch v-model="config.on" inline-prompt active-text="开" inactive-text="关" @change="handlePluginStateChange" />
+      <el-switch v-model="config.on" aria-label="插件状态" inline-prompt active-text="开" inactive-text="关" @change="handlePluginStateChange" />
     </el-col>
   </el-row>
 
@@ -17,12 +17,12 @@
 
   <div v-show="config.on">
     <!--    翻译模式-->
-    <el-row class="margin-bottom margin-left-2em">
+    <el-row id="settings-services" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <span class="popup-text popup-vertical-left">翻译模式</span>
       </el-col>
       <el-col :span="12">
-        <el-select v-model="config.display" placeholder="请选择翻译模式">
+        <el-select v-model="config.display" aria-label="翻译模式" placeholder="请选择翻译模式">
           <el-option class="select-left" v-for="item in options.display" :key="item.value" :label="item.label"
             :value="item.value" />
         </el-select>
@@ -40,7 +40,7 @@
         </el-tooltip>
       </el-col>
       <el-col :span="12">
-        <el-select v-model="config.style" placeholder="请选择译文显示样式">
+        <el-select v-model="config.style" aria-label="译文样式" placeholder="请选择译文显示样式">
           <el-option-group v-for="group in styleGroups" :key="group.value" :label="group.label">
             <el-option v-for="item in group.options" :key="item.value" :label="item.label" :value="item.value"
               :class="item.class" />
@@ -61,7 +61,7 @@
       </el-col>
       <el-col :span="12">
         <b>
-          <el-select v-model="config.service" placeholder="请选择翻译服务">
+          <el-select v-model="config.service" aria-label="翻译服务" placeholder="请选择翻译服务">
             <el-option class="select-left" v-for="item in compute.filteredServices" :key="item.value"
               :label="item.label" :value="item.value" :disabled="item.disabled"
               :class="{ 'select-divider': item.disabled }" />
@@ -92,7 +92,7 @@
         <span class="popup-text popup-vertical-left">目标语言</span>
       </el-col>
       <el-col :span="12">
-        <el-select v-model="config.to" placeholder="请选择目标语言">
+        <el-select v-model="config.to" aria-label="目标语言" placeholder="请选择目标语言">
           <el-option class="select-left" v-for="item in options.to" :key="item.value" :label="item.label"
             :value="item.value" />
         </el-select>
@@ -102,7 +102,7 @@
 
 
     <!-- 鼠标悬浮快捷键 -->
-    <el-row class="margin-bottom margin-left-2em" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
+    <el-row id="settings-shortcuts" class="margin-bottom margin-left-2em" :class="{ 'custom-hotkey-row': config.hotkey === 'custom' }">
       <el-col :span="14" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="按住指定快捷键并悬停在文本上进行翻译" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">
@@ -117,6 +117,7 @@
         <div class="hotkey-config">
           <el-select 
             v-model="config.hotkey" 
+            aria-label="鼠标悬浮快捷键"
             placeholder="请选择快捷键" 
             size="small" 
             style="width: 100%"
@@ -158,6 +159,7 @@
         <div class="hotkey-config">
           <el-select 
             v-model="config.floatingBallHotkey" 
+            aria-label="全文翻译快捷键"
             placeholder="选择快捷键" 
             size="small" 
             style="width: 100%"
@@ -197,7 +199,7 @@
         </el-tooltip>
       </el-col>
       <el-col :span="10" class="flex-end">
-        <el-select v-model="config.selectionTranslatorMode" placeholder="选择模式" size="small" style="width: 100%">
+        <el-select v-model="config.selectionTranslatorMode" aria-label="划词翻译模式" placeholder="选择模式" size="small" style="width: 100%">
           <el-option label="关闭" value="disabled" />
           <el-option label="双语显示" value="bilingual" />
           <el-option label="只显示译文" value="translation-only" />
@@ -497,7 +499,7 @@
     </el-row>
 
     <!-- 高级选项-->
-    <el-collapse class="margin-left-2em margin-bottom">
+    <el-collapse id="settings-advanced" class="margin-left-2em margin-bottom">
       <el-collapse-item title="高级选项">
 
         <!-- 主题设置 -->
@@ -693,7 +695,7 @@
         </el-row>
 
         <!-- 配置导入导出 -->
-        <el-row class="margin-bottom margin-left-2em">
+        <el-row id="settings-data" class="margin-bottom margin-left-2em">
           <el-col :span="24">
             <el-divider content-position="center">配置管理</el-divider>
           </el-col>

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -160,7 +160,6 @@
       <el-col :span="14" class="settings-control-label lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="（测试版）设置快捷键以便快速切换全文翻译状态，无需鼠标点击悬浮球" placement="top-start" :show-after="500">
         <span class="popup-text popup-vertical-left">
-          <!-- <span class="new-feature-badge">新</span> -->
           全文翻译快捷键
           <el-icon class="icon-margin">
             <ChatDotRound />
@@ -203,7 +202,6 @@
       <el-col :span="14" class="settings-control-label lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="选中文本后显示红点，鼠标移到红点上查看翻译结果。可选择关闭、双语显示或只显示译文" placement="top-start" :show-after="500">
       <span class="popup-text popup-vertical-left">
-        <!-- <span class="new-feature-badge">新</span> -->
         划词翻译
         <el-icon class="icon-margin">
           <ChatDotRound />
@@ -258,7 +256,6 @@
         <el-col :span="20" class="settings-control-label lightblue rounded-corner">
           <el-tooltip class="box-item" effect="dark" content="（测试版）控制是否显示屏幕边缘的即时翻译悬浮球，用于对整个网页进行翻译" placement="top-start" :show-after="500">
           <span class="popup-text popup-vertical-left">
-            <!-- <span class="new-feature-badge">新</span> -->
             全文翻译悬浮球
             <el-icon class="icon-margin">
               <ChatDotRound />
@@ -493,7 +490,7 @@ import { models, options, servicesType, defaultOption } from "../entrypoints/uti
 import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 import { storage } from '@wxt-dev/storage';
 import { ChatDotRound, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
-import { ElMessage, ElMessageBox, ElInputNumber } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import browser from 'webextension-polyfill';
 import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
@@ -505,6 +502,7 @@ import {
   isValidCustomBody,
 } from '@/entrypoints/utils/custom-body';
 import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
+import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
 
 const props = withDefaults(defineProps<{
   activeSection?: string
@@ -519,10 +517,7 @@ const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 function updateTheme(theme: string) {
   if (theme === 'auto') {
     // 自动模式下，直接使用系统主题
-    const isDark = darkModeMediaQuery.matches;
-    console.log('isDark', isDark);
-
-    document.documentElement.classList.toggle('dark', isDark);
+    document.documentElement.classList.toggle('dark', darkModeMediaQuery.matches);
   } else {
     // 手动模式下，使用选择的主题
     document.documentElement.classList.toggle('dark', theme === 'dark');
@@ -530,7 +525,7 @@ function updateTheme(theme: string) {
 }
 
 // 配置信息
-let config = ref(new Config());
+const config = ref(new Config());
 const selectedDeepLXPreset = ref('');
 
 const appendDeepLXPreset = (endpoint: string | undefined) => {
@@ -545,38 +540,29 @@ const appendDeepLXPreset = (endpoint: string | undefined) => {
   selectedDeepLXPreset.value = '';
 };
 
-// 从 storage 中获取本地配置
-storage.getItem('local:config').then((value: any) => {
-  if (typeof value === 'string' && value) {
-    const parsedConfig = JSON.parse(value);
-    Object.assign(config.value, normalizeConfig(parsedConfig));
-  }
-  // 初始应用主题
-  updateTheme(config.value.theme || 'auto');
-});
+function applyStoredConfig(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return;
 
-// 监听 storage 中 'local:config' 的变化
-// 当其他页面修改了配置时,会触发这个监听器
-// newValue 是新的配置值,oldValue 是旧的配置值
-storage.watch('local:config', (newValue: any, oldValue: any) => {
-  // 检查 newValue 是否为非空字符串
-  if (typeof newValue === 'string' && newValue) {
-    // 将新的配置值解析为对象,并合并到当前的 config.value 中
-    // 这样可以保持所有页面的配置同步
-    Object.assign(config.value, normalizeConfig(JSON.parse(newValue)));
+  try {
+    Object.assign(config.value, normalizeConfig(JSON.parse(value)));
+  } catch (error) {
+    console.warn('[FluentRead] 无法读取设置页配置', error);
   }
-});
+}
 
-// 监听菜单栏配置变化
-// 当配置发生改变时,将新的配置序列化为 JSON 字符串并保存到 storage 中
-// deep: true 表示深度监听对象内部属性的变化
-watch(config, (newValue: any, oldValue: any) => {
-  // TODO 监听配置变化，显示刷新提示
-  storage.setItem('local:config', JSON.stringify(newValue));
+void storage.getItem('local:config')
+  .then((value) => applyStoredConfig(value))
+  .catch((error) => console.warn('[FluentRead] 无法读取本地配置', error))
+  .finally(() => updateTheme(config.value.theme || 'auto'));
+
+storage.watch('local:config', (newValue) => applyStoredConfig(newValue));
+
+watch(config, (newValue) => {
+  void storage.setItem('local:config', JSON.stringify(newValue));
 }, { deep: true });
 
 // 计算属性
-let compute = ref({
+const compute = ref({
   // 1、是否是AI服务
   showAI: computed(() => servicesType.isAI(config.value.service)),
   // 2、是否是机器翻译
@@ -709,11 +695,6 @@ watch(() => config.value.selectionTranslatorMode, (newMode) => {
   });
 });
 
-// 监听开关变化
-const handleSwitchChange = () => {
-  showRefreshTip.value = true;
-};
-
 // 处理插件状态变化
 const handlePluginStateChange = (val: boolean) => {
   // 总开关只控制当前运行状态，不覆盖用户对悬浮球和划词翻译的偏好。
@@ -756,13 +737,6 @@ const toggleFloatingBall = (val: boolean) => {
 // 自定义快捷键相关
 const showCustomHotkeyDialog = ref(false);
 const showCustomMouseHotkeyDialog = ref(false);
-
-// 配置导入导出相关
-const showExportConfig = ref(false);
-const showImportConfig = ref(false);
-const exportedConfig = ref('');
-const importConfigText = ref('');
-const importLoading = ref(false);
 
 // 处理快捷键选择变化
 const handleHotkeyChange = (value: string) => {
@@ -865,7 +839,7 @@ const getCustomMouseHotkeyDisplayName = () => {
 };
 
 // 处理并发数量变化
-const handleConcurrentChange = (currentValue: number | undefined, oldValue: number | undefined) => {
+const handleConcurrentChange = (currentValue: number | undefined) => {
   // 验证并发数量的有效性
   if (currentValue === undefined || currentValue < 1 || currentValue > 100) {
     ElMessage({
@@ -878,26 +852,11 @@ const handleConcurrentChange = (currentValue: number | undefined, oldValue: numb
     return;
   }
   
-  // 显示设置已更新的提示
-  showRefreshTip.value = true;
-  
   ElMessage({
     message: `并发数量已更新为 ${currentValue}`,
     type: 'success',
     duration: 2000
   });
-};
-
-// 显示刷新提示
-const showRefreshTip = ref(false);
-
-// 刷新页面
-const refreshPage = async () => {
-  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  if (tabs[0]?.id) {
-    browser.tabs.reload(tabs[0].id);
-    showRefreshTip.value = false; // 刷新后隐藏提示
-  }
 };
 
 const showExportBox = ref(false);
@@ -920,59 +879,26 @@ const isValidAzureEndpoint = (endpoint: string) => {
 };
 
 const handleExport = async () => {
-  const configStr = await storage.getItem('local:config');
-  if (!configStr) {
+  try {
+    const configStr = await storage.getItem('local:config');
+    if (typeof configStr !== 'string' || !configStr.trim()) {
+      ElMessage({ message: '没有找到配置信息', type: 'warning' });
+      return;
+    }
+
+    exportData.value = JSON.stringify(
+      sanitizeConfigForExport(JSON.parse(configStr)),
+      null,
+      2,
+    );
+    showExportBox.value = !showExportBox.value;
+    showImportBox.value = false;
+  } catch (error) {
     ElMessage({
-      message: '没有找到配置信息',
-      type: 'warning',
+      message: `导出配置失败：${error instanceof Error ? error.message : '配置格式错误'}`,
+      type: 'error',
     });
-    return;
   }
-
-  const configToExport = JSON.parse(configStr as string);
-
-  // Create a deep copy to avoid modifying the actual config
-  const cleanedConfig = JSON.parse(JSON.stringify(configToExport));
-
-  // Clean system_role and user_role if they are default
-  if (cleanedConfig.system_role) {
-    for (const service in cleanedConfig.system_role) {
-      if (cleanedConfig.system_role[service] === defaultOption.system_role) {
-        delete cleanedConfig.system_role[service];
-      }
-    }
-    if (Object.keys(cleanedConfig.system_role).length === 0) {
-      delete cleanedConfig.system_role;
-    }
-  }
-
-  if (cleanedConfig.user_role) {
-    for (const service in cleanedConfig.user_role) {
-      if (cleanedConfig.user_role[service] === defaultOption.user_role) {
-        delete cleanedConfig.user_role[service];
-      }
-    }
-    if (Object.keys(cleanedConfig.user_role).length === 0) {
-      delete cleanedConfig.user_role;
-    }
-  }
-
-  // Clean empty customBody entries
-  if (cleanedConfig.customBody) {
-    for (const service in cleanedConfig.customBody) {
-      const value = cleanedConfig.customBody[service];
-      if (!value || !String(value).trim()) {
-        delete cleanedConfig.customBody[service];
-      }
-    }
-    if (Object.keys(cleanedConfig.customBody).length === 0) {
-      delete cleanedConfig.customBody;
-    }
-  }
-
-  exportData.value = JSON.stringify(cleanedConfig, null, 2);
-  showExportBox.value = !showExportBox.value;
-  showImportBox.value = false;
 };
 
 const handleImport = () => {
@@ -983,8 +909,7 @@ const handleImport = () => {
 const saveImport = async () => {
   try {
     const parsedConfig = JSON.parse(importData.value);
-    // Add validation here
-    if (!validateConfig(parsedConfig)) {
+    if (!isConfigImportValid(parsedConfig)) {
       ElMessage({
         message: '配置无效或格式不正确, 请检查!',
         type: 'error',
@@ -1004,178 +929,6 @@ const saveImport = async () => {
       message: '配置格式错误, 请检查!',
       type: 'error',
     });
-  }
-};
-
-
-// 切换导出配置显示
-const toggleExportConfig = async () => {
-  if (showExportConfig.value) {
-    // 如果已经显示，则隐藏
-    showExportConfig.value = false;
-    exportedConfig.value = '';
-  } else {
-    // 如果未显示，则显示并生成配置
-    try {
-      // 确保从storage获取最新的配置
-      const latestConfig = await storage.getItem('local:config');
-      let configToExport;
-
-      if (latestConfig && typeof latestConfig === 'string') {
-        // 使用storage中的最新配置
-        configToExport = JSON.parse(latestConfig);
-      } else {
-        // 如果storage中没有，使用当前config.value
-        configToExport = JSON.parse(JSON.stringify(config.value));
-      }
-
-      exportedConfig.value = JSON.stringify(configToExport, null, 2);
-      showExportConfig.value = true;
-
-      ElMessage({
-        message: '配置已生成，请复制保存',
-        type: 'success',
-        duration: 2000
-      });
-    } catch (error) {
-      ElMessage({
-         message: '导出配置失败：' + ((error as Error)?.message || '未知错误'),
-         type: 'error',
-         duration: 3000
-       });
-    }
-  }
-};
-
-// 复制导出的配置到剪贴板
-const copyExportedConfig = async () => {
-  try {
-    await navigator.clipboard.writeText(exportedConfig.value);
-    ElMessage({
-      message: '配置已复制到剪贴板',
-      type: 'success',
-      duration: 2000
-    });
-  } catch (error) {
-    ElMessage({
-      message: '复制失败，请手动复制',
-      type: 'warning',
-      duration: 2000
-    });
-  }
-};
-
-// 切换导入配置显示
-const toggleImportConfig = () => {
-  if (showImportConfig.value) {
-    // 如果已经显示，则隐藏并清空内容
-    showImportConfig.value = false;
-    importConfigText.value = '';
-  } else {
-    // 如果未显示，则显示
-    showImportConfig.value = true;
-    importConfigText.value = '';
-  }
-};
-
-// 取消导入
-const cancelImport = () => {
-  // 清空输入框并隐藏导入区域
-  importConfigText.value = '';
-  showImportConfig.value = false;
-  importLoading.value = false;
-};
-
-// 导入配置
-const importConfig = async () => {
-  if (!importConfigText.value.trim()) {
-    ElMessage({
-      message: '请输入配置内容',
-      type: 'warning',
-      duration: 2000
-    });
-    return;
-  }
-
-  importLoading.value = true;
-
-  try {
-    // 解析JSON配置
-    const importedConfig = JSON.parse(importConfigText.value);
-
-    // 验证配置格式
-    if (!validateConfig(importedConfig)) {
-      throw new Error('配置格式不正确');
-    }
-
-    // 确认导入
-    await ElMessageBox.confirm(
-      '导入配置将覆盖当前所有设置，确定要继续吗？',
-      '确认导入',
-      {
-        confirmButtonText: '确定导入',
-        cancelButtonText: '取消',
-        type: 'warning',
-      }
-    );
-
-    // 应用新配置
-    Object.assign(config.value, normalizeConfig(importedConfig));
-
-    // 保存到storage
-    await storage.setItem('local:config', JSON.stringify(config.value));
-
-    // 隐藏导入区域并清空输入
-    showImportConfig.value = false;
-    importConfigText.value = '';
-
-    ElMessage({
-      message: '配置导入成功',
-      type: 'success',
-      duration: 2000
-    });
-
-  } catch (error) {
-    if ((error as Error).message !== 'cancel') {
-      ElMessage({
-        message: '导入失败：' + ((error as Error).message || '配置格式错误'),
-        type: 'error',
-        duration: 3000
-      });
-    }
-  } finally {
-    importLoading.value = false;
-  }
-};
-
-// 验证配置格式
-const validateConfig = (configData: any): boolean => {
-  try {
-    // 检查是否是对象
-    if (typeof configData !== 'object' || configData === null) {
-      return false;
-    }
-
-    // 检查必要的配置字段
-    const requiredFields = ['on', 'service', 'display', 'from', 'to'];
-    for (const field of requiredFields) {
-      if (!(field in configData)) {
-        return false;
-      }
-    }
-
-    // 检查服务配置
-    if (typeof configData.service !== 'string') {
-      return false;
-    }
-
-    if ('customBody' in configData && !isCustomBodyMapping(configData.customBody)) {
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    return false;
   }
 };
 
@@ -1369,14 +1122,6 @@ const validateConfig = (configData: any): boolean => {
   margin-right: 1em;
 }
 
-.margin-top-2em {
-  margin-top: 1em;
-}
-
-.margin-top-1em {
-  margin-top: 0.5em;
-}
-
 /* 设置滚动条样式 */
 ::-webkit-scrollbar {
   width: 6px;
@@ -1391,57 +1136,6 @@ const validateConfig = (configData: any): boolean => {
 ::-webkit-scrollbar-track {
   background: #f5f5f5;
   border-radius: 3px;
-}
-
-.refresh-tip {
-  margin: 0 1em;
-}
-
-.refresh-button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0.5em 1em;
-  color: #fff;
-  background-color: #409eff;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.3s, color 0.3s;
-}
-
-.refresh-button:hover {
-  background-color: #66b1ff;
-  color: #fff;
-}
-
-.new-feature-badge {
-  display: inline-block;
-  font-size: 12px;
-  background-color: #f56c6c;
-  color: white;
-  padding: 1px 6px;
-  border-radius: 10px;
-  margin-right: 8px;
-  font-weight: bold;
-  animation: bounce 1s infinite alternate;
-}
-
-@keyframes pulse-glow {
-  0% {
-    box-shadow: 0 2px 8px rgba(64, 158, 255, 0.1);
-  }
-  100% {
-    box-shadow: 0 2px 12px rgba(64, 158, 255, 0.5);
-  }
-}
-
-@keyframes bounce {
-  0% {
-    transform: translateY(0);
-  }
-  100% {
-    transform: translateY(-3px);
-  }
 }
 
 /* 自定义快捷键相关样式 */

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -73,7 +73,7 @@
     <p>请先在“通用设置”中启用插件，再调整该分类。</p>
   </div>
 
-  <div v-show="config.on">
+  <div v-show="config.on" class="settings-main-sections">
 
     <!-- 翻译服务 -->
     <section v-show="props.activeSection === 'settings-services'" id="settings-services" class="settings-section">
@@ -85,7 +85,17 @@
         :show-model="compute.showModel"
         @update:service="config.service = $event"
         @update:model="config.model[config.service] = $event"
-      />
+      >
+        <template #configuration>
+          <ServiceConfiguration
+            :config="config"
+            :compute="compute"
+            :options="options"
+            :current-service-label="currentServiceLabel"
+            :is-valid-azure-endpoint="isValidAzureEndpoint"
+          />
+        </template>
+      </ServiceCatalog>
 
     <!-- 免费翻译服务降级顺序 -->
     <el-row v-show="compute.showFreeTranslation" class="margin-bottom margin-left-2em">
@@ -228,290 +238,6 @@
     </section>
 
     <!-- token -->
-    <section v-show="props.activeSection === 'settings-services'" class="settings-section service-connection-section">
-      <div class="subsection-heading">
-        <div><span>服务配置</span><strong>连接与请求参数</strong></div>
-        <p>这里只显示 {{ currentServiceLabel }} 实际需要的设置。</p>
-      </div>
-    <el-row v-show="compute.showToken" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content="API访问令牌仅保存在本地，用于访问翻译服务。获取方式请参考对应服务的官方文档；翻译服务为 ollama 时，token 可为任意值" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">访问令牌<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.token[config.service]" type="password" show-password placeholder="请输入API访问令牌" />
-      </el-col>
-    </el-row>
-
-    <!-- Azure OpenAI 端点配置 -->
-    <el-row v-show="compute.showAzureOpenaiEndpoint" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content="Azure OpenAI 服务端点地址，必须包含完整的部署信息。格式：https://your-resource-name.openai.azure.com/openai/deployments/your-deployment-name/chat/completions?api-version=2024-02-15-preview" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">Azure 端点<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input
-          v-model="config.azureOpenaiEndpoint"
-          placeholder="https://your-resource.openai.azure.com/openai/deployments/your-model/chat/completions?api-version=2024-02-15-preview"
-          :class="{ 'input-error': config.azureOpenaiEndpoint && !isValidAzureEndpoint(config.azureOpenaiEndpoint) }"
-        />
-        <div v-if="config.azureOpenaiEndpoint && !isValidAzureEndpoint(config.azureOpenaiEndpoint)" class="error-text">
-          端点地址格式不正确，请确保包含 openai.azure.com 域名和 /chat/completions 路径
-        </div>
-      </el-col>
-    </el-row>
-
-    <!-- DeepLX URL 配置-->
-    <el-row v-show="compute.showDeepLX" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content="DeepLX 是非官方免费服务。可填写多个地址，每行或逗号分隔；请求会按顺序故障转移。公共站点可能记录翻译文本，敏感内容建议使用本地或自建服务。"
-          placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">服务地址</span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input
-          v-model="config.deeplx"
-          type="textarea"
-          :rows="3"
-          resize="vertical"
-          placeholder="https://deeplx.1stg.me/translate&#10;http://localhost:1188/translate"
-        />
-        <div class="deeplx-hint">每行或逗号分隔，按顺序尝试；带 &#123;&#123;apiKey&#125;&#125; 的地址会使用上方访问令牌。</div>
-        <el-select
-          v-model="selectedDeepLXPreset"
-          class="deeplx-presets"
-          size="small"
-          clearable
-          placeholder="快速添加推荐站点"
-          @change="appendDeepLXPreset"
-        >
-          <el-option
-            v-for="preset in DEEPLX_ENDPOINT_PRESETS"
-            :key="preset.url"
-            :label="preset.label"
-            :value="preset.url"
-          />
-        </el-select>
-      </el-col>
-    </el-row>
-
-    <!-- 使用AkSk -->
-    <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="百度文心一言API密钥对，用于访问翻译服务" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">API Key<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.ak" placeholder="请输入Access Key" />
-      </el-col>
-    </el-row>
-    <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="百度文心一言API密钥对，用于访问翻译服务" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.sk" type="password" placeholder="请输入Secret Key" />
-      </el-col>
-    </el-row>
-
-    <!-- 有道翻译配置 -->
-    <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="有道智云翻译API应用ID，用于访问有道翻译服务。可在有道智云控制台获取" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">App Key<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.youdaoAppKey" placeholder="有道 AppKey" />
-      </el-col>
-    </el-row>
-    <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="有道智云翻译API应用密钥，用于访问有道翻译服务。可在有道智云控制台获取" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">App Secret<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.youdaoAppSecret" type="password" show-password placeholder="有道 AppSecret" />
-      </el-col>
-    </el-row>
-
-    <!-- 腾讯云机器翻译配置 -->
-    <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="腾讯云API访问密钥ID，用于访问腾讯云机器翻译服务。可在腾讯云控制台的访问管理中获取" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">Secret ID<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.tencentSecretId" placeholder="腾讯云 SecretId" />
-      </el-col>
-    </el-row>
-    <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="腾讯云API访问密钥，用于访问腾讯云机器翻译服务。可在腾讯云控制台的访问管理中获取" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.tencentSecretKey" type="password" show-password placeholder="腾讯云 SecretKey" />
-      </el-col>
-    </el-row>
-
-    <!--  Coze需显示 robot_id -->
-    <el-row v-show="compute.showRobotId" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="Coze机器人ID，可在Coze开发者文档中查看获取方式" placement="top-start"
-          :show-after="500">
-          <span class="popup-text popup-vertical-left">机器人ID<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.robot_id[config.service]" placeholder="请输入Coze机器人ID" />
-      </el-col>
-    </el-row>
-
-    <!-- 本地大模型配置 -->
-    <el-row v-show="compute.showCustom" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="目前仅支持OpenAI格式的请求接口，如http://localhost:3000/v1/chat/completions，其中 localhost:11434 可更换为任意值。
-                     ollama 配置请参考：https://fluent.thinkstu.com/guide/faq.html" placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">自定义接口<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.custom" placeholder="请输入自定义接口地址" />
-      </el-col>
-    </el-row>
-
-    <!-- NewAPI 配置 -->
-    <el-row v-show="compute.showNewAPI" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark" content="填写 New API 的访问地址，如：http://localhost:3000" placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">NewAPI接口<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.newApiUrl" placeholder="请输入您的New API接口地址" />
-      </el-col>
-    </el-row>
-
-    <el-row v-show="compute.showCustomModel" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          :content="config.service === 'doubao' ? '豆包的model为接入点，获取方式见官方文档：https://console.volcengine.com/ark/region:ark+cn-beijing/endpoint' : '注意：自定义模型名称需要与服务商提供的模型名称一致，否则无法使用！'"
-          placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">{{ config.service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon
-              class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.customModel[config.service]" placeholder="例如：gemma:7b" />
-      </el-col>
-    </el-row>
-
-    <!-- DeepSeek API 格式 -->
-    <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content="自动：使用 DeepSeek 官方 Chat Completion；仅当代理或网关明确支持 Responses API 时手动选择 Responses API"
-          placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式">
-          <el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label"
-                     :value="item.value" />
-        </el-select>
-      </el-col>
-    </el-row>
-
-    <!-- DeepSeek 思考模式 -->
-    <el-row v-show="compute.showDeepseekThinkingMode" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content="DeepSeek V4 Chat Completion 思考模式。翻译通常建议关闭以降低延迟；旧 deepseek-reasoner 配置会自动迁移为开启。"
-          placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">思考模式<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-select v-model="config.deepseekThinkingMode" placeholder="请选择思考模式">
-          <el-option class="select-left" v-for="item in options.deepseekThinkingMode" :key="item.value"
-                     :label="item.label" :value="item.value" />
-        </el-select>
-      </el-col>
-    </el-row>
-
-    <!-- 自定义请求体 -->
-    <el-row v-show="compute.showCustomBody" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip class="box-item" effect="dark"
-          content='以 JSON 对象形式追加到请求体（顶层合并，会覆盖同名默认字段）。'
-          placement="top-start" :show-after="500">
-          <span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin">
-              <ChatDotRound />
-            </el-icon></span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12">
-        <el-input v-model="config.customBody[config.service]"
-          :class="{ 'input-error': !isValidCustomBody(config.customBody[config.service]) }"
-          placeholder='例如：{"thinking": {"type": "disabled"}}' />
-        <div v-if="!isValidCustomBody(config.customBody[config.service])" class="error-text">
-          请输入合法的 JSON 对象，否则该配置将被忽略
-        </div>
-      </el-col>
-    </el-row>
-    </section>
-
     <!-- 高级选项-->
     <section v-show="props.activeSection === 'settings-advanced'" id="settings-advanced" class="settings-section">
 
@@ -788,7 +514,8 @@ import { ElMessage, ElMessageBox, ElInputNumber } from 'element-plus'
 import browser from 'webextension-polyfill';
 import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
-const ServiceCatalog = defineAsyncComponent(() => import('@/components/ServiceCatalog.vue'));
+import ServiceCatalog from '@/components/ServiceCatalog.vue';
+import ServiceConfiguration from '@/components/ServiceConfiguration.vue';
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
 import {
   isCustomBodyMapping,

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -1,13 +1,18 @@
 <template>
   <section v-show="props.activeSection === 'settings-general'" id="settings-general" class="settings-section">
   <!-- 开关 -->
-  <el-row class="margin-bottom margin-left-2em">
-    <el-col :span="20" class="lightblue rounded-corner">
-      <span class="popup-text popup-vertical-left">插件状态</span>
+  <el-row class="margin-bottom margin-left-2em settings-status-row">
+    <el-col :span="18" class="lightblue rounded-corner">
+      <div class="settings-status-copy">
+        <span class="settings-status-kicker">{{ config.on ? '正在工作' : '已暂停' }}</span>
+        <strong>插件状态</strong>
+        <small>{{ config.on ? '网页翻译与快捷功能均已启用' : '重新启用后即可继续翻译网页' }}</small>
+      </div>
     </el-col>
 
-    <el-col :span="4" class="flex-end">
-      <el-switch v-model="config.on" aria-label="插件状态" inline-prompt active-text="开" inactive-text="关" @change="handlePluginStateChange" />
+    <el-col :span="6" class="flex-end settings-status-control">
+      <span class="settings-status-badge" :class="{ active: config.on }"><i />{{ config.on ? '已启用' : '已暂停' }}</span>
+      <el-switch class="settings-switch" v-model="config.on" aria-label="插件状态" size="large" @change="handlePluginStateChange" />
     </el-col>
   </el-row>
 
@@ -49,6 +54,17 @@
         </el-select>
       </el-col>
     </el-row>
+
+    <section v-show="config.display === 1" class="style-preview-card" aria-live="polite">
+      <div class="style-preview-heading">
+        <div><span>实时预览</span><strong>译文样式</strong></div>
+      </div>
+      <div class="style-preview-example">
+        <p class="style-preview-source">Reading should feel calm and effortless.</p>
+        <p :key="config.style" class="style-preview-text" :class="currentStyleClass">阅读应该轻松、自然，不打断你的节奏。</p>
+      </div>
+      <small class="style-preview-note">切换上方选项即可预览译文在网页中的显示效果。</small>
+    </section>
   </div>
   </section>
 
@@ -925,6 +941,10 @@ const styleGroups = computed(() => {
   }));
 });
 
+const currentStyleClass = computed(() =>
+  options.styles.find(item => item.value === config.value.style && !item.disabled)?.class || 'fluent-display-default'
+);
+
 // 恢复默认模板
 const resetTemplate = () => {
   ElMessageBox.confirm(
@@ -993,44 +1013,24 @@ const handleSwitchChange = () => {
 
 // 处理插件状态变化
 const handlePluginStateChange = (val: boolean) => {
-  // 如果插件被关闭，确保悬浮球和划词翻译也被关闭
-  if (!val) {
-    // 处理悬浮球
-    if (!config.value.disableFloatingBall) {
-      config.value.disableFloatingBall = true;
-      // 向所有激活的标签页发送消息，关闭悬浮球
-      browser.tabs.query({}).then(tabs => {
-        tabs.forEach(tab => {
-          if (tab.id) {
-            browser.tabs.sendMessage(tab.id, { 
-              type: 'toggleFloatingBall',
-              isEnabled: false
-            }).catch(() => {
-              // 忽略发送失败的错误（可能是页面未加载内容脚本）
-            });
-          }
-        });
+  // 总开关只控制当前运行状态，不覆盖用户对悬浮球和划词翻译的偏好。
+  browser.tabs.query({}).then(tabs => {
+    tabs.forEach(tab => {
+      if (!tab.id) return;
+      browser.tabs.sendMessage(tab.id, {
+        type: 'toggleFloatingBall',
+        isEnabled: val && !config.value.disableFloatingBall,
+      }).catch(() => {
+        // 忽略发送失败的错误（可能是页面未加载内容脚本）
       });
-    }
-    
-    // 处理划词翻译
-    if (config.value.selectionTranslatorMode !== 'disabled') {
-      config.value.selectionTranslatorMode = 'disabled';
-      // 向所有激活的标签页发送消息，关闭划词翻译
-      browser.tabs.query({}).then(tabs => {
-        tabs.forEach(tab => {
-          if (tab.id) {
-            browser.tabs.sendMessage(tab.id, { 
-              type: 'updateSelectionTranslatorMode',
-              mode: 'disabled'
-            }).catch(() => {
-              // 忽略发送失败的错误（可能是页面未加载内容脚本）
-            });
-          }
-        });
+      browser.tabs.sendMessage(tab.id, {
+        type: 'updateSelectionTranslatorMode',
+        mode: val ? config.value.selectionTranslatorMode : 'disabled',
+      }).catch(() => {
+        // 忽略发送失败的错误（可能是页面未加载内容脚本）
       });
-    }
-  }
+    });
+  });
 };
 
 // 处理悬浮球开关变化
@@ -1483,6 +1483,80 @@ const validateConfig = (configData: any): boolean => {
 .settings-section {
   min-width: 0;
 }
+
+.settings-status-row {
+  align-items: center;
+  min-height: 92px !important;
+  padding: 18px 20px !important;
+  border: 1px solid #e4e8f0;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #fff8fa, #fff);
+}
+
+.settings-status-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-status-kicker {
+  color: #dc315f;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .08em;
+}
+
+.settings-status-copy strong { color: #172033; font-size: 16px; }
+.settings-status-copy small { color: #737c8f; font-size: 11px; }
+.settings-status-control { align-items: center; gap: 13px; }
+.settings-status-badge {
+  display: inline-flex; align-items: center; gap: 6px; padding: 7px 10px; border: 1px solid #e1e5ed;
+  border-radius: 999px; color: #7b8496; background: #f7f8fb; font-size: 10px; font-weight: 750;
+}
+.settings-status-badge i { width: 7px; height: 7px; border-radius: 50%; background: #aab2c0; }
+.settings-status-badge.active { border-color: #bfead9; color: #18835d; background: #effbf6; }
+.settings-status-badge.active i { background: #25aa78; box-shadow: 0 0 0 4px rgba(37, 170, 120, .12); }
+.settings-switch { --el-switch-on-color: #ef4776; --el-switch-off-color: #cfd5df; }
+
+.style-preview-card {
+  margin: 6px 12px 24px;
+  padding: 18px;
+  border: 1px solid #e3e7ef;
+  border-radius: 18px;
+  background: linear-gradient(145deg, #fbfcff, #fff8fa);
+}
+.style-preview-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.style-preview-heading div { display: flex; flex-direction: column; gap: 4px; }
+.style-preview-heading span { color: #dc315f; font-size: 10px; font-weight: 800; letter-spacing: .08em; }
+.style-preview-heading strong { color: #172033; font-size: 14px; }
+.style-preview-example { margin-top: 14px; padding: 14px 16px; border: 1px solid #e5e8ef; border-radius: 14px; background: #fff; }
+.style-preview-source { margin: 0 0 8px; color: #7f889b; font-size: 11px; }
+.style-preview-text { margin: 0; color: #172033; font-size: 15px; line-height: 1.7; transition: all 160ms ease; }
+.style-preview-note { display: block; margin-top: 10px; color: #8b93a4; font-size: 10px; }
+.style-preview-text.fluent-display-default { color: #273247; }
+.style-preview-text.fluent-display-bold { font-weight: 800; }
+.style-preview-text.fluent-display-italic { font-style: italic; }
+.style-preview-text.fluent-display-text-shadow { text-shadow: 1px 2px 3px rgba(23, 32, 51, .22); }
+.style-preview-text.fluent-display-solid-underline { text-decoration: underline; text-decoration-color: #4d8eea; text-decoration-thickness: 2px; text-underline-offset: 4px; }
+.style-preview-text.fluent-display-dot-underline { text-decoration: underline dotted #4d8eea 2px; text-underline-offset: 4px; }
+.style-preview-text.fluent-display-wavy { text-decoration: underline wavy #ef4776 2px; text-underline-offset: 4px; }
+.style-preview-text.fluent-display-card-mode { padding: 8px 10px; border-radius: 8px; background: #f4f6fb; }
+.style-preview-text.fluent-display-modern-card { padding: 8px 10px; border-radius: 8px; background: linear-gradient(90deg, #fff0f4, #f1f4ff); }
+.style-preview-text.fluent-display-paper { padding: 8px 10px; border: 1px solid #eadfca; background: #fffaf0; }
+.style-preview-text.fluent-display-learning-mode { padding: 2px 6px; background: #fff1a8; }
+.style-preview-text.fluent-display-marker { padding: 2px 6px; background: #d6f5b7; }
+.style-preview-text.fluent-display-highlight-fade { padding: 2px 6px; background: linear-gradient(90deg, #fff0b8, transparent); }
+.style-preview-text.fluent-display-lightyellow { padding: 4px 8px; background: #fff7db; }
+.style-preview-text.fluent-display-lightblue { padding: 4px 8px; background: #eaf4ff; }
+.style-preview-text.fluent-display-lightgray { padding: 4px 8px; background: #f1f3f5; }
+.style-preview-text.fluent-display-quote { padding-left: 10px; border-left: 3px solid #ef4776; }
+.style-preview-text.fluent-display-border { padding: 6px 9px; border: 1px solid #bfc8d8; border-radius: 6px; }
+.style-preview-text.fluent-display-focus { padding: 5px 8px; border-radius: 6px; box-shadow: 0 0 0 3px rgba(239, 71, 118, .12); }
+.style-preview-text.fluent-display-clean { border-bottom: 2px solid #ef4776; }
+.style-preview-text.fluent-display-tech { padding: 5px 8px; border-radius: 5px; color: #245070; background: #edf6fb; font-family: ui-monospace, SFMono-Regular, monospace; }
+.style-preview-text.fluent-display-elegant { font-family: Georgia, "Songti SC", serif; letter-spacing: .04em; }
+.style-preview-text.fluent-display-dimmed { opacity: .62; }
+.style-preview-text.fluent-display-transparent-mode { opacity: .82; }
 
 .disabled-section {
   margin: 18px 12px 8px;

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -23,7 +23,7 @@
 
   <div v-show="config.on">
     <!--    翻译模式-->
-    <el-row class="margin-bottom margin-left-2em">
+    <el-row class="margin-bottom margin-left-2em settings-preference-row">
       <el-col :span="12" class="lightblue rounded-corner">
         <span class="popup-text popup-vertical-left">翻译模式</span>
       </el-col>
@@ -36,7 +36,7 @@
     </el-row>
 
     <!-- 默认目标语言 -->
-    <el-row class="margin-bottom margin-left-2em">
+    <el-row class="margin-bottom margin-left-2em settings-preference-row">
       <el-col :span="12" class="lightblue rounded-corner">
         <span class="popup-text popup-vertical-left">默认目标语言</span>
       </el-col>
@@ -49,7 +49,7 @@
     </el-row>
 
     <!--    译文样式选择器-->
-    <el-row v-show="config.display === 1" class="margin-bottom margin-left-2em">
+    <el-row v-show="config.display === 1" class="margin-bottom margin-left-2em settings-preference-row">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="选择双语模式下译文的显示样式，提供多种美观的效果" placement="top-start"
           :show-after="500">

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -35,6 +35,19 @@
       </el-col>
     </el-row>
 
+    <!-- 默认目标语言 -->
+    <el-row class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <span class="popup-text popup-vertical-left">默认目标语言</span>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.to" aria-label="默认目标语言" placeholder="请选择目标语言">
+          <el-option class="select-left" v-for="item in options.to" :key="item.value" :label="item.label"
+            :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
     <!--    译文样式选择器-->
     <el-row v-show="config.display === 1" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
@@ -91,40 +104,11 @@
             :config="config"
             :compute="compute"
             :options="options"
-            :current-service-label="currentServiceLabel"
             :is-valid-azure-endpoint="isValidAzureEndpoint"
           />
         </template>
       </ServiceCatalog>
 
-    <!-- 免费翻译服务降级顺序 -->
-    <el-row v-show="compute.showFreeTranslation" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <el-tooltip
-          class="box-item"
-          effect="dark"
-          content="按微软翻译、DeepLX、谷歌翻译的顺序尝试。只有失败后才会继续下一个服务；DeepLX 地址使用 DeepLX 服务中的配置。"
-          placement="top-start"
-          :show-after="500"
-        >
-          <span class="popup-text popup-vertical-left">免费翻译降级顺序</span>
-        </el-tooltip>
-      </el-col>
-      <el-col :span="12" class="free-translation-order">微软翻译 → DeepLX → 谷歌翻译</el-col>
-    </el-row>
-
-    <!-- 目标语言 -->
-    <el-row class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner">
-        <span class="popup-text popup-vertical-left">目标语言</span>
-      </el-col>
-      <el-col :span="12">
-        <el-select v-model="config.to" aria-label="目标语言" placeholder="请选择目标语言">
-          <el-option class="select-left" v-for="item in options.to" :key="item.value" :label="item.label"
-            :value="item.value" />
-        </el-select>
-      </el-col>
-    </el-row>
     </section>
 
 
@@ -505,8 +489,7 @@
 
 // Main 处理配置信息
 import { computed, ref, watch, onUnmounted } from 'vue'
-import { models, options, services, servicesType, defaultOption } from "../entrypoints/utils/option";
-import { cleanServiceLabel } from '@/entrypoints/utils/serviceCatalog';
+import { models, options, servicesType, defaultOption } from "../entrypoints/utils/option";
 import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 import { storage } from '@wxt-dev/storage';
 import { ChatDotRound, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
@@ -618,8 +601,6 @@ let compute = ref({
   showCustom: computed(() => servicesType.isCustom(config.value.service)),
   // 9、是否显示 DeepLX URL 配置
   showDeepLX: computed(() => config.value.service === 'deeplx'),
-  // 9.1、是否显示免费翻译服务的降级说明
-  showFreeTranslation: computed(() => config.value.service === services.freeTranslation),
   // 10、是否自定义模型
   showCustomModel: computed(() => servicesType.isAI(config.value.service) && config.value.model[config.value.service] === "自定义模型"),
   // 11、判断是否为"双语模式"，控制一些翻译服务的显示
@@ -635,11 +616,6 @@ let compute = ref({
   // 15、是否显示 DeepSeek API 格式配置
   showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
   showDeepseekThinkingMode: computed(() => config.value.service === 'deepseek' && config.value.deepseekApiType !== 'responses'),
-})
-
-const currentServiceLabel = computed(() => {
-  const item = options.services.find((service: any) => service.value === config.value.service)
-  return item ? cleanServiceLabel(item.label) : config.value.service
 })
 
 // 监听主题变化

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -91,18 +91,20 @@
     <!-- 翻译服务 -->
     <section v-show="props.activeSection === 'settings-services'" id="settings-services" class="settings-section">
       <ServiceCatalog
-        :service="config.service"
-        :selected-model="config.model[config.service]"
-        :services="compute.filteredServices"
-        :model-options="compute.model"
-        :show-model="compute.showModel"
-        @update:service="config.service = $event"
-        @update:model="config.model[config.service] = $event"
+        :service="selectedConfigurationService"
+        :default-service="config.service"
+        :selected-model="config.model[selectedConfigurationService]"
+        :services="configurationCompute.filteredServices"
+        :model-options="configurationCompute.model"
+        :show-model="configurationCompute.showModel"
+        @update:service="setConfigurationService"
+        @update:model="config.model[selectedConfigurationService] = $event"
       >
         <template #configuration>
           <ServiceConfiguration
             :config="config"
-            :compute="compute"
+            :service="selectedConfigurationService"
+            :compute="configurationCompute"
             :options="options"
             :is-valid-azure-endpoint="isValidAzureEndpoint"
           />
@@ -561,48 +563,58 @@ watch(config, (newValue) => {
   void storage.setItem('local:config', JSON.stringify(newValue));
 }, { deep: true });
 
-// 计算属性
-const compute = ref({
-  // 1、是否是AI服务
-  showAI: computed(() => servicesType.isAI(config.value.service)),
-  // 2、是否是机器翻译
-  showMachine: computed(() => servicesType.isMachine(config.value.service)),
-  // 3、是否显示代理
-  showProxy: computed(() => servicesType.isUseProxy(config.value.service)),
-  // 4、是否显示模型
-  showModel: computed(() => servicesType.isUseModel(config.value.service)),
-  // 4.5、是否支持自定义请求体
-  showCustomBody: computed(() => servicesType.isUseCustomBody(config.value.service)),
-  // 5、是否显示token
-  showToken: computed(() => servicesType.isUseToken(config.value.service)),
-  // 6、是否显示 AkSk
-  showAkSk: computed(() => servicesType.isUseAkSk(config.value.service)),
-  // 6.5、是否显示有道翻译配置
-  showYoudao: computed(() => servicesType.isYoudao(config.value.service)),
-  // 6.6、是否显示腾讯云机器翻译配置
-  showTencent: computed(() => servicesType.isTencent(config.value.service)),
-  // 7、获取模型列表
-  model: computed(() => models.get(config.value.service) || []),
-  // 8、是否需要自定义接口
-  showCustom: computed(() => servicesType.isCustom(config.value.service)),
-  // 9、是否显示 DeepLX URL 配置
-  showDeepLX: computed(() => config.value.service === 'deeplx'),
-  // 10、是否自定义模型
-  showCustomModel: computed(() => servicesType.isAI(config.value.service) && config.value.model[config.value.service] === "自定义模型"),
-  // 11、判断是否为"双语模式"，控制一些翻译服务的显示
-  filteredServices: computed(() => options.services.filter((service: any) =>
-    !([service.google].includes(service.value) && config.value.display !== 1))
+// 设置页左侧列表只切换正在编辑的服务，不改变网页翻译实际使用的默认服务。
+const configurationService = ref<string | null>(null);
+const selectedConfigurationService = computed(
+  () => configurationService.value ?? config.value.service,
+);
+
+const setConfigurationService = (value: string) => {
+  configurationService.value = value;
+};
+
+type ServiceSource = { value: string };
+
+const actualService = computed(() => config.value.service);
+const filteredServices = computed(() =>
+  options.services.filter((item: any) =>
+    !([item.google].includes(item.value) && config.value.display !== 1),
   ),
-  // 12、判断是否为 coze
-  showRobotId: computed(() => servicesType.isCoze(config.value.service)),
-  // 13、是否显示New API配置
-  showNewAPI: computed(() => servicesType.isNewApi(config.value.service)),
-  // 14、是否显示Azure OpenAI端点配置
-  showAzureOpenaiEndpoint: computed(() => servicesType.isAzureOpenai(config.value.service)),
-  // 15、是否显示 DeepSeek API 格式配置
-  showDeepseekApiType: computed(() => config.value.service === 'deepseek'),
-  showDeepseekThinkingMode: computed(() => config.value.service === 'deepseek' && config.value.deepseekApiType !== 'responses'),
-})
+);
+
+// 两个页面都需要相同的服务能力判断，但数据源不同：实际翻译使用默认服务，
+// 设置页右侧表单使用正在配置的服务。统一从这里生成，避免两套逻辑继续漂移。
+const createServiceCompute = (serviceSource: ServiceSource) => ({
+  showAI: computed(() => servicesType.isAI(serviceSource.value)),
+  showMachine: computed(() => servicesType.isMachine(serviceSource.value)),
+  showProxy: computed(() => servicesType.isUseProxy(serviceSource.value)),
+  showModel: computed(() => servicesType.isUseModel(serviceSource.value)),
+  showCustomBody: computed(() => servicesType.isUseCustomBody(serviceSource.value)),
+  showToken: computed(() => servicesType.isUseToken(serviceSource.value)),
+  showAkSk: computed(() => servicesType.isUseAkSk(serviceSource.value)),
+  showYoudao: computed(() => servicesType.isYoudao(serviceSource.value)),
+  showTencent: computed(() => servicesType.isTencent(serviceSource.value)),
+  model: computed(() => models.get(serviceSource.value) || []),
+  showCustom: computed(() => servicesType.isCustom(serviceSource.value)),
+  showDeepLX: computed(() => serviceSource.value === 'deeplx'),
+  showCustomModel: computed(
+    () =>
+      servicesType.isAI(serviceSource.value) &&
+      config.value.model[serviceSource.value] === '自定义模型',
+  ),
+  filteredServices,
+  showRobotId: computed(() => servicesType.isCoze(serviceSource.value)),
+  showNewAPI: computed(() => servicesType.isNewApi(serviceSource.value)),
+  showAzureOpenaiEndpoint: computed(() => servicesType.isAzureOpenai(serviceSource.value)),
+  showDeepseekApiType: computed(() => serviceSource.value === 'deepseek'),
+  showDeepseekThinkingMode: computed(
+    () => serviceSource.value === 'deepseek' && config.value.deepseekApiType !== 'responses',
+  ),
+});
+
+const compute = ref(createServiceCompute(actualService));
+// config.service 仍表示实际默认翻译服务；这里仅用于设置页正在编辑的服务。
+const configurationCompute = ref(createServiceCompute(selectedConfigurationService));
 
 // 监听主题变化
 watch(() => config.value.theme, (newTheme) => {

--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport to="body">
+  <div class="fr-selection-translator-root">
     <div ref="selection-ref" class="fr-selection-translator-wrapper">
       <!-- 小红点指示器 -->
       <div v-if="showIndicator" 
@@ -89,7 +89,7 @@
       </div>
       <span>复制译文成功!</span>
     </div>
-  </teleport>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -168,7 +168,7 @@ watch(modelQuery, () => {
 
 <style scoped>
 .service-catalog { display: flex; height: clamp(520px, calc(100vh - 270px), 760px); min-height: 520px; margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; flex-direction: column; }
-.catalog-layout { display: grid; grid-template-columns: 300px minmax(0, 1fr); min-height: 0; flex: 1; overflow: hidden; }
+.catalog-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 0; flex: 1; overflow: hidden; }
 .service-rail { min-height: 0; padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; overflow-y: auto; }
 .catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
 .catalog-search span, .model-search span { color: #8991a2; font-size: 16px; }
@@ -185,7 +185,11 @@ watch(modelQuery, () => {
 .service-copy strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
 .service-copy small { margin-top: 3px; color: #9097a7; font-size: 10px; }
 .current-dot { width: 7px; height: 7px; border-radius: 50%; background: #ef4776; box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
-.service-detail { display: flex; min-width: 0; min-height: 0; padding: 24px; flex-direction: column; overflow: hidden; }
+.service-detail { display: flex; min-width: 0; min-height: 0; margin: 14px; padding: 22px; border: 1px solid #e4e7ef; border-radius: 16px; background: #fff; flex-direction: column; overflow: hidden; }
+.service-detail > .detail-hero,
+.service-detail > .model-section,
+.service-detail > .no-model-panel,
+.service-detail > .service-configuration-slot { width: min(100%, 1080px); }
 .detail-hero { display: flex; align-items: flex-start; gap: 13px; padding-bottom: 20px; border-bottom: 1px solid #eceef3; }
 .detail-hero > div:last-child { min-width: 0; }
 .detail-title-row { display: flex; align-items: center; gap: 9px; }
@@ -236,7 +240,7 @@ watch(modelQuery, () => {
   .service-detail { padding: 18px; }
   .model-heading { align-items: stretch; flex-direction: column; }
   .model-search { width: 100%; }
-  .service-detail { min-height: 520px; overflow: visible; }
+  .service-detail { min-height: 520px; margin: 0; padding: 18px; border: 0; border-radius: 0; overflow: visible; }
   .model-grid { max-height: 400px; }
   .service-configuration-slot { max-height: none; overflow: visible; }
 }

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -64,29 +64,50 @@
               <span>模型列表</span>
               <strong>{{ selectedModel || '尚未选择模型' }}</strong>
             </div>
-            <label v-if="modelOptions.length > 6" class="model-search">
+            <label v-if="modelOptions.length > commonModelCount" class="model-search">
               <span aria-hidden="true">⌕</span>
               <input v-model.trim="modelQuery" type="search" placeholder="搜索模型" />
             </label>
           </div>
 
-          <div v-if="filteredModels.length" class="model-grid" role="listbox" aria-label="可用模型">
+          <div v-if="displayedModels.length" class="model-list">
+            <div class="model-list-heading">
+              <strong>{{ modelQuery ? '搜索结果' : moreModelsOpen ? '全部模型' : '常用模型' }}</strong>
+              <span>{{ displayedModels.length }}</span>
+            </div>
+            <div id="model-options" class="model-grid" role="listbox" aria-label="可用模型">
+              <button
+                v-for="model in displayedModels"
+                :key="model"
+                type="button"
+                class="model-item"
+                :class="{ active: selectedModel === model, custom: model === customModelLabel }"
+                role="option"
+                :aria-selected="selectedModel === model"
+                @click="$emit('update:model', model)"
+              >
+                <span class="model-icon">{{ model === customModelLabel ? '+' : 'M' }}</span>
+                <span>
+                  <strong>{{ model }}</strong>
+                  <small>{{ model === customModelLabel ? '填写服务商支持的模型标识' : '使用此模型进行翻译' }}</small>
+                </span>
+                <span v-if="selectedModel === model" class="checkmark">✓</span>
+              </button>
+            </div>
+
             <button
-              v-for="model in filteredModels"
-              :key="model"
+              v-if="!modelQuery && moreModels.length"
               type="button"
-              class="model-item"
-              :class="{ active: selectedModel === model, custom: model === customModelLabel }"
-              role="option"
-              :aria-selected="selectedModel === model"
-              @click="$emit('update:model', model)"
+              class="more-models-toggle"
+              :aria-expanded="moreModelsOpen"
+              aria-controls="model-options"
+              @click="moreModelsOpen = !moreModelsOpen"
             >
-              <span class="model-icon">{{ model === customModelLabel ? '+' : 'M' }}</span>
               <span>
-                <strong>{{ model }}</strong>
-                <small>{{ model === customModelLabel ? '填写服务商支持的模型标识' : '使用此模型进行翻译' }}</small>
+                <strong>更多模型</strong>
+                <small>{{ moreModels.length }} 个较少使用的模型</small>
               </span>
-              <span v-if="selectedModel === model" class="checkmark">✓</span>
+              <b>{{ moreModelsOpen ? '收起' : '展开' }} <i aria-hidden="true">⌄</i></b>
             </button>
           </div>
           <p v-else class="catalog-empty">没有匹配的模型</p>
@@ -113,6 +134,7 @@ import {
   buildServiceGroups,
   filterModels,
   filterServiceGroups,
+  splitModelOptions,
   type ServiceOption,
 } from '@/entrypoints/utils/serviceCatalog'
 
@@ -131,11 +153,18 @@ defineEmits<{
 
 const serviceQuery = ref('')
 const modelQuery = ref('')
+const moreModelsOpen = ref(false)
+const commonModelCount = 4
 const customModelLabel = customModelString
 
 const groups = computed(() => buildServiceGroups(props.services))
 const filteredGroups = computed(() => filterServiceGroups(groups.value, serviceQuery.value))
 const filteredModels = computed(() => filterModels(props.modelOptions, modelQuery.value))
+const modelGroups = computed(() => splitModelOptions(props.modelOptions, props.selectedModel, commonModelCount))
+const moreModels = computed(() => modelGroups.value.more)
+const displayedModels = computed(() => modelQuery.value
+  ? filteredModels.value
+  : moreModelsOpen.value ? [...modelGroups.value.common, ...moreModels.value] : modelGroups.value.common)
 const selectedService = computed(() => groups.value.flatMap((group) => group.items).find((item) => item.value === props.service))
 
 const descriptions: Record<string, string> = {
@@ -161,6 +190,11 @@ const serviceDescription = computed(() =>
 
 watch(() => props.service, () => {
   modelQuery.value = ''
+  moreModelsOpen.value = false
+})
+
+watch(modelQuery, () => {
+  moreModelsOpen.value = false
 })
 
 const markMap: Record<string, string> = {
@@ -225,7 +259,10 @@ function serviceTone(value: string) {
 .model-heading span { color: #81899a; font-size: 9px; font-weight: 750; }
 .model-heading strong { overflow: hidden; margin-top: 3px; color: #172033; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .model-search { width: 168px; height: 34px; }
-.model-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; max-height: 330px; padding: 2px; overflow: auto; }
+.model-list-heading { display: flex; align-items: center; justify-content: space-between; margin: 0 2px 8px; color: #81899a; }
+.model-list-heading strong { font-size: 9px; }
+.model-list-heading span { font-size: 9px; }
+.model-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
 .model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
 .model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
 .model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }
@@ -235,6 +272,14 @@ function serviceTone(value: string) {
 .model-item strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .model-item small { overflow: hidden; margin-top: 2px; color: #9299a8; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .checkmark { color: #da315f; font-size: 12px; font-weight: 900; }
+.more-models-toggle { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; margin-top: 10px; padding: 11px 12px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fafbfc; text-align: left; cursor: pointer; }
+.more-models-toggle:hover { border-color: #f0a9bc; background: #fff8fa; }
+.more-models-toggle > span { display: flex; flex-direction: column; }
+.more-models-toggle strong { font-size: 10px; }
+.more-models-toggle small { margin-top: 2px; color: #9299a8; font-size: 8px; }
+.more-models-toggle b { color: #c72a56; font-size: 9px; font-weight: 750; white-space: nowrap; }
+.more-models-toggle i { display: inline-block; margin-left: 3px; font-style: normal; transition: transform 150ms ease; }
+.more-models-toggle[aria-expanded="true"] i { transform: rotate(180deg); }
 .no-model-panel { display: flex; align-items: center; gap: 12px; margin-top: 20px; padding: 18px; border: 1px solid #d9eee5; border-radius: 14px; background: #f2faf6; }
 .no-model-panel > span { display: grid; place-items: center; width: 32px; height: 32px; border-radius: 50%; color: #fff; background: #28aa79; font-size: 14px; }
 .no-model-panel strong { color: #185d46; font-size: 12px; }

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -1,5 +1,10 @@
 <template>
-  <section class="service-catalog" aria-label="配置翻译服务与模型">
+  <section
+    class="service-catalog"
+    aria-label="翻译服务配置"
+    :data-default-service="defaultService"
+    :data-editing-service="service"
+  >
     <div class="catalog-layout">
       <aside class="service-rail" aria-label="翻译服务列表">
         <label class="catalog-search">
@@ -18,6 +23,7 @@
               :key="item.value"
               type="button"
               class="service-item"
+              :data-service-value="item.value"
               :class="{ active: service === item.value }"
               :aria-pressed="service === item.value"
               @click="$emit('update:service', item.value)"
@@ -27,7 +33,11 @@
                 <strong>{{ item.label }}</strong>
                 <small>{{ group.id === 'machine' ? '机器翻译' : 'AI 翻译' }}</small>
               </span>
-              <span v-if="service === item.value" class="current-dot" title="默认服务"></span>
+              <span
+                v-if="defaultService === item.value"
+                class="current-dot"
+                title="默认翻译服务"
+              ></span>
             </button>
           </section>
         </div>
@@ -40,7 +50,7 @@
           <div>
             <div class="detail-title-row">
               <h4>{{ selectedService?.label || '尚未配置服务' }}</h4>
-              <span class="active-badge">默认配置</span>
+              <span class="active-badge">{{ service === defaultService ? '当前默认' : '正在配置' }}</span>
             </div>
           </div>
         </div>
@@ -128,6 +138,7 @@ import {
 
 const props = defineProps<{
   service: string
+  defaultService: string
   selectedModel?: string
   services: ServiceOption[]
   modelOptions: string[]

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -1,17 +1,5 @@
 <template>
-  <section class="service-catalog" aria-labelledby="service-catalog-title">
-    <header class="catalog-header">
-      <div>
-        <span class="catalog-eyebrow">翻译引擎</span>
-        <h3 id="service-catalog-title">选择服务与模型</h3>
-        <p>这里配置默认翻译服务和模型，之后网页翻译会按此设置执行。</p>
-      </div>
-      <div class="current-summary" aria-live="polite">
-        <span>默认服务</span>
-        <strong>{{ selectedService?.label || '未选择' }}</strong>
-      </div>
-    </header>
-
+  <section class="service-catalog" aria-label="配置翻译服务与模型">
     <div class="catalog-layout">
       <aside class="service-rail" aria-label="翻译服务列表">
         <label class="catalog-search">
@@ -51,10 +39,9 @@
           <span class="service-mark large" :data-tone="serviceTone(service)">{{ serviceMark(service, selectedService?.label) }}</span>
           <div>
             <div class="detail-title-row">
-              <h4>{{ selectedService?.label || '请选择翻译服务' }}</h4>
+              <h4>{{ selectedService?.label || '尚未配置服务' }}</h4>
               <span class="active-badge">默认配置</span>
             </div>
-            <p>{{ serviceDescription }}</p>
           </div>
         </div>
 
@@ -115,17 +102,13 @@
 
         <div v-else class="no-model-panel">
           <span aria-hidden="true">✓</span>
-          <div><strong>该服务不使用模型</strong><p>微软翻译等机器翻译服务会直接使用自身引擎，无需配置模型。</p></div>
+          <div><strong>此服务无需模型配置</strong><p>机器翻译直接使用自身引擎。</p></div>
         </div>
 
         <div class="service-configuration-slot" aria-label="当前服务配置">
           <slot name="configuration" />
         </div>
 
-        <div class="detail-footer">
-          <span>下方配置该默认服务需要的连接参数</span>
-          <b>{{ showModel ? `${modelOptions.length} 个模型候选` : '无需模型配置' }}</b>
-        </div>
       </section>
     </div>
   </section>
@@ -171,27 +154,6 @@ const displayedModels = computed(() => modelQuery.value
   : moreModelsOpen.value ? [...modelGroups.value.common, ...moreModels.value] : modelGroups.value.common)
 const selectedService = computed(() => groups.value.flatMap((group) => group.items).find((item) => item.value === props.service))
 
-const descriptions: Record<string, string> = {
-  microsoft: '稳定快速的机器翻译服务，适合日常网页双语阅读。',
-  google: 'Google 翻译服务，仅在双语对照模式下提供。',
-  deepL: '偏重自然表达的机器翻译服务，需要配置访问令牌。',
-  deeplx: '可连接自托管 DeepLX 地址的翻译服务。',
-  chromeTranslator: '调用 Chrome 内置翻译能力，无需选择模型。',
-  openai: '使用 OpenAI 兼容模型进行更自然的上下文翻译。',
-  azureOpenai: '通过 Azure OpenAI 部署端点调用模型。',
-  deepseek: '使用 DeepSeek 模型，可继续配置 API 格式与思考模式。',
-  gemini: '使用 Google Gemini 模型完成上下文翻译。',
-  custom: '连接兼容 OpenAI 请求格式的自定义或本地模型服务。',
-  newapi: '连接 New API 聚合服务，并选择对应的模型标识。',
-}
-
-const serviceDescription = computed(() =>
-  descriptions[props.service]
-    || (groups.value.find((group) => group.items.some((item) => item.value === props.service))?.id === 'machine'
-      ? '快速稳定的机器翻译服务，无需额外选择模型。'
-      : '使用大语言模型进行上下文翻译，需要按服务要求配置连接参数。'),
-)
-
 watch(() => props.service, () => {
   modelQuery.value = ''
   moreModelsOpen.value = false
@@ -221,13 +183,6 @@ function serviceTone(value: string) {
 
 <style scoped>
 .service-catalog { display: flex; height: clamp(520px, calc(100vh - 270px), 760px); min-height: 520px; margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; flex-direction: column; }
-.catalog-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 22px 24px; border-bottom: 1px solid #eceef3; }
-.catalog-eyebrow { color: #dc315f; font-size: 12px; font-weight: 800; letter-spacing: .1em; }
-.catalog-header h3 { margin: 6px 0 6px; color: #172033; font-size: 24px; letter-spacing: -.02em; }
-.catalog-header p { margin: 0; color: #737c8f; font-size: 14px; }
-.current-summary { display: flex; min-width: 140px; padding: 10px 13px; flex-direction: column; border: 1px solid #f4cad6; border-radius: 12px; background: #fff4f7; }
-.current-summary span { color: #9a6171; font-size: 10px; font-weight: 750; }
-.current-summary strong { margin-top: 3px; color: #c92b57; font-size: 14px; }
 .catalog-layout { display: grid; grid-template-columns: 300px minmax(0, 1fr); min-height: 0; flex: 1; overflow: hidden; }
 .service-rail { min-height: 0; padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; overflow-y: auto; }
 .catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
@@ -290,16 +245,12 @@ function serviceTone(value: string) {
 .no-model-panel strong { color: #185d46; font-size: 15px; }
 .no-model-panel p { margin: 4px 0 0; color: #628074; font-size: 12px; }
 .service-configuration-slot { min-height: 0; margin-top: 20px; padding-top: 20px; border-top: 1px solid #eceef3; overflow-y: auto; flex: 1; }
-.detail-footer { display: flex; justify-content: space-between; gap: 12px; margin-top: auto; padding-top: 18px; color: #8b92a2; font-size: 9px; }
-.detail-footer b { color: #5f687a; }
 .catalog-empty { margin: 20px 8px; color: #9299a8; font-size: 10px; text-align: center; }
 @media (max-width: 900px) {
   .catalog-layout { grid-template-columns: 220px minmax(0, 1fr); }
   .model-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 700px) {
-  .catalog-header { align-items: flex-start; padding: 18px; flex-direction: column; }
-  .current-summary { width: 100%; }
   .service-catalog { height: auto; min-height: 0; }
   .catalog-layout { display: block; flex: 0 0 auto; }
   .service-rail { border-right: 0; border-bottom: 1px solid #eceef3; }

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -1,0 +1,259 @@
+<template>
+  <section class="service-catalog" aria-labelledby="service-catalog-title">
+    <header class="catalog-header">
+      <div>
+        <span class="catalog-eyebrow">翻译引擎</span>
+        <h3 id="service-catalog-title">选择服务与模型</h3>
+        <p>先选择翻译服务，再为支持模型的 AI 服务指定模型。</p>
+      </div>
+      <div class="current-summary" aria-live="polite">
+        <span>当前使用</span>
+        <strong>{{ selectedService?.label || '未选择' }}</strong>
+      </div>
+    </header>
+
+    <div class="catalog-layout">
+      <aside class="service-rail" aria-label="翻译服务列表">
+        <label class="catalog-search">
+          <span aria-hidden="true">⌕</span>
+          <input v-model.trim="serviceQuery" type="search" placeholder="搜索翻译服务" />
+        </label>
+
+        <div v-if="filteredGroups.length" class="service-groups">
+          <section v-for="group in filteredGroups" :key="group.id" class="service-group">
+            <div class="group-heading">
+              <strong>{{ group.label }}</strong>
+              <span>{{ group.items.length }}</span>
+            </div>
+            <button
+              v-for="item in group.items"
+              :key="item.value"
+              type="button"
+              class="service-item"
+              :class="{ active: service === item.value }"
+              :aria-pressed="service === item.value"
+              @click="$emit('update:service', item.value)"
+            >
+              <span class="service-mark" :data-tone="serviceTone(item.value)">{{ serviceMark(item.value, item.label) }}</span>
+              <span class="service-copy">
+                <strong>{{ item.label }}</strong>
+                <small>{{ group.id === 'machine' ? '机器翻译' : 'AI 翻译' }}</small>
+              </span>
+              <span v-if="service === item.value" class="current-dot" title="当前使用"></span>
+            </button>
+          </section>
+        </div>
+        <p v-else class="catalog-empty">没有匹配的翻译服务</p>
+      </aside>
+
+      <section class="service-detail" aria-label="当前翻译服务详情">
+        <div class="detail-hero">
+          <span class="service-mark large" :data-tone="serviceTone(service)">{{ serviceMark(service, selectedService?.label) }}</span>
+          <div>
+            <div class="detail-title-row">
+              <h4>{{ selectedService?.label || '请选择翻译服务' }}</h4>
+              <span class="active-badge">当前默认</span>
+            </div>
+            <p>{{ serviceDescription }}</p>
+          </div>
+        </div>
+
+        <div v-if="showModel" class="model-section">
+          <div class="model-heading">
+            <div>
+              <span>模型列表</span>
+              <strong>{{ selectedModel || '尚未选择模型' }}</strong>
+            </div>
+            <label v-if="modelOptions.length > 6" class="model-search">
+              <span aria-hidden="true">⌕</span>
+              <input v-model.trim="modelQuery" type="search" placeholder="搜索模型" />
+            </label>
+          </div>
+
+          <div v-if="filteredModels.length" class="model-grid" role="listbox" aria-label="可用模型">
+            <button
+              v-for="model in filteredModels"
+              :key="model"
+              type="button"
+              class="model-item"
+              :class="{ active: selectedModel === model, custom: model === customModelLabel }"
+              role="option"
+              :aria-selected="selectedModel === model"
+              @click="$emit('update:model', model)"
+            >
+              <span class="model-icon">{{ model === customModelLabel ? '+' : 'M' }}</span>
+              <span>
+                <strong>{{ model }}</strong>
+                <small>{{ model === customModelLabel ? '填写服务商支持的模型标识' : '使用此模型进行翻译' }}</small>
+              </span>
+              <span v-if="selectedModel === model" class="checkmark">✓</span>
+            </button>
+          </div>
+          <p v-else class="catalog-empty">没有匹配的模型</p>
+        </div>
+
+        <div v-else class="no-model-panel">
+          <span aria-hidden="true">✓</span>
+          <div><strong>无需选择模型</strong><p>该服务会使用自身的翻译引擎，保存后即可使用。</p></div>
+        </div>
+
+        <div class="detail-footer">
+          <span>下方仅显示当前服务需要的连接参数</span>
+          <b>{{ showModel ? `${modelOptions.length} 个模型候选` : '即选即用' }}</b>
+        </div>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { customModelString } from '@/entrypoints/utils/option'
+import {
+  buildServiceGroups,
+  filterModels,
+  filterServiceGroups,
+  type ServiceOption,
+} from '@/entrypoints/utils/serviceCatalog'
+
+const props = defineProps<{
+  service: string
+  selectedModel?: string
+  services: ServiceOption[]
+  modelOptions: string[]
+  showModel: boolean
+}>()
+
+defineEmits<{
+  'update:service': [value: string]
+  'update:model': [value: string]
+}>()
+
+const serviceQuery = ref('')
+const modelQuery = ref('')
+const customModelLabel = customModelString
+
+const groups = computed(() => buildServiceGroups(props.services))
+const filteredGroups = computed(() => filterServiceGroups(groups.value, serviceQuery.value))
+const filteredModels = computed(() => filterModels(props.modelOptions, modelQuery.value))
+const selectedService = computed(() => groups.value.flatMap((group) => group.items).find((item) => item.value === props.service))
+
+const descriptions: Record<string, string> = {
+  microsoft: '稳定快速的机器翻译服务，适合日常网页双语阅读。',
+  google: 'Google 翻译服务，仅在双语对照模式下提供。',
+  deepL: '偏重自然表达的机器翻译服务，需要配置访问令牌。',
+  deeplx: '可连接自托管 DeepLX 地址的翻译服务。',
+  chromeTranslator: '调用 Chrome 内置翻译能力，无需选择模型。',
+  openai: '使用 OpenAI 兼容模型进行更自然的上下文翻译。',
+  azureOpenai: '通过 Azure OpenAI 部署端点调用模型。',
+  deepseek: '使用 DeepSeek 模型，可继续配置 API 格式与思考模式。',
+  gemini: '使用 Google Gemini 模型完成上下文翻译。',
+  custom: '连接兼容 OpenAI 请求格式的自定义或本地模型服务。',
+  newapi: '连接 New API 聚合服务，并选择对应的模型标识。',
+}
+
+const serviceDescription = computed(() =>
+  descriptions[props.service]
+    || (groups.value.find((group) => group.items.some((item) => item.value === props.service))?.id === 'machine'
+      ? '快速稳定的机器翻译服务，无需额外选择模型。'
+      : '使用大语言模型进行上下文翻译，需要按服务要求配置连接参数。'),
+)
+
+watch(() => props.service, () => {
+  modelQuery.value = ''
+})
+
+const markMap: Record<string, string> = {
+  microsoft: 'M', google: 'G', deepL: 'D', deeplx: 'DX', chromeTranslator: 'C',
+  openai: 'OA', azureOpenai: 'AZ', deepseek: 'DS', gemini: 'G', claude: 'C',
+  siliconCloud: 'S', huanYuan: '混', tongyi: '通', doubao: '豆', custom: '自', newapi: 'N',
+}
+
+function serviceMark(value: string, label = '') {
+  return markMap[value] || label.trim().slice(0, 1).toLocaleUpperCase() || '译'
+}
+
+function serviceTone(value: string) {
+  if (['openai', 'azureOpenai', 'custom', 'newapi'].includes(value)) return 'violet'
+  if (['deepseek', 'deepL', 'deeplx', 'microsoft'].includes(value)) return 'blue'
+  if (['gemini', 'google', 'chromeTranslator'].includes(value)) return 'green'
+  return 'rose'
+}
+</script>
+
+<style scoped>
+.service-catalog { margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; }
+.catalog-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 22px 24px; border-bottom: 1px solid #eceef3; }
+.catalog-eyebrow { color: #dc315f; font-size: 11px; font-weight: 800; letter-spacing: .1em; }
+.catalog-header h3 { margin: 5px 0 5px; color: #172033; font-size: 20px; letter-spacing: -.02em; }
+.catalog-header p { margin: 0; color: #737c8f; font-size: 12px; }
+.current-summary { display: flex; min-width: 140px; padding: 10px 13px; flex-direction: column; border: 1px solid #f4cad6; border-radius: 12px; background: #fff4f7; }
+.current-summary span { color: #9a6171; font-size: 9px; font-weight: 750; }
+.current-summary strong { margin-top: 3px; color: #c92b57; font-size: 12px; }
+.catalog-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 520px; }
+.service-rail { padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; }
+.catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
+.catalog-search span, .model-search span { color: #8991a2; font-size: 16px; }
+.catalog-search input, .model-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: #172033; background: transparent; font-size: 11px; }
+.service-groups { display: grid; gap: 18px; margin-top: 17px; }
+.group-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 8px 7px; color: #858d9e; }
+.group-heading strong { font-size: 10px; letter-spacing: .05em; }
+.group-heading span { font-size: 9px; }
+.service-group { min-width: 0; }
+.service-item { display: grid; grid-template-columns: 34px minmax(0, 1fr) 8px; align-items: center; gap: 9px; width: 100%; padding: 9px; border: 1px solid transparent; border-radius: 12px; color: #172033; background: transparent; text-align: left; cursor: pointer; transition: 150ms ease; }
+.service-item:hover { border-color: #e2e5ec; background: #fff; transform: translateX(2px); }
+.service-item.active { border-color: #f3c4d1; background: #fff0f4; box-shadow: 0 7px 18px rgba(214, 50, 96, .08); }
+.service-copy { display: flex; min-width: 0; flex-direction: column; }
+.service-copy strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.service-copy small { margin-top: 2px; color: #9097a7; font-size: 9px; }
+.service-mark { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; color: #d42f60; background: #ffeaf0; font-size: 10px; font-weight: 850; }
+.service-mark[data-tone="blue"] { color: #2c65bb; background: #eaf2ff; }
+.service-mark[data-tone="green"] { color: #18835d; background: #e9f8f1; }
+.service-mark[data-tone="violet"] { color: #694bc2; background: #f0ebff; }
+.service-mark.large { width: 48px; height: 48px; border-radius: 14px; font-size: 13px; }
+.current-dot { width: 7px; height: 7px; border-radius: 50%; background: #ef4776; box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
+.service-detail { display: flex; min-width: 0; padding: 24px; flex-direction: column; }
+.detail-hero { display: flex; align-items: flex-start; gap: 13px; padding-bottom: 20px; border-bottom: 1px solid #eceef3; }
+.detail-hero > div:last-child { min-width: 0; }
+.detail-title-row { display: flex; align-items: center; gap: 9px; }
+.detail-title-row h4 { margin: 1px 0 5px; color: #172033; font-size: 17px; }
+.active-badge { padding: 3px 7px; border-radius: 999px; color: #bd2853; background: #ffe9ef; font-size: 8px; font-weight: 800; }
+.detail-hero p { margin: 0; color: #737c8f; font-size: 11px; line-height: 1.6; }
+.model-section { margin-top: 20px; }
+.model-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 15px; margin-bottom: 12px; }
+.model-heading > div { display: flex; min-width: 0; flex-direction: column; }
+.model-heading span { color: #81899a; font-size: 9px; font-weight: 750; }
+.model-heading strong { overflow: hidden; margin-top: 3px; color: #172033; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.model-search { width: 168px; height: 34px; }
+.model-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; max-height: 330px; padding: 2px; overflow: auto; }
+.model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
+.model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
+.model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }
+.model-icon { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px; color: #6b7487; background: #f1f3f7; font-size: 10px; font-weight: 850; }
+.model-item.custom .model-icon { color: #c72a56; background: #ffe9ef; font-size: 16px; }
+.model-item > span:nth-child(2) { display: flex; min-width: 0; flex-direction: column; }
+.model-item strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.model-item small { overflow: hidden; margin-top: 2px; color: #9299a8; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.checkmark { color: #da315f; font-size: 12px; font-weight: 900; }
+.no-model-panel { display: flex; align-items: center; gap: 12px; margin-top: 20px; padding: 18px; border: 1px solid #d9eee5; border-radius: 14px; background: #f2faf6; }
+.no-model-panel > span { display: grid; place-items: center; width: 32px; height: 32px; border-radius: 50%; color: #fff; background: #28aa79; font-size: 14px; }
+.no-model-panel strong { color: #185d46; font-size: 12px; }
+.no-model-panel p { margin: 3px 0 0; color: #628074; font-size: 10px; }
+.detail-footer { display: flex; justify-content: space-between; gap: 12px; margin-top: auto; padding-top: 18px; color: #8b92a2; font-size: 9px; }
+.detail-footer b { color: #5f687a; }
+.catalog-empty { margin: 20px 8px; color: #9299a8; font-size: 10px; text-align: center; }
+@media (max-width: 900px) {
+  .catalog-layout { grid-template-columns: 220px minmax(0, 1fr); }
+  .model-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 700px) {
+  .catalog-header { align-items: flex-start; padding: 18px; flex-direction: column; }
+  .current-summary { width: 100%; }
+  .catalog-layout { display: block; }
+  .service-rail { border-right: 0; border-bottom: 1px solid #eceef3; }
+  .service-groups { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .service-detail { padding: 18px; }
+  .model-heading { align-items: stretch; flex-direction: column; }
+  .model-search { width: 100%; }
+}
+</style>

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -4,10 +4,10 @@
       <div>
         <span class="catalog-eyebrow">翻译引擎</span>
         <h3 id="service-catalog-title">选择服务与模型</h3>
-        <p>先选择翻译服务，再为支持模型的 AI 服务指定模型。</p>
+        <p>这里配置默认翻译服务和模型，之后网页翻译会按此设置执行。</p>
       </div>
       <div class="current-summary" aria-live="polite">
-        <span>当前使用</span>
+        <span>默认服务</span>
         <strong>{{ selectedService?.label || '未选择' }}</strong>
       </div>
     </header>
@@ -23,7 +23,7 @@
           <section v-for="group in filteredGroups" :key="group.id" class="service-group">
             <div class="group-heading">
               <strong>{{ group.label }}</strong>
-              <span>{{ group.items.length }}</span>
+              <span>{{ group.items.length }} 项</span>
             </div>
             <button
               v-for="item in group.items"
@@ -39,7 +39,7 @@
                 <strong>{{ item.label }}</strong>
                 <small>{{ group.id === 'machine' ? '机器翻译' : 'AI 翻译' }}</small>
               </span>
-              <span v-if="service === item.value" class="current-dot" title="当前使用"></span>
+              <span v-if="service === item.value" class="current-dot" title="默认服务"></span>
             </button>
           </section>
         </div>
@@ -52,7 +52,7 @@
           <div>
             <div class="detail-title-row">
               <h4>{{ selectedService?.label || '请选择翻译服务' }}</h4>
-              <span class="active-badge">当前默认</span>
+              <span class="active-badge">默认配置</span>
             </div>
             <p>{{ serviceDescription }}</p>
           </div>
@@ -115,12 +115,16 @@
 
         <div v-else class="no-model-panel">
           <span aria-hidden="true">✓</span>
-          <div><strong>无需选择模型</strong><p>该服务会使用自身的翻译引擎，保存后即可使用。</p></div>
+          <div><strong>该服务不使用模型</strong><p>微软翻译等机器翻译服务会直接使用自身引擎，无需配置模型。</p></div>
+        </div>
+
+        <div class="service-configuration-slot" aria-label="当前服务配置">
+          <slot name="configuration" />
         </div>
 
         <div class="detail-footer">
-          <span>下方仅显示当前服务需要的连接参数</span>
-          <b>{{ showModel ? `${modelOptions.length} 个模型候选` : '即选即用' }}</b>
+          <span>下方配置该默认服务需要的连接参数</span>
+          <b>{{ showModel ? `${modelOptions.length} 个模型候选` : '无需模型配置' }}</b>
         </div>
       </section>
     </div>
@@ -218,29 +222,29 @@ function serviceTone(value: string) {
 <style scoped>
 .service-catalog { display: flex; height: clamp(520px, calc(100vh - 270px), 760px); min-height: 520px; margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; flex-direction: column; }
 .catalog-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 22px 24px; border-bottom: 1px solid #eceef3; }
-.catalog-eyebrow { color: #dc315f; font-size: 11px; font-weight: 800; letter-spacing: .1em; }
-.catalog-header h3 { margin: 5px 0 5px; color: #172033; font-size: 20px; letter-spacing: -.02em; }
-.catalog-header p { margin: 0; color: #737c8f; font-size: 12px; }
+.catalog-eyebrow { color: #dc315f; font-size: 12px; font-weight: 800; letter-spacing: .1em; }
+.catalog-header h3 { margin: 6px 0 6px; color: #172033; font-size: 24px; letter-spacing: -.02em; }
+.catalog-header p { margin: 0; color: #737c8f; font-size: 14px; }
 .current-summary { display: flex; min-width: 140px; padding: 10px 13px; flex-direction: column; border: 1px solid #f4cad6; border-radius: 12px; background: #fff4f7; }
-.current-summary span { color: #9a6171; font-size: 9px; font-weight: 750; }
-.current-summary strong { margin-top: 3px; color: #c92b57; font-size: 12px; }
-.catalog-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 0; flex: 1; }
+.current-summary span { color: #9a6171; font-size: 10px; font-weight: 750; }
+.current-summary strong { margin-top: 3px; color: #c92b57; font-size: 14px; }
+.catalog-layout { display: grid; grid-template-columns: 300px minmax(0, 1fr); min-height: 0; flex: 1; overflow: hidden; }
 .service-rail { min-height: 0; padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; overflow-y: auto; }
 .catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
 .catalog-search span, .model-search span { color: #8991a2; font-size: 16px; }
-.catalog-search input, .model-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: #172033; background: transparent; font-size: 11px; }
+.catalog-search input, .model-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: #172033; background: transparent; font-size: 13px; }
 .service-groups { display: grid; gap: 18px; margin-top: 17px; }
-.group-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 8px 7px; color: #858d9e; }
-.group-heading strong { font-size: 10px; letter-spacing: .05em; }
-.group-heading span { font-size: 9px; }
+.group-heading { display: flex; align-items: center; justify-content: space-between; margin-bottom: 3px; padding: 8px 9px; border-bottom: 1px solid #e5e8ef; color: #667187; background: #f3f5f9; }
+.group-heading strong { color: #46526a; font-size: 12px; letter-spacing: .05em; }
+.group-heading span { font-size: 10px; }
 .service-group { min-width: 0; }
-.service-item { display: grid; grid-template-columns: 34px minmax(0, 1fr) 8px; align-items: center; gap: 9px; width: 100%; padding: 9px; border: 1px solid transparent; border-radius: 12px; color: #172033; background: transparent; text-align: left; cursor: pointer; transition: 150ms ease; }
+.service-item { display: grid; grid-template-columns: 40px minmax(0, 1fr) 8px; align-items: center; gap: 10px; width: 100%; padding: 10px; border: 1px solid transparent; border-radius: 12px; color: #172033; background: transparent; text-align: left; cursor: pointer; transition: 150ms ease; }
 .service-item:hover { border-color: #e2e5ec; background: #fff; transform: translateX(2px); }
 .service-item.active { border-color: #f3c4d1; background: #fff0f4; box-shadow: 0 7px 18px rgba(214, 50, 96, .08); }
 .service-copy { display: flex; min-width: 0; flex-direction: column; }
-.service-copy strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
-.service-copy small { margin-top: 2px; color: #9097a7; font-size: 9px; }
-.service-mark { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; color: #d42f60; background: #ffeaf0; font-size: 10px; font-weight: 850; }
+.service-copy strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.service-copy small { margin-top: 3px; color: #9097a7; font-size: 10px; }
+.service-mark { display: grid; place-items: center; width: 40px; height: 40px; border-radius: 11px; color: #d42f60; background: #ffeaf0; font-size: 12px; font-weight: 850; }
 .service-mark[data-tone="blue"] { color: #2c65bb; background: #eaf2ff; }
 .service-mark[data-tone="green"] { color: #18835d; background: #e9f8f1; }
 .service-mark[data-tone="violet"] { color: #694bc2; background: #f0ebff; }
@@ -250,28 +254,28 @@ function serviceTone(value: string) {
 .detail-hero { display: flex; align-items: flex-start; gap: 13px; padding-bottom: 20px; border-bottom: 1px solid #eceef3; }
 .detail-hero > div:last-child { min-width: 0; }
 .detail-title-row { display: flex; align-items: center; gap: 9px; }
-.detail-title-row h4 { margin: 1px 0 5px; color: #172033; font-size: 17px; }
-.active-badge { padding: 3px 7px; border-radius: 999px; color: #bd2853; background: #ffe9ef; font-size: 8px; font-weight: 800; }
-.detail-hero p { margin: 0; color: #737c8f; font-size: 11px; line-height: 1.6; }
-.model-section { display: flex; min-height: 0; margin-top: 20px; flex: 1; flex-direction: column; }
+.detail-title-row h4 { margin: 1px 0 5px; color: #172033; font-size: 22px; }
+.active-badge { padding: 4px 8px; border-radius: 999px; color: #bd2853; background: #ffe9ef; font-size: 10px; font-weight: 800; }
+.detail-hero p { margin: 0; color: #737c8f; font-size: 13px; line-height: 1.6; }
+.model-section { display: flex; min-height: 0; margin-top: 20px; flex: 0 0 auto; flex-direction: column; }
 .model-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 15px; margin-bottom: 12px; }
 .model-heading > div { display: flex; min-width: 0; flex-direction: column; }
-.model-heading span { color: #81899a; font-size: 9px; font-weight: 750; }
-.model-heading strong { overflow: hidden; margin-top: 3px; color: #172033; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.model-heading span { color: #81899a; font-size: 11px; font-weight: 750; }
+.model-heading strong { overflow: hidden; margin-top: 3px; color: #172033; font-size: 15px; text-overflow: ellipsis; white-space: nowrap; }
 .model-search { width: 168px; height: 34px; }
 .model-list { display: flex; min-height: 0; flex: 1; flex-direction: column; }
 .model-list-heading { display: flex; align-items: center; justify-content: space-between; margin: 0 2px 8px; color: #81899a; flex: 0 0 auto; }
-.model-list-heading strong { font-size: 9px; }
-.model-list-heading span { font-size: 9px; }
-.model-grid { display: grid; min-height: 0; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; align-content: start; overflow-y: auto; padding: 1px 4px 4px 1px; }
+.model-list-heading strong { font-size: 12px; }
+.model-list-heading span { font-size: 11px; }
+.model-grid { display: grid; min-height: 0; max-height: 246px; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; align-content: start; overflow-y: auto; padding: 1px 4px 4px 1px; }
 .model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
 .model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
 .model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }
 .model-icon { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px; color: #6b7487; background: #f1f3f7; font-size: 10px; font-weight: 850; }
 .model-item.custom .model-icon { color: #c72a56; background: #ffe9ef; font-size: 16px; }
 .model-item > span:nth-child(2) { display: flex; min-width: 0; flex-direction: column; }
-.model-item strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
-.model-item small { overflow: hidden; margin-top: 2px; color: #9299a8; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.model-item strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.model-item small { overflow: hidden; margin-top: 3px; color: #9299a8; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .checkmark { color: #da315f; font-size: 12px; font-weight: 900; }
 .more-models-toggle { display: flex; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 12px; width: 100%; margin-top: 10px; padding: 11px 12px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fafbfc; text-align: left; cursor: pointer; }
 .more-models-toggle:hover { border-color: #f0a9bc; background: #fff8fa; }
@@ -283,8 +287,9 @@ function serviceTone(value: string) {
 .more-models-toggle[aria-expanded="true"] i { transform: rotate(180deg); }
 .no-model-panel { display: flex; align-items: center; gap: 12px; margin-top: 20px; padding: 18px; border: 1px solid #d9eee5; border-radius: 14px; background: #f2faf6; }
 .no-model-panel > span { display: grid; place-items: center; width: 32px; height: 32px; border-radius: 50%; color: #fff; background: #28aa79; font-size: 14px; }
-.no-model-panel strong { color: #185d46; font-size: 12px; }
-.no-model-panel p { margin: 3px 0 0; color: #628074; font-size: 10px; }
+.no-model-panel strong { color: #185d46; font-size: 15px; }
+.no-model-panel p { margin: 4px 0 0; color: #628074; font-size: 12px; }
+.service-configuration-slot { min-height: 0; margin-top: 20px; padding-top: 20px; border-top: 1px solid #eceef3; overflow-y: auto; flex: 1; }
 .detail-footer { display: flex; justify-content: space-between; gap: 12px; margin-top: auto; padding-top: 18px; color: #8b92a2; font-size: 9px; }
 .detail-footer b { color: #5f687a; }
 .catalog-empty { margin: 20px 8px; color: #9299a8; font-size: 10px; text-align: center; }
@@ -304,5 +309,6 @@ function serviceTone(value: string) {
   .model-search { width: 100%; }
   .service-detail { min-height: 520px; overflow: visible; }
   .model-grid { max-height: 400px; }
+  .service-configuration-slot { max-height: none; overflow: visible; }
 }
 </style>

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -22,7 +22,7 @@
               :aria-pressed="service === item.value"
               @click="$emit('update:service', item.value)"
             >
-              <span class="service-mark" :data-tone="serviceTone(item.value)">{{ serviceMark(item.value, item.label) }}</span>
+              <ServiceIcon :service="item.value" :label="item.label" />
               <span class="service-copy">
                 <strong>{{ item.label }}</strong>
                 <small>{{ group.id === 'machine' ? '机器翻译' : 'AI 翻译' }}</small>
@@ -36,7 +36,7 @@
 
       <section class="service-detail" aria-label="当前翻译服务详情">
         <div class="detail-hero">
-          <span class="service-mark large" :data-tone="serviceTone(service)">{{ serviceMark(service, selectedService?.label) }}</span>
+          <ServiceIcon :service="service" :label="selectedService?.label" size="large" />
           <div>
             <div class="detail-title-row">
               <h4>{{ selectedService?.label || '尚未配置服务' }}</h4>
@@ -73,7 +73,7 @@
                 :aria-selected="selectedModel === model"
                 @click="$emit('update:model', model)"
               >
-                <span class="model-icon">{{ model === customModelLabel ? '+' : 'M' }}</span>
+                <ServiceIcon :service="model === customModelLabel ? 'custom' : service" :label="model" size="model" />
                 <span>
                   <strong>{{ model }}</strong>
                   <small>{{ model === customModelLabel ? '填写服务商支持的模型标识' : '使用此模型进行翻译' }}</small>
@@ -116,6 +116,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import ServiceIcon from '@/components/ServiceIcon.vue'
 import { customModelString } from '@/entrypoints/utils/option'
 import {
   buildServiceGroups,
@@ -163,22 +164,6 @@ watch(modelQuery, () => {
   moreModelsOpen.value = false
 })
 
-const markMap: Record<string, string> = {
-  microsoft: 'M', google: 'G', deepL: 'D', deeplx: 'DX', chromeTranslator: 'C',
-  openai: 'OA', azureOpenai: 'AZ', deepseek: 'DS', gemini: 'G', claude: 'C',
-  siliconCloud: 'S', huanYuan: '混', tongyi: '通', doubao: '豆', custom: '自', newapi: 'N',
-}
-
-function serviceMark(value: string, label = '') {
-  return markMap[value] || label.trim().slice(0, 1).toLocaleUpperCase() || '译'
-}
-
-function serviceTone(value: string) {
-  if (['openai', 'azureOpenai', 'custom', 'newapi'].includes(value)) return 'violet'
-  if (['deepseek', 'deepL', 'deeplx', 'microsoft'].includes(value)) return 'blue'
-  if (['gemini', 'google', 'chromeTranslator'].includes(value)) return 'green'
-  return 'rose'
-}
 </script>
 
 <style scoped>
@@ -199,11 +184,6 @@ function serviceTone(value: string) {
 .service-copy { display: flex; min-width: 0; flex-direction: column; }
 .service-copy strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
 .service-copy small { margin-top: 3px; color: #9097a7; font-size: 10px; }
-.service-mark { display: grid; place-items: center; width: 40px; height: 40px; border-radius: 11px; color: #d42f60; background: #ffeaf0; font-size: 12px; font-weight: 850; }
-.service-mark[data-tone="blue"] { color: #2c65bb; background: #eaf2ff; }
-.service-mark[data-tone="green"] { color: #18835d; background: #e9f8f1; }
-.service-mark[data-tone="violet"] { color: #694bc2; background: #f0ebff; }
-.service-mark.large { width: 48px; height: 48px; border-radius: 14px; font-size: 13px; }
 .current-dot { width: 7px; height: 7px; border-radius: 50%; background: #ef4776; box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
 .service-detail { display: flex; min-width: 0; min-height: 0; padding: 24px; flex-direction: column; overflow: hidden; }
 .detail-hero { display: flex; align-items: flex-start; gap: 13px; padding-bottom: 20px; border-bottom: 1px solid #eceef3; }
@@ -226,8 +206,6 @@ function serviceTone(value: string) {
 .model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
 .model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
 .model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }
-.model-icon { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px; color: #6b7487; background: #f1f3f7; font-size: 10px; font-weight: 850; }
-.model-item.custom .model-icon { color: #c72a56; background: #ffe9ef; font-size: 16px; }
 .model-item > span:nth-child(2) { display: flex; min-width: 0; flex-direction: column; }
 .model-item strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
 .model-item small { overflow: hidden; margin-top: 3px; color: #9299a8; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }

--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -216,7 +216,7 @@ function serviceTone(value: string) {
 </script>
 
 <style scoped>
-.service-catalog { margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; }
+.service-catalog { display: flex; height: clamp(520px, calc(100vh - 270px), 760px); min-height: 520px; margin: 2px 0 20px; border: 1px solid #e4e7ef; border-radius: 20px; overflow: hidden; background: #fff; flex-direction: column; }
 .catalog-header { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: 22px 24px; border-bottom: 1px solid #eceef3; }
 .catalog-eyebrow { color: #dc315f; font-size: 11px; font-weight: 800; letter-spacing: .1em; }
 .catalog-header h3 { margin: 5px 0 5px; color: #172033; font-size: 20px; letter-spacing: -.02em; }
@@ -224,8 +224,8 @@ function serviceTone(value: string) {
 .current-summary { display: flex; min-width: 140px; padding: 10px 13px; flex-direction: column; border: 1px solid #f4cad6; border-radius: 12px; background: #fff4f7; }
 .current-summary span { color: #9a6171; font-size: 9px; font-weight: 750; }
 .current-summary strong { margin-top: 3px; color: #c92b57; font-size: 12px; }
-.catalog-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 520px; }
-.service-rail { padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; }
+.catalog-layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); min-height: 0; flex: 1; }
+.service-rail { min-height: 0; padding: 16px 12px 18px; border-right: 1px solid #eceef3; background: #fafbfc; overflow-y: auto; }
 .catalog-search, .model-search { display: flex; align-items: center; gap: 8px; height: 38px; padding: 0 11px; border: 1px solid #dfe3eb; border-radius: 11px; background: #fff; }
 .catalog-search span, .model-search span { color: #8991a2; font-size: 16px; }
 .catalog-search input, .model-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: #172033; background: transparent; font-size: 11px; }
@@ -246,23 +246,24 @@ function serviceTone(value: string) {
 .service-mark[data-tone="violet"] { color: #694bc2; background: #f0ebff; }
 .service-mark.large { width: 48px; height: 48px; border-radius: 14px; font-size: 13px; }
 .current-dot { width: 7px; height: 7px; border-radius: 50%; background: #ef4776; box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
-.service-detail { display: flex; min-width: 0; padding: 24px; flex-direction: column; }
+.service-detail { display: flex; min-width: 0; min-height: 0; padding: 24px; flex-direction: column; overflow: hidden; }
 .detail-hero { display: flex; align-items: flex-start; gap: 13px; padding-bottom: 20px; border-bottom: 1px solid #eceef3; }
 .detail-hero > div:last-child { min-width: 0; }
 .detail-title-row { display: flex; align-items: center; gap: 9px; }
 .detail-title-row h4 { margin: 1px 0 5px; color: #172033; font-size: 17px; }
 .active-badge { padding: 3px 7px; border-radius: 999px; color: #bd2853; background: #ffe9ef; font-size: 8px; font-weight: 800; }
 .detail-hero p { margin: 0; color: #737c8f; font-size: 11px; line-height: 1.6; }
-.model-section { margin-top: 20px; }
+.model-section { display: flex; min-height: 0; margin-top: 20px; flex: 1; flex-direction: column; }
 .model-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 15px; margin-bottom: 12px; }
 .model-heading > div { display: flex; min-width: 0; flex-direction: column; }
 .model-heading span { color: #81899a; font-size: 9px; font-weight: 750; }
 .model-heading strong { overflow: hidden; margin-top: 3px; color: #172033; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .model-search { width: 168px; height: 34px; }
-.model-list-heading { display: flex; align-items: center; justify-content: space-between; margin: 0 2px 8px; color: #81899a; }
+.model-list { display: flex; min-height: 0; flex: 1; flex-direction: column; }
+.model-list-heading { display: flex; align-items: center; justify-content: space-between; margin: 0 2px 8px; color: #81899a; flex: 0 0 auto; }
 .model-list-heading strong { font-size: 9px; }
 .model-list-heading span { font-size: 9px; }
-.model-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.model-grid { display: grid; min-height: 0; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; align-content: start; overflow-y: auto; padding: 1px 4px 4px 1px; }
 .model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
 .model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
 .model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }
@@ -272,7 +273,7 @@ function serviceTone(value: string) {
 .model-item strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .model-item small { overflow: hidden; margin-top: 2px; color: #9299a8; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .checkmark { color: #da315f; font-size: 12px; font-weight: 900; }
-.more-models-toggle { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; margin-top: 10px; padding: 11px 12px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fafbfc; text-align: left; cursor: pointer; }
+.more-models-toggle { display: flex; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 12px; width: 100%; margin-top: 10px; padding: 11px 12px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fafbfc; text-align: left; cursor: pointer; }
 .more-models-toggle:hover { border-color: #f0a9bc; background: #fff8fa; }
 .more-models-toggle > span { display: flex; flex-direction: column; }
 .more-models-toggle strong { font-size: 10px; }
@@ -294,11 +295,14 @@ function serviceTone(value: string) {
 @media (max-width: 700px) {
   .catalog-header { align-items: flex-start; padding: 18px; flex-direction: column; }
   .current-summary { width: 100%; }
-  .catalog-layout { display: block; }
+  .service-catalog { height: auto; min-height: 0; }
+  .catalog-layout { display: block; flex: 0 0 auto; }
   .service-rail { border-right: 0; border-bottom: 1px solid #eceef3; }
   .service-groups { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .service-detail { padding: 18px; }
   .model-heading { align-items: stretch; flex-direction: column; }
   .model-search { width: 100%; }
+  .service-detail { min-height: 520px; overflow: visible; }
+  .model-grid { max-height: 400px; }
 }
 </style>

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -1,8 +1,7 @@
 <template>
   <section class="settings-section service-connection-section">
     <div class="subsection-heading">
-      <div><span>服务配置</span><strong>连接与请求参数</strong></div>
-      <p>这里只显示 {{ currentServiceLabel }} 实际需要的设置。</p>
+      <div><strong>连接参数</strong></div>
     </div>
 
     <el-row v-show="compute.showToken" class="margin-bottom margin-left-2em">
@@ -109,13 +108,11 @@ const props = defineProps<{
   config: Config
   compute: Record<string, any>
   options: typeof optionConfig
-  currentServiceLabel: string
   isValidAzureEndpoint: (endpoint: string) => boolean
 }>()
 
 const config = toRef(props, 'config')
 const compute = toRef(props, 'compute')
 const options = toRef(props, 'options')
-const currentServiceLabel = toRef(props, 'currentServiceLabel')
 const isValidAzureEndpoint = toRef(props, 'isValidAzureEndpoint')
 </script>

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -1,0 +1,121 @@
+<template>
+  <section class="settings-section service-connection-section">
+    <div class="subsection-heading">
+      <div><span>服务配置</span><strong>连接与请求参数</strong></div>
+      <p>这里只显示 {{ currentServiceLabel }} 实际需要的设置。</p>
+    </div>
+
+    <el-row v-show="compute.showToken" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="API访问令牌仅保存在本地，用于访问翻译服务。获取方式请参考对应服务的官方文档；翻译服务为 ollama 时，token 可为任意值" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">访问令牌<el-icon class="icon-margin"><ChatDotRound /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12"><el-input v-model="config.token[config.service]" type="password" show-password placeholder="请输入API访问令牌" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showAzureOpenaiEndpoint" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="Azure OpenAI 服务端点地址，必须包含完整的部署信息。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">Azure 端点<el-icon class="icon-margin"><ChatDotRound /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-input v-model="config.azureOpenaiEndpoint" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-model/chat/completions?api-version=2024-02-15-preview" :class="{ 'input-error': config.azureOpenaiEndpoint && !isValidAzureEndpoint(config.azureOpenaiEndpoint) }" />
+        <div v-if="config.azureOpenaiEndpoint && !isValidAzureEndpoint(config.azureOpenaiEndpoint)" class="error-text">端点地址格式不正确，请确保包含 openai.azure.com 域名和 /chat/completions 路径</div>
+      </el-col>
+    </el-row>
+
+    <el-row v-show="compute.showDeepLX" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="DeepLX API 服务地址，默认为本地地址。如果使用远程 DeepLX 服务，请修改为对应的服务地址" placement="top-start" :show-after="500"><span class="popup-text popup-vertical-left">服务地址</span></el-tooltip>
+      </el-col>
+      <el-col :span="12"><el-input v-model="config.deeplx" placeholder="http://localhost:1188/translate" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">API Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.ak" placeholder="请输入Access Key" /></el-col>
+    </el-row>
+    <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.sk" type="password" placeholder="请输入Secret Key" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">App Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.youdaoAppKey" placeholder="有道 AppKey" /></el-col>
+    </el-row>
+    <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">App Secret<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.youdaoAppSecret" type="password" show-password placeholder="有道 AppSecret" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.tencentSecretId" placeholder="腾讯云 SecretId" /></el-col>
+    </el-row>
+    <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.tencentSecretKey" type="password" show-password placeholder="腾讯云 SecretKey" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showRobotId" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">机器人ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.robot_id[config.service]" placeholder="请输入Coze机器人ID" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showCustom" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">自定义接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.custom" placeholder="请输入自定义接口地址" /></el-col>
+    </el-row>
+    <el-row v-show="compute.showNewAPI" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">NewAPI接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.newApiUrl" placeholder="请输入您的New API接口地址" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showCustomModel" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">{{ config.service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-input v-model="config.customModel[config.service]" placeholder="例如：gemma:7b" /></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式"><el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label" :value="item.value" /></el-select></el-col>
+    </el-row>
+    <el-row v-show="compute.showDeepseekThinkingMode" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">思考模式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12"><el-select v-model="config.deepseekThinkingMode" placeholder="请选择思考模式"><el-option class="select-left" v-for="item in options.deepseekThinkingMode" :key="item.value" :label="item.label" :value="item.value" /></el-select></el-col>
+    </el-row>
+
+    <el-row v-show="compute.showCustomBody" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12">
+        <el-input v-model="config.customBody[config.service]" :class="{ 'input-error': !isValidCustomBody(config.customBody[config.service]) }" placeholder='例如：{"thinking": {"type": "disabled"}}' />
+        <div v-if="!isValidCustomBody(config.customBody[config.service])" class="error-text">请输入合法的 JSON 对象，否则该配置将被忽略</div>
+      </el-col>
+    </el-row>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue'
+import { ChatDotRound } from '@element-plus/icons-vue'
+import type { Config } from '@/entrypoints/utils/model'
+import { options as optionConfig } from '@/entrypoints/utils/option'
+import { isValidCustomBody } from '@/entrypoints/utils/custom-body'
+
+const props = defineProps<{
+  config: Config
+  compute: Record<string, any>
+  options: typeof optionConfig
+  currentServiceLabel: string
+  isValidAzureEndpoint: (endpoint: string) => boolean
+}>()
+
+const config = toRef(props, 'config')
+const compute = toRef(props, 'compute')
+const options = toRef(props, 'options')
+const currentServiceLabel = toRef(props, 'currentServiceLabel')
+const isValidAzureEndpoint = toRef(props, 'isValidAzureEndpoint')
+</script>

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -10,7 +10,7 @@
           <span class="popup-text popup-vertical-left">访问令牌<el-icon class="icon-margin"><ChatDotRound /></el-icon></span>
         </el-tooltip>
       </el-col>
-      <el-col :span="12"><el-input v-model="config.token[config.service]" type="password" show-password placeholder="请输入API访问令牌" /></el-col>
+      <el-col :span="12"><el-input v-model="config.token[service]" type="password" show-password placeholder="请输入API访问令牌" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showAzureOpenaiEndpoint" class="margin-bottom margin-left-2em">
@@ -61,7 +61,7 @@
 
     <el-row v-show="compute.showRobotId" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写对应 Coze 机器人的 ID。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">机器人ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
-      <el-col :span="12"><el-input v-model="config.robot_id[config.service]" placeholder="请输入Coze机器人ID" /></el-col>
+      <el-col :span="12"><el-input v-model="config.robot_id[service]" placeholder="请输入Coze机器人ID" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showCustom" class="margin-bottom margin-left-2em">
@@ -74,8 +74,8 @@
     </el-row>
 
     <el-row v-show="compute.showCustomModel" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写服务商支持的模型标识；选择自定义模型后，网页翻译会使用这里的值。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">{{ config.service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
-      <el-col :span="12"><el-input v-model="config.customModel[config.service]" placeholder="例如：gemma:7b" /></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写服务商支持的模型标识；选择自定义模型后，网页翻译会使用这里的值。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">{{ service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
+      <el-col :span="12"><el-input v-model="config.customModel[service]" placeholder="例如：gemma:7b" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
@@ -90,8 +90,8 @@
     <el-row v-show="compute.showCustomBody" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写要合并到翻译请求中的 JSON 参数对象。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12">
-        <el-input v-model="config.customBody[config.service]" :class="{ 'input-error': !isValidCustomBody(config.customBody[config.service]) }" placeholder='例如：{"thinking": {"type": "disabled"}}' />
-        <div v-if="!isValidCustomBody(config.customBody[config.service])" class="error-text">请输入合法的 JSON 对象，否则该配置将被忽略</div>
+        <el-input v-model="config.customBody[service]" :class="{ 'input-error': !isValidCustomBody(config.customBody[service]) }" placeholder='例如：{"thinking": {"type": "disabled"}}' />
+        <div v-if="!isValidCustomBody(config.customBody[service])" class="error-text">请输入合法的 JSON 对象，否则该配置将被忽略</div>
       </el-col>
     </el-row>
   </section>
@@ -106,12 +106,14 @@ import { isValidCustomBody } from '@/entrypoints/utils/custom-body'
 
 const props = defineProps<{
   config: Config
+  service: string
   compute: Record<string, any>
   options: typeof optionConfig
   isValidAzureEndpoint: (endpoint: string) => boolean
 }>()
 
 const config = toRef(props, 'config')
+const service = toRef(props, 'service')
 const compute = toRef(props, 'compute')
 const options = toRef(props, 'options')
 const isValidAzureEndpoint = toRef(props, 'isValidAzureEndpoint')

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -33,62 +33,62 @@
     </el-row>
 
     <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">API Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="服务商提供的访问密钥。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">API Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.ak" placeholder="请输入Access Key" /></el-col>
     </el-row>
     <el-row v-show="compute.showAkSk" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="服务商提供的私密密钥，请妥善保管。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.sk" type="password" placeholder="请输入Secret Key" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">App Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="有道翻译服务提供的 App Key。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">App Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.youdaoAppKey" placeholder="有道 AppKey" /></el-col>
     </el-row>
     <el-row v-show="compute.showYoudao" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">App Secret<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="有道翻译服务提供的 App Secret。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">App Secret<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.youdaoAppSecret" type="password" show-password placeholder="有道 AppSecret" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="腾讯云翻译服务提供的 SecretId。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">Secret ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.tencentSecretId" placeholder="腾讯云 SecretId" /></el-col>
     </el-row>
     <el-row v-show="compute.showTencent" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="腾讯云翻译服务提供的 SecretKey。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">Secret Key<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.tencentSecretKey" type="password" show-password placeholder="腾讯云 SecretKey" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showRobotId" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">机器人ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写对应 Coze 机器人的 ID。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">机器人ID<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.robot_id[config.service]" placeholder="请输入Coze机器人ID" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showCustom" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">自定义接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写兼容翻译请求的自定义接口地址。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">自定义接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.custom" placeholder="请输入自定义接口地址" /></el-col>
     </el-row>
     <el-row v-show="compute.showNewAPI" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">NewAPI接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写 New API 服务的接口地址。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">NewAPI接口<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.newApiUrl" placeholder="请输入您的New API接口地址" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showCustomModel" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">{{ config.service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写服务商支持的模型标识；选择自定义模型后，网页翻译会使用这里的值。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">{{ config.service === 'doubao' ? '接入点' : '自定义模型' }}<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-input v-model="config.customModel[config.service]" placeholder="例如：gemma:7b" /></el-col>
     </el-row>
 
     <el-row v-show="compute.showDeepseekApiType" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="选择 DeepSeek 接口使用的 API 格式。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">API 格式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-select v-model="config.deepseekApiType" placeholder="请选择 API 格式"><el-option class="select-left" v-for="item in options.deepseekApiType" :key="item.value" :label="item.label" :value="item.value" /></el-select></el-col>
     </el-row>
     <el-row v-show="compute.showDeepseekThinkingMode" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">思考模式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="控制 DeepSeek 是否启用思考过程。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">思考模式<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12"><el-select v-model="config.deepseekThinkingMode" placeholder="请选择思考模式"><el-option class="select-left" v-for="item in options.deepseekThinkingMode" :key="item.value" :label="item.label" :value="item.value" /></el-select></el-col>
     </el-row>
 
     <el-row v-show="compute.showCustomBody" class="margin-bottom margin-left-2em">
-      <el-col :span="12" class="lightblue rounded-corner"><span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-col>
+      <el-col :span="12" class="lightblue rounded-corner"><el-tooltip effect="dark" content="填写要合并到翻译请求中的 JSON 参数对象。" placement="top-start" :show-after="300"><span class="popup-text popup-vertical-left">自定义请求体<el-icon class="icon-margin"><ChatDotRound /></el-icon></span></el-tooltip></el-col>
       <el-col :span="12">
         <el-input v-model="config.customBody[config.service]" :class="{ 'input-error': !isValidCustomBody(config.customBody[config.service]) }" placeholder='例如：{"thinking": {"type": "disabled"}}' />
         <div v-if="!isValidCustomBody(config.customBody[config.service])" class="error-text">请输入合法的 JSON 对象，否则该配置将被忽略</div>

--- a/components/ServiceIcon.vue
+++ b/components/ServiceIcon.vue
@@ -1,0 +1,53 @@
+<template>
+  <span class="service-brand-icon" :class="[`service-brand-icon--${size}`, `service-brand-icon--${tone}`]" :title="label" aria-hidden="true">
+    <svg v-if="service === 'microsoft'" viewBox="0 0 24 24"><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></svg>
+    <svg v-else-if="service === 'google'" viewBox="0 0 24 24"><text x="12" y="17" text-anchor="middle">G</text></svg>
+    <svg v-else-if="service === 'chromeTranslator'" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3"/><path d="M12 4h8M5 8l4 7M19 8l-4 7"/></svg>
+    <svg v-else-if="service === 'openai' || service === 'azureOpenai'" viewBox="0 0 24 24"><path d="M12 4.2a3.4 3.4 0 0 1 5.8 2.4 3.4 3.4 0 0 1 1.9 5.8 3.4 3.4 0 0 1-3.4 5.2 3.4 3.4 0 0 1-5.8 2.2 3.4 3.4 0 0 1-5.8-2.4 3.4 3.4 0 0 1-1.9-5.8A3.4 3.4 0 0 1 6.2 6.4 3.4 3.4 0 0 1 12 4.2Z"/><path d="m8.2 8.5 7.5 4.3M15.8 8.5l-7.5 4.3M12 6v8.7M12 18v-2.2"/></svg>
+    <svg v-else-if="service === 'gemini'" viewBox="0 0 24 24"><path d="m12 2 2.1 7.9L22 12l-7.9 2.1L12 22l-2.1-7.9L2 12l7.9-2.1L12 2Z"/></svg>
+    <svg v-else-if="service === 'claude'" viewBox="0 0 24 24"><path d="M12 2v20M2 12h20M4.9 4.9l14.2 14.2M19.1 4.9 4.9 19.1"/><circle cx="12" cy="12" r="2.4"/></svg>
+    <svg v-else-if="service === 'deepseek'" viewBox="0 0 24 24"><path d="M4 15.2c2.6 3.6 7.8 5.1 12 2.5 2.3-1.4 3.4-3.7 3.1-5.8-.3-2.3-2.2-4-4.5-4.2-1.7-.2-3.2.5-4.2 1.8 1.7-.4 3.4.1 4.4 1.3-2.2-.8-4.7-.2-6.1 1.8-.8 1-2.5 1.7-4.7 2.6Z"/><circle cx="15.8" cy="10.6" r=".8"/></svg>
+    <svg v-else-if="service === 'deepL' || service === 'deeplx'" viewBox="0 0 24 24"><path d="M5 4h9.2a5.8 5.8 0 0 1 0 11.6H9.8L5 20V4Z"/><path d="M9 8h5M9 11h4"/></svg>
+    <svg v-else-if="service === 'grok'" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.5"/><path d="m7.8 7.8 8.4 8.4M16.8 7.3l-4.1 4.1"/></svg>
+    <svg v-else-if="service === 'custom'" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
+    <svg v-else-if="service === 'tongyi' || service === 'doubao' || service === 'yiyan' || service === 'zhipu'" viewBox="0 0 24 24"><path d="M12 3.5 19 7v10l-7 3.5L5 17V7l7-3.5Z"/><path d="m8.5 12 2.2 2.2 4.8-5"/></svg>
+    <svg v-else viewBox="0 0 24 24"><path d="M12 3.5 19.5 8v8L12 20.5 4.5 16V8L12 3.5Z"/><circle cx="12" cy="12" r="2.5"/></svg>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  service: string
+  label?: string
+  size?: 'small' | 'medium' | 'large' | 'model'
+}>(), {
+  label: '',
+  size: 'medium',
+})
+
+const tone = computed(() => {
+  if (['openai', 'azureOpenai', 'newapi'].includes(props.service)) return 'violet'
+  if (['deepseek', 'deepL', 'deeplx', 'microsoft'].includes(props.service)) return 'blue'
+  if (['gemini', 'google', 'chromeTranslator'].includes(props.service)) return 'green'
+  return 'rose'
+})
+</script>
+
+<style scoped>
+.service-brand-icon { display: grid; place-items: center; flex: none; border-radius: 11px; color: #d42f60; background: #ffeaf0; }
+.service-brand-icon--small { width: 25px; height: 25px; border-radius: 8px; }
+.service-brand-icon--medium { width: 40px; height: 40px; }
+.service-brand-icon--large { width: 48px; height: 48px; border-radius: 14px; }
+.service-brand-icon--model { width: 30px; height: 30px; border-radius: 9px; }
+.service-brand-icon--blue { color: #2c65bb; background: #eaf2ff; }
+.service-brand-icon--green { color: #18835d; background: #e9f8f1; }
+.service-brand-icon--violet { color: #694bc2; background: #f0ebff; }
+.service-brand-icon svg { width: 57%; height: 57%; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+.service-brand-icon--small svg, .service-brand-icon--model svg { width: 62%; height: 62%; }
+.service-brand-icon svg text { fill: currentColor; stroke: none; font-family: Arial, sans-serif; font-size: 15px; font-weight: 800; }
+.service-brand-icon svg rect { fill: currentColor; stroke: none; }
+.service-brand-icon svg circle:first-child { fill: none; }
+.service-brand-icon--green svg text { fill: #18835d; }
+</style>

--- a/components/ServiceIcon.vue
+++ b/components/ServiceIcon.vue
@@ -1,17 +1,139 @@
 <template>
-  <span class="service-brand-icon" :class="[`service-brand-icon--${size}`, `service-brand-icon--${tone}`]" :title="label" aria-hidden="true">
-    <svg v-if="service === 'microsoft'" viewBox="0 0 24 24"><rect x="3" y="3" width="8" height="8"/><rect x="13" y="3" width="8" height="8"/><rect x="3" y="13" width="8" height="8"/><rect x="13" y="13" width="8" height="8"/></svg>
-    <svg v-else-if="service === 'google'" viewBox="0 0 24 24"><text x="12" y="17" text-anchor="middle">G</text></svg>
-    <svg v-else-if="service === 'chromeTranslator'" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3"/><path d="M12 4h8M5 8l4 7M19 8l-4 7"/></svg>
-    <svg v-else-if="service === 'openai' || service === 'azureOpenai'" viewBox="0 0 24 24"><path d="M12 4.2a3.4 3.4 0 0 1 5.8 2.4 3.4 3.4 0 0 1 1.9 5.8 3.4 3.4 0 0 1-3.4 5.2 3.4 3.4 0 0 1-5.8 2.2 3.4 3.4 0 0 1-5.8-2.4 3.4 3.4 0 0 1-1.9-5.8A3.4 3.4 0 0 1 6.2 6.4 3.4 3.4 0 0 1 12 4.2Z"/><path d="m8.2 8.5 7.5 4.3M15.8 8.5l-7.5 4.3M12 6v8.7M12 18v-2.2"/></svg>
-    <svg v-else-if="service === 'gemini'" viewBox="0 0 24 24"><path d="m12 2 2.1 7.9L22 12l-7.9 2.1L12 22l-2.1-7.9L2 12l7.9-2.1L12 2Z"/></svg>
-    <svg v-else-if="service === 'claude'" viewBox="0 0 24 24"><path d="M12 2v20M2 12h20M4.9 4.9l14.2 14.2M19.1 4.9 4.9 19.1"/><circle cx="12" cy="12" r="2.4"/></svg>
-    <svg v-else-if="service === 'deepseek'" viewBox="0 0 24 24"><path d="M4 15.2c2.6 3.6 7.8 5.1 12 2.5 2.3-1.4 3.4-3.7 3.1-5.8-.3-2.3-2.2-4-4.5-4.2-1.7-.2-3.2.5-4.2 1.8 1.7-.4 3.4.1 4.4 1.3-2.2-.8-4.7-.2-6.1 1.8-.8 1-2.5 1.7-4.7 2.6Z"/><circle cx="15.8" cy="10.6" r=".8"/></svg>
-    <svg v-else-if="service === 'deepL' || service === 'deeplx'" viewBox="0 0 24 24"><path d="M5 4h9.2a5.8 5.8 0 0 1 0 11.6H9.8L5 20V4Z"/><path d="M9 8h5M9 11h4"/></svg>
-    <svg v-else-if="service === 'grok'" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8.5"/><path d="m7.8 7.8 8.4 8.4M16.8 7.3l-4.1 4.1"/></svg>
-    <svg v-else-if="service === 'custom'" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
-    <svg v-else-if="service === 'tongyi' || service === 'doubao' || service === 'yiyan' || service === 'zhipu'" viewBox="0 0 24 24"><path d="M12 3.5 19 7v10l-7 3.5L5 17V7l7-3.5Z"/><path d="m8.5 12 2.2 2.2 4.8-5"/></svg>
-    <svg v-else viewBox="0 0 24 24"><path d="M12 3.5 19.5 8v8L12 20.5 4.5 16V8L12 3.5Z"/><circle cx="12" cy="12" r="2.5"/></svg>
+  <span
+    class="service-brand-icon"
+    :class="[`service-brand-icon--${size}`, `service-brand-icon--${tone}`]"
+    :data-service="service"
+    :title="label || service"
+    aria-hidden="true"
+  >
+    <svg v-if="service === 'microsoft'" viewBox="0 0 24 24" role="img">
+      <rect x="3" y="3" width="8" height="8" fill="#f35325" />
+      <rect x="13" y="3" width="8" height="8" fill="#81bc06" />
+      <rect x="3" y="13" width="8" height="8" fill="#05a6f0" />
+      <rect x="13" y="13" width="8" height="8" fill="#ffba08" />
+    </svg>
+    <svg v-else-if="service === 'google'" viewBox="0 0 24 24" role="img">
+      <path d="M23 12.245c0-.905-.075-1.565-.236-2.25h-10.54v4.083h6.186c-.124 1.014-.797 2.542-2.294 3.569l-.021.136 3.332 2.53.23.022C21.779 18.417 23 15.593 23 12.245z" fill="#4285F4" />
+      <path d="M12.225 23c3.03 0 5.574-.978 7.433-2.665l-3.542-2.688c-.948.648-2.22 1.1-3.891 1.1a6.745 6.745 0 0 1-6.386-4.572l-.132.011-3.465 2.628-.045.124C4.043 20.531 7.835 23 12.225 23z" fill="#34A853" />
+      <path d="M5.84 14.175A6.65 6.65 0 0 1 5.463 12c0-.758.138-1.491.361-2.175l-.006-.147-3.508-2.67-.115.054A10.831 10.831 0 0 0 1 12c0 1.772.436 3.447 1.197 4.938l3.642-2.763z" fill="#FBBC05" />
+      <path d="M12.225 5.253c2.108 0 3.529.892 4.34 1.638l3.167-3.031C17.787 2.088 15.255 1 12.225 1 7.834 1 4.043 3.469 2.197 7.062l3.63 2.763a6.77 6.77 0 0 1 6.398-4.572z" fill="#EB4335" />
+    </svg>
+    <svg v-else-if="service === 'deepL'" viewBox="0 0 24 24" role="img">
+      <path d="M5 4.5h8.5a6 6 0 1 1 0 12H10L5 20V4.5Z" />
+      <path d="M9 8.5h5.5M9 12h4" />
+    </svg>
+    <svg v-else-if="service === 'deeplx'" viewBox="0 0 24 24" role="img">
+      <path d="M4.5 4.5h8.7a5.8 5.8 0 1 1 0 11.6H9.5l-5 3.4V4.5Z" />
+      <text x="13.3" y="15.4" text-anchor="middle">X</text>
+    </svg>
+    <svg v-else-if="service === 'xiaoniu'" viewBox="0 0 24 24" role="img">
+      <path d="M7 8.5 4.3 5.6M17 8.5l2.7-2.9M6.1 10.5a5.9 5.9 0 0 1 11.8 0v4.1a5.9 5.9 0 0 1-11.8 0v-4.1Z" />
+      <path d="M9 13h.1M15 13h.1M10 16c1.2.8 2.8.8 4 0" />
+    </svg>
+    <svg v-else-if="service === 'youdao'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">有</text>
+    </svg>
+    <svg v-else-if="service === 'tencent'" viewBox="0 0 24 24" role="img">
+      <path d="M5 11.5c0-3.7 3.1-6.5 7-6.5s7 2.8 7 6.5-3.1 6.5-7 6.5c-1.1 0-2.2-.2-3.1-.7L5 19l1.2-3.1A6.2 6.2 0 0 1 5 11.5Z" />
+      <path d="m12 7.2 1.1 2.2 2.4.4-1.7 1.7.4 2.4-2.2-1.1-2.2 1.1.4-2.4-1.7-1.7 2.4-.4L12 7.2Z" />
+    </svg>
+    <svg v-else-if="service === 'chromeTranslator'" viewBox="0 0 24 24" role="img">
+      <path d="M12 4a8 8 0 0 1 6.9 4H12a4 4 0 0 0 0 8h.2A8 8 0 1 1 12 4Z" />
+      <path d="M12 8h6.9M12 16l3.5-6" />
+      <circle cx="12" cy="12" r="2.5" />
+    </svg>
+    <svg v-else-if="service === 'openai'" viewBox="0 0 24 24" role="img">
+      <path d="M12 4.2a3.4 3.4 0 0 1 5.8 2.4 3.4 3.4 0 0 1 1.9 5.8 3.4 3.4 0 0 1-3.4 5.2 3.4 3.4 0 0 1-5.8 2.2 3.4 3.4 0 0 1-5.8-2.4 3.4 3.4 0 0 1-1.9-5.8A3.4 3.4 0 0 1 6.2 6.4 3.4 3.4 0 0 1 12 4.2Z" />
+      <path d="m8.2 8.5 7.5 4.3M15.8 8.5l-7.5 4.3M12 6v8.7M12 18v-2.2" />
+    </svg>
+    <svg v-else-if="service === 'azureOpenai'" viewBox="0 0 24 24" role="img">
+      <path d="m13.8 3.5 6.1 5.1-6.3 11.9-3.1-6.1 3.8-4.5-6.2 1.1 4.6-7.5 1.1 4.2Z" />
+      <path d="m10.5 14.4 3.1-4.5" />
+    </svg>
+    <svg v-else-if="service === 'gemini'" viewBox="0 0 24 24" role="img">
+      <path d="m12 2 2.1 7.9L22 12l-7.9 2.1L12 22l-2.1-7.9L2 12l7.9-2.1L12 2Z" />
+    </svg>
+    <svg v-else-if="service === 'yiyan'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">文</text>
+    </svg>
+    <svg v-else-if="service === 'tongyi'" viewBox="0 0 24 24" role="img">
+      <path d="M5 13.5c.5-4.3 4.1-7.4 8.3-6.7 3 .5 5.1 3 5.1 5.8 0 3.4-2.8 6.1-6.2 6.1-2.4 0-4.5-1.4-5.5-3.5 1.3 1 3.1 1.1 4.6.4 1.9-.9 2.7-3.2 1.8-5.1" />
+      <path d="M7.2 8.7c1.3-.9 3.1-.8 4.2.2" />
+    </svg>
+    <svg v-else-if="service === 'zhipu'" viewBox="0 0 24 24" role="img">
+      <path d="m12 2.8 7.4 4.6v9.2L12 21.2l-7.4-4.6V7.4L12 2.8Z" />
+      <path d="m8.5 9.2 3.5-2 3.5 2v5.6l-3.5 2-3.5-2V9.2ZM8.5 12h7" />
+    </svg>
+    <svg v-else-if="service === 'moonshot'" viewBox="0 0 24 24" role="img">
+      <text x="11" y="16.5" text-anchor="middle">K</text>
+      <path d="m18 4 .7 2.4L21 7l-2.3.6L18 10l-.7-2.4L15 7l2.3-.6L18 4Z" />
+    </svg>
+    <svg v-else-if="service === 'claude'" viewBox="0 0 24 24" role="img">
+      <path d="M12 2.5v19M2.5 12h19M5.3 5.3l13.4 13.4M18.7 5.3 5.3 18.7" />
+      <circle cx="12" cy="12" r="2.2" />
+    </svg>
+    <svg v-else-if="service === 'custom'" viewBox="0 0 24 24" role="img">
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+    <svg v-else-if="service === 'infini'" viewBox="0 0 24 24" role="img">
+      <path d="M4 12c0-2.6 2.2-4.6 4.8-4.6 3.1 0 4.1 4.6 6.4 4.6s4.8-2 4.8-4.6M4 12c0 2.6 2.2 4.6 4.8 4.6 3.1 0 4.1-4.6 6.4-4.6s4.8 2 4.8 4.6" />
+    </svg>
+    <svg v-else-if="service === 'baichuan'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">百</text>
+    </svg>
+    <svg v-else-if="service === 'deepseek'" viewBox="0 0 24 24" role="img">
+      <path d="M4 15.2c2.6 3.6 7.8 5.1 12 2.5 2.3-1.4 3.4-3.7 3.1-5.8-.3-2.3-2.2-4-4.5-4.2-1.7-.2-3.2.5-4.2 1.8 1.7-.4 3.4.1 4.4 1.3-2.2-.8-4.7-.2-6.1 1.8-.8 1-2.5 1.7-4.7 2.6Z" />
+      <circle cx="15.8" cy="10.6" r=".8" />
+    </svg>
+    <svg v-else-if="service === 'lingyi'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">01</text>
+    </svg>
+    <svg v-else-if="service === 'minimax'" viewBox="0 0 24 24" role="img">
+      <path d="M4.5 17V7l4 5 3.5-5v10M13 17V7l3.2 4.2L19.5 7v10" />
+    </svg>
+    <svg v-else-if="service === 'jieyue'" viewBox="0 0 24 24" role="img">
+      <path d="m12 3 1.7 6.3L20 11l-6.3 1.7L12 19l-1.7-6.3L4 11l6.3-1.7L12 3Z" />
+      <path d="M17.5 16.5 20 19" />
+    </svg>
+    <svg v-else-if="service === 'groq'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">G</text>
+      <path d="M15.5 13.5H19v3.7" />
+    </svg>
+    <svg v-else-if="service === 'cozecom'" viewBox="0 0 24 24" role="img">
+      <path d="M19 11.5a7 7 0 0 1-7 7H7l-3 2v-5a7 7 0 1 1 15-4Z" />
+      <path d="M9 10.2h6M9 13.3h4" />
+    </svg>
+    <svg v-else-if="service === 'cozecn'" viewBox="0 0 24 24" role="img">
+      <path d="M19 11.5a7 7 0 0 1-7 7H7l-3 2v-5a7 7 0 1 1 15-4Z" />
+      <text x="12" y="14.5" text-anchor="middle">C</text>
+    </svg>
+    <svg v-else-if="service === 'huanYuan'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">混</text>
+    </svg>
+    <svg v-else-if="service === 'huanYuanTranslation'" viewBox="0 0 24 24" role="img">
+      <text x="12" y="16.5" text-anchor="middle">译</text>
+    </svg>
+    <svg v-else-if="service === 'doubao'" viewBox="0 0 24 24" role="img">
+      <path d="M7.2 8.1c0-2.1 1.8-3.6 3.9-3.6 2 0 3.6 1.4 3.6 3.3 0 1.4-.7 2.5-1.8 3.2 1.5-.1 3.1.7 3.7 2.2.9 2.1-.6 4.3-2.9 4.8-2.3.5-4.4-.8-4.9-2.8-.3-1.2.1-2.4 1-3.3-1.4.1-2.6-.6-3.2-1.8-.3-.6-.4-1.3-.4-2Z" />
+    </svg>
+    <svg v-else-if="service === 'siliconCloud'" viewBox="0 0 24 24" role="img">
+      <path d="M4 15.8c0-2.3 1.9-4.2 4.2-4.2.6-2.3 2.7-4 5.2-4 2.9 0 5.2 2.2 5.4 5 1.1.4 1.9 1.4 1.9 2.7 0 1.7-1.4 3.1-3.1 3.1H7.2A3.2 3.2 0 0 1 4 15.8Z" />
+      <path d="M8 15.7c1.4-1.4 2.6-1.4 3.8 0 1.2 1.4 2.4 1.4 3.8 0" />
+    </svg>
+    <svg v-else-if="service === 'openrouter'" viewBox="0 0 24 24" role="img">
+      <circle cx="8" cy="8" r="2.1" />
+      <circle cx="16" cy="16" r="2.1" />
+      <path d="M9.5 9.5 14.5 14.5M16.5 8.5 19 6M5 18l2.5-2.5" />
+    </svg>
+    <svg v-else-if="service === 'grok'" viewBox="0 0 24 24" role="img">
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="m7.8 7.8 8.4 8.4M16.8 7.3l-4.1 4.1" />
+    </svg>
+    <svg v-else-if="service === 'newapi'" viewBox="0 0 24 24" role="img">
+      <path d="m12 3.5 7 4v9l-7 4-7-4v-9l7-4Z" />
+      <text x="12" y="15.8" text-anchor="middle">N</text>
+    </svg>
+    <span v-else class="service-brand-fallback">{{ fallbackGlyph }}</span>
   </span>
 </template>
 
@@ -33,21 +155,232 @@ const tone = computed(() => {
   if (['gemini', 'google', 'chromeTranslator'].includes(props.service)) return 'green'
   return 'rose'
 })
+
+const fallbackGlyph = computed(() => {
+  const glyphs: Record<string, string> = {
+    microsoft: 'M',
+    google: 'G',
+    deepL: 'D',
+    deeplx: 'DX',
+    xiaoniu: '小',
+    youdao: '有',
+    tencent: '云',
+    chromeTranslator: 'C',
+    openai: 'OAI',
+    azureOpenai: 'A',
+    gemini: '✦',
+    yiyan: '文',
+    tongyi: '通',
+    zhipu: '智',
+    moonshot: 'K',
+    claude: '✳',
+    custom: '+',
+    infini: '∞',
+    baichuan: '百',
+    deepseek: 'DS',
+    lingyi: '01',
+    minimax: 'MM',
+    jieyue: '阶',
+    groq: 'G',
+    cozecom: 'C',
+    cozecn: 'C',
+    huanYuan: '混',
+    huanYuanTranslation: '译',
+    doubao: '豆',
+    siliconCloud: 'S',
+    openrouter: 'O',
+    grok: 'X',
+    newapi: 'N',
+  }
+  return glyphs[props.service] || props.service.slice(0, 2).toUpperCase()
+})
 </script>
 
 <style scoped>
-.service-brand-icon { display: grid; place-items: center; flex: none; border-radius: 11px; color: #d42f60; background: #ffeaf0; }
-.service-brand-icon--small { width: 25px; height: 25px; border-radius: 8px; }
-.service-brand-icon--medium { width: 40px; height: 40px; }
-.service-brand-icon--large { width: 48px; height: 48px; border-radius: 14px; }
-.service-brand-icon--model { width: 30px; height: 30px; border-radius: 9px; }
-.service-brand-icon--blue { color: #2c65bb; background: #eaf2ff; }
-.service-brand-icon--green { color: #18835d; background: #e9f8f1; }
-.service-brand-icon--violet { color: #694bc2; background: #f0ebff; }
-.service-brand-icon svg { width: 57%; height: 57%; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
-.service-brand-icon--small svg, .service-brand-icon--model svg { width: 62%; height: 62%; }
-.service-brand-icon svg text { fill: currentColor; stroke: none; font-family: Arial, sans-serif; font-size: 15px; font-weight: 800; }
-.service-brand-icon svg rect { fill: currentColor; stroke: none; }
-.service-brand-icon svg circle:first-child { fill: none; }
-.service-brand-icon--green svg text { fill: #18835d; }
+.service-brand-icon {
+  display: grid;
+  place-items: center;
+  flex: none;
+  border-radius: 11px;
+  color: #d42f60;
+  background: #ffeaf0;
+}
+
+.service-brand-icon--small {
+  width: 25px;
+  height: 25px;
+  border-radius: 8px;
+}
+
+.service-brand-icon--medium {
+  width: 40px;
+  height: 40px;
+}
+
+.service-brand-icon--large {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+}
+
+.service-brand-icon--model {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+}
+
+.service-brand-icon--blue {
+  color: #2c65bb;
+  background: #eaf2ff;
+}
+
+.service-brand-icon--green {
+  color: #18835d;
+  background: #e9f8f1;
+}
+
+.service-brand-icon--violet {
+  color: #694bc2;
+  background: #f0ebff;
+}
+
+.service-brand-icon[data-service='microsoft'] {
+  background: #edf3ff;
+}
+
+.service-brand-icon[data-service='google'] {
+  color: #4285f4;
+  background: #edf3ff;
+}
+
+.service-brand-icon[data-service='deepL'],
+.service-brand-icon[data-service='deeplx'] {
+  color: #0f5bda;
+  background: #eaf2ff;
+}
+
+.service-brand-icon[data-service='xiaoniu'],
+.service-brand-icon[data-service='youdao'],
+.service-brand-icon[data-service='doubao'],
+.service-brand-icon[data-service='cozecom'],
+.service-brand-icon[data-service='cozecn'] {
+  color: #e52b62;
+  background: #ffeaf0;
+}
+
+.service-brand-icon[data-service='tencent'],
+.service-brand-icon[data-service='azureOpenai'] {
+  color: #2f6fc3;
+  background: #eaf2ff;
+}
+
+.service-brand-icon[data-service='chromeTranslator'] {
+  color: #16825c;
+  background: #e8f8f0;
+}
+
+.service-brand-icon[data-service='openai'] {
+  color: #252a31;
+  background: #f0f2f5;
+}
+
+.service-brand-icon[data-service='gemini'] {
+  color: #5b56d6;
+  background: #f0efff;
+}
+
+.service-brand-icon[data-service='claude'] {
+  color: #b66b43;
+  background: #fff0e8;
+}
+
+.service-brand-icon[data-service='deepseek'] {
+  color: #4d6cff;
+  background: #edf1ff;
+}
+
+.service-brand-icon[data-service='tongyi'],
+.service-brand-icon[data-service='zhipu'],
+.service-brand-icon[data-service='newapi'] {
+  color: #6847c6;
+  background: #f0ebff;
+}
+
+.service-brand-icon[data-service='moonshot'],
+.service-brand-icon[data-service='lingyi'],
+.service-brand-icon[data-service='baichuan'] {
+  color: #3f64c6;
+  background: #eaf2ff;
+}
+
+.service-brand-icon[data-service='infini'],
+.service-brand-icon[data-service='openrouter'] {
+  color: #2877c7;
+  background: #eaf4ff;
+}
+
+.service-brand-icon[data-service='minimax'],
+.service-brand-icon[data-service='jieyue'],
+.service-brand-icon[data-service='huanYuan'],
+.service-brand-icon[data-service='huanYuanTranslation'] {
+  color: #d42f60;
+  background: #ffeaf0;
+}
+
+.service-brand-icon[data-service='groq'],
+.service-brand-icon[data-service='grok'] {
+  color: #22252c;
+  background: #f0f2f5;
+}
+
+.service-brand-icon[data-service='siliconCloud'] {
+  color: #16825c;
+  background: #e8f8f0;
+}
+
+.service-brand-icon svg {
+  width: 57%;
+  height: 57%;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+  overflow: visible;
+}
+
+.service-brand-icon--small svg,
+.service-brand-icon--model svg {
+  width: 62%;
+  height: 62%;
+}
+
+.service-brand-icon svg text {
+  fill: currentColor;
+  stroke: none;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 800;
+  dominant-baseline: middle;
+}
+
+.service-brand-icon--small svg text,
+.service-brand-icon--model svg text {
+  font-size: 12px;
+}
+
+.service-brand-icon svg rect {
+  stroke: none;
+}
+
+.service-brand-icon svg circle:first-child {
+  fill: none;
+}
+
+.service-brand-fallback {
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
 </style>

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -24,10 +24,18 @@ export default defineBackground({
     },
     main() {
         const isContextMenuSupported = !!browser.contextMenus
+        let contextMenusReady = false
 
-        // 创建右键菜单项
-        if (isContextMenuSupported) {
+        // 开发模式会多次重载后台脚本。先清理本扩展已有菜单，避免重复 ID。
+        const setupContextMenus = async () => {
+            if (!isContextMenuSupported) {
+                console.log("不支持右键菜单")
+                return
+            }
+
             try {
+                await browser.contextMenus.removeAll()
+
                 // 创建父菜单
                 browser.contextMenus.create({
                     id: 'fluentread-parent',
@@ -51,68 +59,70 @@ export default defineBackground({
                     contexts: ['page', 'selection'],
                     enabled: false, // 初始状态为禁用
                 });
-
-                // 监听右键菜单点击事件
-                browser.contextMenus.onClicked.addListener((info: any, tab: any) => {
-                    if (!tab?.id) return;
-
-                    if (info.menuItemId === CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE) {
-                        // 发送消息到内容脚本触发全文翻译
-                        browser.tabs.sendMessage(tab.id, {
-                            type: 'contextMenuTranslate',
-                            action: 'fullPage'
-                        }).then(() => {
-                            // 更新翻译状态
-                            translationStateMap.set(tab.id!, true);
-                            updateContextMenus(tab.id!);
-                        }).catch((error: any) => {
-                            console.error('Failed to send message to content script:', error);
-                        });
-                    } else if (info.menuItemId === CONTEXT_MENU_IDS.RESTORE_ORIGINAL) {
-                        // 发送消息到内容脚本撤销翻译
-                        browser.tabs.sendMessage(tab.id, {
-                            type: 'contextMenuTranslate',
-                            action: 'restore'
-                        }).then(() => {
-                            // 更新翻译状态
-                            translationStateMap.set(tab.id!, false);
-                            updateContextMenus(tab.id!);
-                        }).catch((error: any) => {
-                            console.error('Failed to send message to content script:', error);
-                        });
-                    }
-                });
-
+                contextMenusReady = true
             } catch (error) {
+                contextMenusReady = false
                 console.error('Error setting up context menu:', error);
             }
-        } else {
-            console.log("不支持右键菜单")
         }
 
+        void setupContextMenus()
+
         // 更新右键菜单状态
-        const updateContextMenus = (tabId: number) => {
+        const updateContextMenus = async (tabId: number) => {
+            if (!contextMenusReady) return
             const isTranslated = translationStateMap.get(tabId) || false;
 
             try {
                 // 更新全文翻译菜单项
-                browser.contextMenus.update(CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE, {
-                    enabled: !isTranslated,
-                    title: isTranslated ? '全文翻译 (已翻译)' : '全文翻译'
-                });
-                // 更新撤销翻译菜单项
-                browser.contextMenus.update(CONTEXT_MENU_IDS.RESTORE_ORIGINAL, {
-                    enabled: isTranslated,
-                    title: isTranslated ? '撤销翻译' : '撤销翻译 (无翻译)'
-                });
+                await Promise.all([
+                    browser.contextMenus.update(CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE, {
+                        enabled: !isTranslated,
+                        title: isTranslated ? '全文翻译 (已翻译)' : '全文翻译'
+                    }),
+                    // 更新撤销翻译菜单项
+                    browser.contextMenus.update(CONTEXT_MENU_IDS.RESTORE_ORIGINAL, {
+                        enabled: isTranslated,
+                        title: isTranslated ? '撤销翻译' : '撤销翻译 (无翻译)'
+                    })
+                ]);
             } catch (error) {
                 console.error('Failed to update context menus:', error);
             }
         };
 
+        // 监听右键菜单点击事件
+        if (isContextMenuSupported) {
+            browser.contextMenus.onClicked.addListener((info: any, tab: any) => {
+                if (!tab?.id) return;
+
+                if (info.menuItemId === CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE) {
+                    browser.tabs.sendMessage(tab.id, {
+                        type: 'contextMenuTranslate',
+                        action: 'fullPage'
+                    }).then(() => {
+                        translationStateMap.set(tab.id!, true);
+                        void updateContextMenus(tab.id!);
+                    }).catch((error: any) => {
+                        console.error('Failed to send message to content script:', error);
+                    });
+                } else if (info.menuItemId === CONTEXT_MENU_IDS.RESTORE_ORIGINAL) {
+                    browser.tabs.sendMessage(tab.id, {
+                        type: 'contextMenuTranslate',
+                        action: 'restore'
+                    }).then(() => {
+                        translationStateMap.set(tab.id!, false);
+                        void updateContextMenus(tab.id!);
+                    }).catch((error: any) => {
+                        console.error('Failed to send message to content script:', error);
+                    });
+                }
+            });
+        }
+
         // 监听标签页切换事件，更新菜单状态
         browser.tabs.onActivated.addListener((activeInfo: any) => {
-            if (isContextMenuSupported) updateContextMenus(activeInfo.tabId);
+            if (isContextMenuSupported) void updateContextMenus(activeInfo.tabId);
         });
 
         // 监听标签页更新事件（页面刷新等）
@@ -120,7 +130,7 @@ export default defineBackground({
             if (changeInfo.status === 'complete') {
                 // 页面加载完成，重置翻译状态
                 translationStateMap.set(tabId, false);
-                if (isContextMenuSupported) updateContextMenus(tabId);
+                if (isContextMenuSupported) void updateContextMenus(tabId);
             }
         });
 
@@ -137,6 +147,12 @@ export default defineBackground({
                     if (message.type === 'inputBoxTranslation') {
                         const translatedText = await translateWithMicrosoftInBackground(message.text, message.targetLang);
                         resolve({ success: true, translatedText });
+                        return;
+                    }
+
+                    if (message.type === 'openOptionsPage') {
+                        await browser.runtime.openOptionsPage();
+                        resolve({ success: true });
                         return;
                     }
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,19 +2,39 @@ import { handleTranslation, autoTranslateEnglishPage, restoreOriginalContent } f
 import { cache } from "./utils/cache";
 import { constants } from "@/entrypoints/utils/constant";
 import { getCenterPoint } from "@/entrypoints/utils/common";
-import './style.css';
+import pageStyles from './style.css?inline';
 import { config, configReady } from "@/entrypoints/utils/config";
 import { mountFloatingBall, unmountFloatingBall, toggleFloatingBallPosition } from "@/entrypoints/utils/floatingBall";
 import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoints/utils/selectionTranslator";
 import { cancelAllTranslations, translateText } from "@/entrypoints/utils/translateApi";
-import { createApp } from 'vue';
 import TranslationStatus from '@/components/TranslationStatus.vue';
 import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import { createShadowRootUi, type ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
+import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
+
+let contentScriptContext: ContentScriptContext | null = null;
+let translationStatusUi: ShadowRootContentScriptUi<VueShadowMount> | null = null;
+let inputTooltipUi: ShadowRootContentScriptUi<HTMLElement> | null = null;
+
+function installPageStyles(ctx: ContentScriptContext) {
+    const existing = document.getElementById('fluent-read-page-styles');
+    if (existing) return;
+
+    const style = document.createElement('style');
+    style.id = 'fluent-read-page-styles';
+    style.textContent = pageStyles;
+    (document.head ?? document.documentElement).appendChild(style);
+    ctx.onInvalidated(() => style.remove());
+}
 
 export default defineContentScript({
     matches: ['<all_urls>'],  // 匹配所有页面
     runAt: 'document_end',  // 在页面加载完成后运行
-    async main() {
+    cssInjectionMode: 'ui',
+    async main(ctx) {
+        contentScriptContext = ctx;
+        installPageStyles(ctx);
         await configReady // 等待配置加载完成
         if (config.on === false) return; // 如果配置关闭，则不执行任何操作
         // 添加手动翻译事件监听器
@@ -40,17 +60,17 @@ export default defineContentScript({
         // 挂载悬浮球（如果配置未禁用）
         if (config.disableFloatingBall !== true) {
             // 使用配置中的位置
-            mountFloatingBall();
+            await mountFloatingBall(ctx);
         }
         
         // 挂载划词翻译组件（如果配置未禁用）
         if (config.disableSelectionTranslator !== true) {
-            mountSelectionTranslator();
+            await mountSelectionTranslator(ctx);
         }
         
         // 挂载翻译状态组件（可配置禁用）
         if (config.translationStatus === true) {
-            mountTranslationStatusComponent();
+            await mountTranslationStatusComponent(ctx);
         }
 
         mountNewApiComponent();
@@ -68,7 +88,7 @@ export default defineContentScript({
         browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: () => void) => {
             if (message.type === 'toggleFloatingBall') {
                 if (message.isEnabled) {
-                    mountFloatingBall();
+                    void mountFloatingBall(ctx);
                 } else {
                     unmountFloatingBall();
                 }
@@ -89,7 +109,7 @@ export default defineContentScript({
                 } else {
                     // 如果之前没有挂载，现在挂载
                     if (!document.getElementById('fluent-read-selection-translator-container')) {
-                        mountSelectionTranslator();
+                        void mountSelectionTranslator(ctx);
                     }
                 }
                 sendResponse();
@@ -130,6 +150,9 @@ export default defineContentScript({
             unmountFloatingBall();
             // 移除划词翻译组件
             unmountSelectionTranslator();
+            translationStatusUi?.remove();
+            translationStatusUi = null;
+            removeExistingTooltip();
         });
     }
 })
@@ -639,15 +662,16 @@ function clearAllTranslations() {
 /**
  * 挂载翻译状态组件
  */
-function mountTranslationStatusComponent() {
-    // 创建容器元素
-    const container = document.createElement('div');
-    container.id = 'fluent-read-translation-status-container';
-    document.body.appendChild(container);
-    
-    // 创建并挂载组件
-    const app = createApp(TranslationStatus);
-    app.mount(container);
+async function mountTranslationStatusComponent(ctx: ContentScriptContext) {
+    if (translationStatusUi) return translationStatusUi.mounted?.instance;
+
+    translationStatusUi = await createVueShadowUi(ctx, {
+        name: 'fluent-read-translation-status-ui',
+        hostId: 'fluent-read-translation-status-container',
+        component: TranslationStatus,
+        zIndex: 2_147_483_645,
+    });
+    return translationStatusUi.mounted?.instance;
 }
 
 /**
@@ -829,26 +853,80 @@ function setInputBoxText(element: HTMLElement, text: string): void {
 /**
  * 创建并显示翻译提示弹窗
  */
-function createTranslationTooltip(element: HTMLElement, message: string, type: 'translating' | 'success' | 'error'): HTMLElement {
+async function createTranslationTooltip(element: HTMLElement, message: string, type: 'translating' | 'success' | 'error'): Promise<HTMLElement> {
     // 移除已存在的提示
     removeExistingTooltip();
-    
-    const tooltip = document.createElement('div');
-    tooltip.className = `fluent-input-tooltip ${type}`;
-    tooltip.id = 'fluent-input-translation-tooltip';
-    
-    // 添加图标和文字
-    const icon = getTooltipIcon(type);
-    tooltip.innerHTML = `${icon} ${message}`;
-    
-    // 计算位置
+
+    if (!contentScriptContext) {
+        throw new Error('Content script context is not ready');
+    }
+
     const rect = element.getBoundingClientRect();
-    const tooltipTop = rect.bottom + window.scrollY + 12;
-    const tooltipLeft = rect.left + window.scrollX + (rect.width / 2);
-    
-    tooltip.style.top = `${tooltipTop}px`;
-    tooltip.style.left = `${tooltipLeft}px`;
-    tooltip.style.transform = 'translateX(-50%)';
+
+    inputTooltipUi = await createShadowRootUi<HTMLElement>(contentScriptContext, {
+        name: 'fluent-read-input-tooltip-ui',
+        position: 'overlay',
+        alignment: 'top-left',
+        zIndex: 2_147_483_647,
+        mode: 'open',
+        inheritStyles: false,
+        css: `
+            :host {
+                all: initial !important;
+                display: block !important;
+                position: relative !important;
+                width: 0 !important;
+                height: 0 !important;
+                overflow: visible !important;
+            }
+            html, body {
+                width: 0 !important;
+                height: 0 !important;
+                margin: 0 !important;
+                padding: 0 !important;
+                overflow: visible !important;
+            }
+            .fluent-input-tooltip {
+                position: fixed;
+                box-sizing: border-box;
+                background: rgba(17, 24, 39, 0.88);
+                color: #fff;
+                padding: 8px 12px;
+                border: 0;
+                border-radius: 8px;
+                font: 500 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                white-space: nowrap;
+                z-index: 2147483647;
+                pointer-events: none;
+                transition: opacity 0.2s ease, transform 0.2s ease;
+                backdrop-filter: blur(8px);
+                box-shadow: 0 8px 24px rgba(15, 23, 42, 0.2);
+            }
+            .fluent-input-tooltip.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+            .fluent-input-tooltip.hide { opacity: 0; transform: translateX(-50%) translateY(-5px); }
+            .fluent-input-tooltip.translating { background: rgba(59, 130, 246, 0.9); }
+            .fluent-input-tooltip.success { background: rgba(34, 197, 94, 0.9); }
+            .fluent-input-tooltip.error { background: rgba(239, 68, 68, 0.9); }
+        `,
+        onMount(container) {
+            const tooltip = document.createElement('div');
+            tooltip.className = `fluent-input-tooltip ${type}`;
+            tooltip.id = 'fluent-input-translation-tooltip';
+            tooltip.textContent = `${getTooltipIcon(type)} ${message}`;
+            tooltip.style.top = `${rect.bottom + 12}px`;
+            tooltip.style.left = `${rect.left + (rect.width / 2)}px`;
+            tooltip.style.transform = 'translateX(-50%) translateY(3px)';
+            tooltip.style.opacity = config.animations ? '0' : '1';
+            container.appendChild(tooltip);
+            return tooltip;
+        },
+    });
+
+    inputTooltipUi.shadowHost.id = 'fluent-input-translation-tooltip-host';
+    inputTooltipUi.shadowHost.setAttribute('data-fluent-read-ui', 'input-tooltip');
+    inputTooltipUi.mount();
+
+    const tooltip = inputTooltipUi.mounted!;
     
     // 如果禁用动画，直接显示，否则使用淡入效果
     if (!config.animations) {
@@ -861,7 +939,6 @@ function createTranslationTooltip(element: HTMLElement, message: string, type: '
         }, 10);
     }
     
-    document.body.appendChild(tooltip);
     return tooltip;
 }
 
@@ -881,15 +958,17 @@ function getTooltipIcon(type: 'translating' | 'success' | 'error'): string {
  * 移除现有的提示弹窗
  */
 function removeExistingTooltip(): void {
-    const existing = document.getElementById('fluent-input-translation-tooltip');
-    if (existing) {
+    const ui = inputTooltipUi;
+    const existing = ui?.mounted;
+    inputTooltipUi = null;
+    if (ui && existing) {
         if (!config.animations) {
             // 如果禁用动画，直接移除
-            existing.remove();
+            ui.remove();
         } else {
             // 使用淡出动画
             existing.classList.add('hide');
-            setTimeout(() => existing.remove(), 300);
+            setTimeout(() => ui.remove(), 300);
         }
     }
 }
@@ -963,7 +1042,7 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
         
         // 显示翻译中的动画和提示
         addInputBoxAnimation(element, 'translating');
-        tooltip = createTranslationTooltip(element, '微软翻译中', 'translating');
+        tooltip = await createTranslationTooltip(element, '微软翻译中', 'translating');
         
         try {
             // 直接调用微软翻译API，不使用缓存
@@ -979,20 +1058,20 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
                 // 显示成功动画和提示
                 addInputBoxAnimation(element, 'success');
                 removeExistingTooltip();
-                tooltip = createTranslationTooltip(element, '翻译成功', 'success');
+                tooltip = await createTranslationTooltip(element, '翻译成功', 'success');
             } else {
                 // 翻译结果与原文相同或为空
                 element.classList.remove('fluent-input-translating');
                 addInputBoxAnimation(element, 'error');
                 removeExistingTooltip();
-                tooltip = createTranslationTooltip(element, '内容无需翻译', 'error');
+                tooltip = await createTranslationTooltip(element, '内容无需翻译', 'error');
             }
         } catch (translationError) {
             // 翻译失败
             element.classList.remove('fluent-input-translating');
             addInputBoxAnimation(element, 'error');
             removeExistingTooltip();
-            tooltip = createTranslationTooltip(element, '微软翻译失败', 'error');
+            tooltip = await createTranslationTooltip(element, '微软翻译失败', 'error');
             console.error('微软翻译失败:', translationError);
         }
         
@@ -1008,7 +1087,7 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
         // 显示错误动画和提示
         addInputBoxAnimation(element, 'error');
         removeExistingTooltip();
-        tooltip = createTranslationTooltip(element, '翻译服务暂时不可用', 'error');
+        tooltip = await createTranslationTooltip(element, '翻译服务暂时不可用', 'error');
         
         // 自动隐藏错误提示
         setTimeout(() => removeExistingTooltip(), 3000);

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -97,85 +97,13 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import Main from '@/components/Main.vue'
-
-type NavigationItem = {
-  id: string
-  icon: string
-  label: string
-  description: string
-  group: string
-  heading: string
-  summary: string
-  kicker: string
-  title: string
-  detail: string
-  searchDescription: string
-}
+import { navigationGroups, navigationItems } from './navigation'
 
 const version = process.env.VUE_APP_VERSION
 const query = ref('')
 const activeSection = ref('settings-general')
 
-const navigationGroups: Array<{ label: string; items: NavigationItem[] }> = [
-  {
-    label: '基础设置',
-    items: [
-      {
-        id: 'settings-general', icon: '⌂', label: '通用设置', description: '状态与显示', group: '基础设置',
-        heading: '调整你的阅读体验', summary: '管理插件状态、翻译模式和译文的基础显示方式。',
-        kicker: '阅读偏好', title: '通用设置', detail: '常用开关集中在这里，修改后会自动保存。',
-        searchDescription: '插件启停、双语模式、译文样式与主题',
-      },
-      {
-        id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础设置',
-        heading: '配置翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置之后网页翻译默认使用的服务、模型及连接参数。',
-        kicker: '翻译能力', title: '翻译服务与模型', detail: '配置网页翻译默认使用的服务、模型和连接参数。',
-        searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
-      },
-    ],
-  },
-  {
-    label: '阅读工具',
-    items: [
-      {
-        id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文', group: '阅读工具',
-        heading: '让翻译顺手发生', summary: '统一设置鼠标悬停、划词和全文翻译的触发习惯。',
-        kicker: '操作方式', title: '交互与快捷键', detail: '为高频动作选择容易记忆且不冲突的触发方式。',
-        searchDescription: '鼠标悬停、划词翻译、全文翻译与自定义按键',
-      },
-    ],
-  },
-  {
-    label: '系统与数据',
-    items: [
-      {
-        id: 'settings-advanced', icon: '◇', label: '高级选项', description: '性能与模板', group: '系统与数据',
-        heading: '精细控制运行方式', summary: '管理缓存、动画、并发、悬浮工具、代理和 AI 提示词。',
-        kicker: '运行策略', title: '高级选项', detail: '这些设置更偏向性能、兼容性和高级翻译行为。',
-        searchDescription: '缓存、动画、并发、悬浮球、输入框、代理与提示词',
-      },
-      {
-        id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出', group: '系统与数据',
-        heading: '备份与迁移配置', summary: '导出当前设置，或从已有配置恢复你的使用习惯。',
-        kicker: '数据工具', title: '配置管理', detail: '通过 JSON 完成配置备份、迁移与恢复。',
-        searchDescription: '备份、迁移、导出与导入 JSON 配置',
-      },
-    ],
-  },
-  {
-    label: '关于',
-    items: [
-      {
-        id: 'settings-about', icon: 'i', label: '关于流畅阅读', description: '版本与项目', group: '关于',
-        heading: '关于流畅阅读', summary: '了解插件版本、核心体验与项目入口。',
-        kicker: '关于项目', title: '关于流畅阅读', detail: '一个让双语阅读更自然的开源浏览器翻译插件。',
-        searchDescription: '版本、开源项目、使用文档与问题反馈',
-      },
-    ],
-  },
-]
-
-const navigation = navigationGroups.flatMap((group) => group.items)
+const navigation = navigationItems
 const activeItem = computed(() => navigation.find((item) => item.id === activeSection.value) || navigation[0])
 
 const filteredResults = computed(() => {

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -45,7 +45,7 @@
       <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
 
       <section class="settings-card" :class="{ 'services-view': activeSection === 'settings-services' }" :aria-label="activeItem.heading">
-        <div class="card-intro">
+        <div v-if="activeSection !== 'settings-services'" class="card-intro">
           <span class="eyebrow">{{ activeItem.kicker }}</span>
           <h2>{{ activeItem.title }}</h2>
           <p>{{ activeItem.detail }}</p>
@@ -92,8 +92,8 @@ const navigationGroups: Array<{ label: string; items: NavigationItem[] }> = [
       },
       {
         id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础设置',
-        heading: '选择翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，清楚管理当前服务、模型及连接参数。',
-        kicker: '翻译能力', title: '服务目录', detail: '先选择服务，再配置模型和该服务实际需要的参数。',
+        heading: '选择翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置之后网页翻译默认使用的服务、模型及连接参数。',
+        kicker: '翻译能力', title: '翻译服务与模型', detail: '配置默认翻译服务和模型，之后网页翻译会按此设置执行。',
         searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
       },
     ],

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -7,51 +7,50 @@
       </div>
 
       <nav aria-label="设置分类">
-        <button
-          v-for="item in navigation"
-          :key="item.id"
-          type="button"
-          :class="{ active: activeSection === item.id }"
-          @click="scrollTo(item.id)"
-        >
-          <span class="nav-icon">{{ item.icon }}</span>
-          <span><strong>{{ item.label }}</strong><small>{{ item.description }}</small></span>
-        </button>
+        <section v-for="group in navigationGroups" :key="group.label" class="nav-group">
+          <span class="nav-group-label">{{ group.label }}</span>
+          <button
+            v-for="item in group.items"
+            :key="item.id"
+            type="button"
+            :class="{ active: activeSection === item.id }"
+            :aria-current="activeSection === item.id ? 'page' : undefined"
+            @click="selectSection(item.id)"
+          >
+            <span class="nav-icon">{{ item.icon }}</span>
+            <span><strong>{{ item.label }}</strong><small>{{ item.description }}</small></span>
+          </button>
+        </section>
       </nav>
-
-      <div class="sidebar-note">
-        <span>隐私优先</span>
-        <p>配置保存在浏览器本地，令牌不会上传到流畅阅读服务器。</p>
-      </div>
     </aside>
 
     <main class="workspace">
       <header class="topbar">
         <div>
-          <span class="eyebrow">偏好设置</span>
-          <h1>打造你的流畅阅读体验</h1>
-          <p>翻译服务、交互习惯与高级能力，都可以在这里精细调整。</p>
+          <span class="eyebrow">{{ activeItem.group }}</span>
+          <h1>{{ activeItem.heading }}</h1>
+          <p>{{ activeItem.summary }}</p>
         </div>
         <label class="search-box">
-          <span>⌕</span>
+          <span aria-hidden="true">⌕</span>
           <input v-model.trim="query" type="search" placeholder="搜索设置，例如：快捷键、缓存、OpenAI" />
         </label>
       </header>
 
       <div v-if="query && filteredResults.length" class="search-results">
-        <button v-for="result in filteredResults" :key="result.label" type="button" @click="selectResult(result.id)">
-          <span><strong>{{ result.label }}</strong><small>{{ result.description }}</small></span><b>前往 →</b>
+        <button v-for="result in filteredResults" :key="result.id" type="button" @click="selectResult(result.id)">
+          <span><strong>{{ result.label }}</strong><small>{{ result.searchDescription }}</small></span><b>打开 →</b>
         </button>
       </div>
       <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
 
-      <section class="settings-card" aria-label="完整设置">
+      <section class="settings-card" :aria-label="activeItem.heading">
         <div class="card-intro">
-          <span class="eyebrow">全部选项</span>
-          <h2>功能与服务</h2>
-          <p>改动会自动保存，并同步到已打开的网页。</p>
+          <span class="eyebrow">{{ activeItem.kicker }}</span>
+          <h2>{{ activeItem.title }}</h2>
+          <p>{{ activeItem.detail }}</p>
         </div>
-        <Main />
+        <Main :active-section="activeSection" />
       </section>
 
       <footer>FluentRead V{{ version }} · 为更自然的双语阅读而设计</footer>
@@ -60,60 +59,104 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import Main from '@/components/Main.vue'
+
+type NavigationItem = {
+  id: string
+  icon: string
+  label: string
+  description: string
+  group: string
+  heading: string
+  summary: string
+  kicker: string
+  title: string
+  detail: string
+  searchDescription: string
+}
 
 const version = process.env.VUE_APP_VERSION
 const query = ref('')
 const activeSection = ref('settings-general')
 
-const navigation = [
-  { id: 'settings-general', icon: '⌂', label: '通用', description: '状态与显示' },
-  { id: 'settings-services', icon: '译', label: '翻译服务', description: '语言与模型' },
-  { id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文' },
-  { id: 'settings-advanced', icon: '◇', label: '高级选项', description: '缓存、性能与模板' },
-  { id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出' },
+const navigationGroups: Array<{ label: string; items: NavigationItem[] }> = [
+  {
+    label: '基础设置',
+    items: [
+      {
+        id: 'settings-general', icon: '⌂', label: '通用设置', description: '状态与显示', group: '基础设置',
+        heading: '调整你的阅读体验', summary: '管理插件状态、翻译模式和译文的基础显示方式。',
+        kicker: '阅读偏好', title: '通用设置', detail: '常用开关集中在这里，修改后会自动保存。',
+        searchDescription: '插件启停、双语模式、译文样式与主题',
+      },
+      {
+        id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础设置',
+        heading: '选择翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，清楚管理当前服务、模型及连接参数。',
+        kicker: '翻译能力', title: '服务目录', detail: '先选择服务，再配置模型和该服务实际需要的参数。',
+        searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
+      },
+    ],
+  },
+  {
+    label: '阅读工具',
+    items: [
+      {
+        id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文', group: '阅读工具',
+        heading: '让翻译顺手发生', summary: '统一设置鼠标悬停、划词和全文翻译的触发习惯。',
+        kicker: '操作方式', title: '交互与快捷键', detail: '为高频动作选择容易记忆且不冲突的触发方式。',
+        searchDescription: '鼠标悬停、划词翻译、全文翻译与自定义按键',
+      },
+    ],
+  },
+  {
+    label: '系统与数据',
+    items: [
+      {
+        id: 'settings-advanced', icon: '◇', label: '高级选项', description: '性能与模板', group: '系统与数据',
+        heading: '精细控制运行方式', summary: '管理缓存、动画、并发、悬浮工具、代理和 AI 提示词。',
+        kicker: '运行策略', title: '高级选项', detail: '这些设置更偏向性能、兼容性和高级翻译行为。',
+        searchDescription: '缓存、动画、并发、悬浮球、输入框、代理与提示词',
+      },
+      {
+        id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出', group: '系统与数据',
+        heading: '备份与迁移配置', summary: '导出当前设置，或从已有配置恢复你的使用习惯。',
+        kicker: '数据工具', title: '配置管理', detail: '通过 JSON 完成配置备份、迁移与恢复。',
+        searchDescription: '备份、迁移、导出与导入 JSON 配置',
+      },
+    ],
+  },
 ]
 
-const searchItems = [
-  { id: 'settings-general', label: '插件状态与译文显示', description: '启停、双语模式、译文样式、主题' },
-  { id: 'settings-services', label: '翻译服务与目标语言', description: '微软翻译、OpenAI、DeepL、Gemini 等' },
-  { id: 'settings-shortcuts', label: '悬停、划词与全文快捷键', description: '设置触发方式与自定义按键' },
-  { id: 'settings-advanced', label: '缓存、动画与并发', description: '性能、输入框翻译、代理及提示词' },
-  { id: 'settings-data', label: '导入与导出配置', description: '备份或迁移本地设置' },
-]
+const navigation = navigationGroups.flatMap((group) => group.items)
+const activeItem = computed(() => navigation.find((item) => item.id === activeSection.value) || navigation[0])
 
 const filteredResults = computed(() => {
   if (!query.value) return []
   const keyword = query.value.toLocaleLowerCase()
-  return searchItems.filter((item) => `${item.label}${item.description}`.toLocaleLowerCase().includes(keyword))
+  return navigation.filter((item) =>
+    `${item.label}${item.description}${item.heading}${item.summary}${item.searchDescription}`
+      .toLocaleLowerCase()
+      .includes(keyword),
+  )
 })
 
-function scrollTo(id: string) {
+function selectSection(id: string) {
+  if (!navigation.some((item) => item.id === id)) return
   activeSection.value = id
-  document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  query.value = ''
+  history.replaceState(null, '', `#${id}`)
+  window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
 function selectResult(id: string) {
-  query.value = ''
-  requestAnimationFrame(() => scrollTo(id))
+  selectSection(id)
 }
 
-function updateActiveSection() {
-  let closest = navigation[0].id
-  let closestDistance = Number.POSITIVE_INFINITY
-  for (const item of navigation) {
-    const element = document.getElementById(item.id)
-    if (!element) continue
-    const distance = Math.abs(element.getBoundingClientRect().top - 150)
-    if (distance < closestDistance) {
-      closest = item.id
-      closestDistance = distance
-    }
+onMounted(() => {
+  const requestedSection = window.location.hash.slice(1)
+  if (navigation.some((item) => item.id === requestedSection)) {
+    activeSection.value = requestedSection
   }
-  activeSection.value = closest
-}
-
-onMounted(() => window.addEventListener('scroll', updateActiveSection, { passive: true }))
-onUnmounted(() => window.removeEventListener('scroll', updateActiveSection))
+})
 </script>

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -92,8 +92,8 @@ const navigationGroups: Array<{ label: string; items: NavigationItem[] }> = [
       },
       {
         id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础设置',
-        heading: '选择翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置之后网页翻译默认使用的服务、模型及连接参数。',
-        kicker: '翻译能力', title: '翻译服务与模型', detail: '配置默认翻译服务和模型，之后网页翻译会按此设置执行。',
+        heading: '配置翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置之后网页翻译默认使用的服务、模型及连接参数。',
+        kicker: '翻译能力', title: '翻译服务与模型', detail: '配置网页翻译默认使用的服务、模型和连接参数。',
         searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
       },
     ],

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -50,7 +50,44 @@
           <h2>{{ activeItem.title }}</h2>
           <p>{{ activeItem.detail }}</p>
         </div>
-        <Main :active-section="activeSection" />
+        <section v-if="activeSection === 'settings-about'" id="settings-about" class="about-page" aria-labelledby="about-title">
+          <div class="about-hero">
+            <img class="about-logo" src="/icon/128.png" alt="流畅阅读图标" />
+            <div>
+              <span class="eyebrow">关于流畅阅读</span>
+              <h3 id="about-title">让双语阅读自然发生</h3>
+              <p>流畅阅读是一款开源浏览器翻译插件，帮助你在阅读网页时更自然地理解不同语言的内容。</p>
+              <span class="about-version">FluentRead · V{{ version }}</span>
+            </div>
+          </div>
+
+          <div class="about-grid">
+            <article class="about-panel">
+              <span class="about-panel-kicker">核心体验</span>
+              <h3>为阅读而生</h3>
+              <p>从网页翻译到划词、悬浮与快捷键，把常用能力放在真正需要的位置。</p>
+              <div class="about-feature-list">
+                <span><b>译</b>网页双语阅读</span>
+                <span><b>⌘</b>顺手的阅读工具</span>
+                <span><b>AI</b>灵活的翻译服务</span>
+              </div>
+            </article>
+
+            <article class="about-panel about-links-panel">
+              <span class="about-panel-kicker">了解更多</span>
+              <h3>一起让它变得更好</h3>
+              <p>查看项目代码、使用文档，或反馈你在阅读中的想法。</p>
+              <div class="about-links">
+                <a href="https://github.com/Bistutu/FluentRead" target="_blank" rel="noreferrer">开源项目 <span>↗</span></a>
+                <a href="https://fluent.thinkstu.com/" target="_blank" rel="noreferrer">使用文档 <span>↗</span></a>
+                <a href="https://github.com/Bistutu/FluentRead/issues" target="_blank" rel="noreferrer">问题反馈 <span>↗</span></a>
+              </div>
+            </article>
+          </div>
+
+          <p class="about-footer">感谢你使用流畅阅读。</p>
+        </section>
+        <Main v-else :active-section="activeSection" />
       </section>
 
       <footer>FluentRead V{{ version }} · 为更自然的双语阅读而设计</footer>
@@ -123,6 +160,17 @@ const navigationGroups: Array<{ label: string; items: NavigationItem[] }> = [
         heading: '备份与迁移配置', summary: '导出当前设置，或从已有配置恢复你的使用习惯。',
         kicker: '数据工具', title: '配置管理', detail: '通过 JSON 完成配置备份、迁移与恢复。',
         searchDescription: '备份、迁移、导出与导入 JSON 配置',
+      },
+    ],
+  },
+  {
+    label: '关于',
+    items: [
+      {
+        id: 'settings-about', icon: 'i', label: '关于流畅阅读', description: '版本与项目', group: '关于',
+        heading: '关于流畅阅读', summary: '了解插件版本、核心体验与项目入口。',
+        kicker: '关于项目', title: '关于流畅阅读', detail: '一个让双语阅读更自然的开源浏览器翻译插件。',
+        searchDescription: '版本、开源项目、使用文档与问题反馈',
       },
     ],
   },

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -45,7 +45,7 @@
       <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
 
       <section class="settings-card" :class="{ 'services-view': activeSection === 'settings-services' }" :aria-label="activeItem.heading">
-        <div v-if="activeSection !== 'settings-services'" class="card-intro">
+        <div v-if="!['settings-services', 'settings-about'].includes(activeSection)" class="card-intro">
           <span class="eyebrow">{{ activeItem.kicker }}</span>
           <h2>{{ activeItem.title }}</h2>
           <p>{{ activeItem.detail }}</p>

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="settings-app">
+    <aside class="sidebar">
+      <div class="brand">
+        <img src="/icon/128.png" alt="" />
+        <div><strong>流畅阅读</strong><small>FluentRead · V{{ version }}</small></div>
+      </div>
+
+      <nav aria-label="设置分类">
+        <button
+          v-for="item in navigation"
+          :key="item.id"
+          type="button"
+          :class="{ active: activeSection === item.id }"
+          @click="scrollTo(item.id)"
+        >
+          <span class="nav-icon">{{ item.icon }}</span>
+          <span><strong>{{ item.label }}</strong><small>{{ item.description }}</small></span>
+        </button>
+      </nav>
+
+      <div class="sidebar-note">
+        <span>隐私优先</span>
+        <p>配置保存在浏览器本地，令牌不会上传到流畅阅读服务器。</p>
+      </div>
+    </aside>
+
+    <main class="workspace">
+      <header class="topbar">
+        <div>
+          <span class="eyebrow">偏好设置</span>
+          <h1>打造你的流畅阅读体验</h1>
+          <p>翻译服务、交互习惯与高级能力，都可以在这里精细调整。</p>
+        </div>
+        <label class="search-box">
+          <span>⌕</span>
+          <input v-model.trim="query" type="search" placeholder="搜索设置，例如：快捷键、缓存、OpenAI" />
+        </label>
+      </header>
+
+      <div v-if="query && filteredResults.length" class="search-results">
+        <button v-for="result in filteredResults" :key="result.label" type="button" @click="selectResult(result.id)">
+          <span><strong>{{ result.label }}</strong><small>{{ result.description }}</small></span><b>前往 →</b>
+        </button>
+      </div>
+      <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
+
+      <section class="settings-card" aria-label="完整设置">
+        <div class="card-intro">
+          <span class="eyebrow">全部选项</span>
+          <h2>功能与服务</h2>
+          <p>改动会自动保存，并同步到已打开的网页。</p>
+        </div>
+        <Main />
+      </section>
+
+      <footer>FluentRead V{{ version }} · 为更自然的双语阅读而设计</footer>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import Main from '@/components/Main.vue'
+
+const version = process.env.VUE_APP_VERSION
+const query = ref('')
+const activeSection = ref('settings-general')
+
+const navigation = [
+  { id: 'settings-general', icon: '⌂', label: '通用', description: '状态与显示' },
+  { id: 'settings-services', icon: '译', label: '翻译服务', description: '语言与模型' },
+  { id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文' },
+  { id: 'settings-advanced', icon: '◇', label: '高级选项', description: '缓存、性能与模板' },
+  { id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出' },
+]
+
+const searchItems = [
+  { id: 'settings-general', label: '插件状态与译文显示', description: '启停、双语模式、译文样式、主题' },
+  { id: 'settings-services', label: '翻译服务与目标语言', description: '微软翻译、OpenAI、DeepL、Gemini 等' },
+  { id: 'settings-shortcuts', label: '悬停、划词与全文快捷键', description: '设置触发方式与自定义按键' },
+  { id: 'settings-advanced', label: '缓存、动画与并发', description: '性能、输入框翻译、代理及提示词' },
+  { id: 'settings-data', label: '导入与导出配置', description: '备份或迁移本地设置' },
+]
+
+const filteredResults = computed(() => {
+  if (!query.value) return []
+  const keyword = query.value.toLocaleLowerCase()
+  return searchItems.filter((item) => `${item.label}${item.description}`.toLocaleLowerCase().includes(keyword))
+})
+
+function scrollTo(id: string) {
+  activeSection.value = id
+  document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function selectResult(id: string) {
+  query.value = ''
+  requestAnimationFrame(() => scrollTo(id))
+}
+
+function updateActiveSection() {
+  let closest = navigation[0].id
+  let closestDistance = Number.POSITIVE_INFINITY
+  for (const item of navigation) {
+    const element = document.getElementById(item.id)
+    if (!element) continue
+    const distance = Math.abs(element.getBoundingClientRect().top - 150)
+    if (distance < closestDistance) {
+      closest = item.id
+      closestDistance = distance
+    }
+  }
+  activeSection.value = closest
+}
+
+onMounted(() => window.addEventListener('scroll', updateActiveSection, { passive: true }))
+onUnmounted(() => window.removeEventListener('scroll', updateActiveSection))
+</script>

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -90,7 +90,6 @@
         <Main v-else :active-section="activeSection" />
       </section>
 
-      <footer>FluentRead V{{ version }} · 为更自然的双语阅读而设计</footer>
     </main>
   </div>
 </template>

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -44,7 +44,7 @@
       </div>
       <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
 
-      <section class="settings-card" :aria-label="activeItem.heading">
+      <section class="settings-card" :class="{ 'services-view': activeSection === 'settings-services' }" :aria-label="activeItem.heading">
         <div class="card-intro">
           <span class="eyebrow">{{ activeItem.kicker }}</span>
           <h2>{{ activeItem.title }}</h2>

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="manifest.open_in_tab" content="true" />
+    <title>流畅阅读设置</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -1,0 +1,78 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './style.css'
+import 'element-plus/dist/index.css'
+import {
+  ElButton,
+  ElCollapse,
+  ElCollapseItem,
+  ElCol,
+  ElDialog,
+  ElDivider,
+  ElEmpty,
+  ElIcon,
+  ElInput,
+  ElInputNumber,
+  ElLink,
+  ElMessage,
+  ElOption,
+  ElOptionGroup,
+  ElRow,
+  ElSelect,
+  ElSwitch,
+  ElText,
+  ElTooltip,
+} from 'element-plus'
+import {
+  ChatDotRound,
+  CircleCheckFilled,
+  Coffee,
+  Download,
+  Edit,
+  Loading,
+  Refresh,
+  Setting,
+  Star,
+  Upload,
+  Warning,
+  WarningFilled,
+} from '@element-plus/icons-vue'
+
+const app = createApp(App)
+
+const components = [
+  ElButton,
+  ElCollapse,
+  ElCollapseItem,
+  ElCol,
+  ElDialog,
+  ElDivider,
+  ElEmpty,
+  ElIcon,
+  ElInput,
+  ElInputNumber,
+  ElLink,
+  ElOption,
+  ElOptionGroup,
+  ElRow,
+  ElSelect,
+  ElSwitch,
+  ElText,
+  ElTooltip,
+]
+
+components.forEach((component) => component.name && app.component(component.name, component))
+app.component('ChatDotRound', ChatDotRound)
+app.component('CircleCheckFilled', CircleCheckFilled)
+app.component('Coffee', Coffee)
+app.component('Download', Download)
+app.component('Edit', Edit)
+app.component('Loading', Loading)
+app.component('Refresh', Refresh)
+app.component('Setting', Setting)
+app.component('Star', Star)
+app.component('Upload', Upload)
+app.component('Warning', Warning)
+app.component('WarningFilled', WarningFilled)
+
+app.mount('#app')

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -1,0 +1,79 @@
+export type NavigationItem = {
+  id: string
+  icon: string
+  label: string
+  description: string
+  group: string
+  heading: string
+  summary: string
+  kicker: string
+  title: string
+  detail: string
+  searchDescription: string
+}
+
+export type NavigationGroup = {
+  label: string
+  items: NavigationItem[]
+}
+
+export const navigationGroups: NavigationGroup[] = [
+  {
+    label: '基础设置',
+    items: [
+      {
+        id: 'settings-general', icon: '⌂', label: '通用设置', description: '状态与显示', group: '基础设置',
+        heading: '调整你的阅读体验', summary: '管理插件状态、翻译模式和译文的基础显示方式。',
+        kicker: '阅读偏好', title: '通用设置', detail: '常用开关集中在这里，修改后会自动保存。',
+        searchDescription: '插件启停、双语模式、译文样式与主题',
+      },
+      {
+        id: 'settings-services', icon: '译', label: '翻译服务', description: '服务与模型', group: '基础设置',
+        heading: '配置翻译服务与模型', summary: '按机器翻译和 AI 翻译分类，配置之后网页翻译默认使用的服务、模型及连接参数。',
+        kicker: '翻译能力', title: '翻译服务与模型', detail: '配置网页翻译默认使用的服务、模型和连接参数。',
+        searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
+      },
+    ],
+  },
+  {
+    label: '阅读工具',
+    items: [
+      {
+        id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文', group: '阅读工具',
+        heading: '让翻译顺手发生', summary: '统一设置鼠标悬停、划词和全文翻译的触发习惯。',
+        kicker: '操作方式', title: '交互与快捷键', detail: '为高频动作选择容易记忆且不冲突的触发方式。',
+        searchDescription: '鼠标悬停、划词翻译、全文翻译与自定义按键',
+      },
+    ],
+  },
+  {
+    label: '系统与数据',
+    items: [
+      {
+        id: 'settings-advanced', icon: '◇', label: '高级选项', description: '性能与模板', group: '系统与数据',
+        heading: '精细控制运行方式', summary: '管理缓存、动画、并发、悬浮工具、代理和 AI 提示词。',
+        kicker: '运行策略', title: '高级选项', detail: '这些设置更偏向性能、兼容性和高级翻译行为。',
+        searchDescription: '缓存、动画、并发、悬浮球、输入框、代理与提示词',
+      },
+      {
+        id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出', group: '系统与数据',
+        heading: '备份与迁移配置', summary: '导出当前设置，或从已有配置恢复你的使用习惯。',
+        kicker: '数据工具', title: '配置管理', detail: '通过 JSON 完成配置备份、迁移与恢复。',
+        searchDescription: '备份、迁移、导出与导入 JSON 配置',
+      },
+    ],
+  },
+  {
+    label: '关于',
+    items: [
+      {
+        id: 'settings-about', icon: 'i', label: '关于流畅阅读', description: '版本与项目', group: '关于',
+        heading: '关于流畅阅读', summary: '了解插件版本、核心体验与项目入口。',
+        kicker: '关于项目', title: '关于流畅阅读', detail: '一个让双语阅读更自然的开源浏览器翻译插件。',
+        searchDescription: '版本、开源项目、使用文档与问题反馈',
+      },
+    ],
+  },
+]
+
+export const navigationItems = navigationGroups.flatMap((group) => group.items)

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -1,0 +1,140 @@
+:root {
+  font-family: Inter, "SF Pro Display", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  color: #172033;
+  background: #f5f6fa;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --brand: #ef4776;
+  --brand-strong: #dc315f;
+  --brand-soft: #fff0f4;
+  --ink: #172033;
+  --muted: #737c8f;
+  --line: #e5e8ef;
+  --surface: #fff;
+  --surface-soft: #f7f8fb;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body { margin: 0; min-width: 920px; background: #f5f6fa; }
+button, input { font: inherit; }
+button:focus-visible, input:focus-visible { outline: 3px solid rgba(239, 71, 118, .2); outline-offset: 2px; }
+
+.settings-app { min-height: 100vh; }
+.sidebar {
+  position: fixed; inset: 0 auto 0 0; z-index: 5; display: flex; width: 252px; padding: 28px 20px 22px;
+  flex-direction: column; border-right: 1px solid var(--line); background: rgba(255, 255, 255, .88);
+  backdrop-filter: blur(18px);
+}
+.brand { display: flex; align-items: center; gap: 12px; padding: 0 8px 28px; }
+.brand img { width: 46px; height: 46px; border-radius: 14px; box-shadow: 0 10px 22px rgba(239, 71, 118, .22); }
+.brand div, nav button > span:last-child { display: flex; flex-direction: column; min-width: 0; }
+.brand strong { font-size: 18px; }
+.brand small { margin-top: 3px; color: var(--muted); font-size: 11px; }
+nav { display: grid; gap: 6px; }
+nav button {
+  display: grid; grid-template-columns: 34px 1fr; align-items: center; gap: 11px; width: 100%; padding: 11px 12px;
+  border: 1px solid transparent; border-radius: 13px; color: var(--ink); background: transparent; text-align: left; cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+nav button:hover { background: var(--surface-soft); transform: translateX(2px); }
+nav button.active { border-color: rgba(239, 71, 118, .16); color: var(--brand-strong); background: var(--brand-soft); }
+.nav-icon { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; background: var(--surface); font-size: 14px; font-weight: 800; }
+nav strong { font-size: 13px; }
+nav small { margin-top: 2px; color: var(--muted); font-size: 10px; }
+.sidebar-note { margin-top: auto; padding: 15px; border: 1px solid #dceee7; border-radius: 15px; background: #f1faf6; }
+.sidebar-note span { color: #18835d; font-size: 11px; font-weight: 750; }
+.sidebar-note p { margin: 6px 0 0; color: #527064; font-size: 10px; line-height: 1.55; }
+
+.workspace { width: min(980px, calc(100% - 300px)); margin-left: 252px; padding: 48px 52px 60px; }
+.topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 32px; margin-bottom: 30px; }
+.eyebrow { display: block; margin-bottom: 7px; color: var(--brand-strong); font-size: 11px; font-weight: 780; letter-spacing: .12em; }
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.035em; }
+.topbar p, .card-intro p { margin-bottom: 0; color: var(--muted); font-size: 13px; }
+.search-box {
+  display: flex; align-items: center; gap: 10px; width: 310px; height: 46px; padding: 0 15px;
+  border: 1px solid var(--line); border-radius: 14px; background: var(--surface); box-shadow: 0 8px 24px rgba(31, 40, 61, .05);
+}
+.search-box > span { color: var(--muted); font-size: 20px; }
+.search-box input { width: 100%; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 12px; }
+.search-box input::placeholder { color: #9ca3b2; }
+.search-results, .search-empty { margin: -14px 0 22px; padding: 10px; border: 1px solid var(--line); border-radius: 16px; background: var(--surface); }
+.search-results { display: grid; gap: 4px; }
+.search-results button { display: flex; align-items: center; justify-content: space-between; padding: 11px 12px; border: 0; border-radius: 10px; background: transparent; text-align: left; cursor: pointer; }
+.search-results button:hover { background: var(--surface-soft); }
+.search-results span { display: flex; flex-direction: column; }
+.search-results strong { font-size: 12px; }
+.search-results small, .search-empty { color: var(--muted); font-size: 10px; }
+.search-results b { color: var(--brand-strong); font-size: 10px; }
+.search-empty { padding: 18px; text-align: center; }
+
+.settings-card { padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); }
+.card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
+.card-intro h2 { margin-bottom: 6px; font-size: 21px; }
+.settings-card > div:last-child > .el-row,
+.settings-card > div:last-child > div > .el-row,
+.settings-card > div:last-child > div > .el-collapse {
+  scroll-margin-top: 28px;
+}
+.settings-card .el-row { min-height: 52px; margin-right: 0 !important; margin-left: 0 !important; padding: 8px 12px; border-radius: 12px; }
+.settings-card .el-row:hover { background: var(--surface-soft); }
+.settings-card .lightblue { background: transparent !important; }
+.settings-card .popup-text { color: var(--ink); font-size: 13px; font-weight: 650; }
+.settings-card .el-select, .settings-card .el-input, .settings-card .el-input-number { max-width: 360px; }
+.settings-card .el-collapse { margin: 18px 0 0 !important; border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
+.settings-card .el-collapse-item__header { height: 56px; padding: 0 18px; border: 0; font-size: 14px; font-weight: 700; }
+.settings-card .el-collapse-item__wrap { border: 0; }
+.settings-card .el-collapse-item__content { padding: 4px 16px 18px; }
+.settings-card .el-divider__text { color: var(--muted); font-size: 11px; }
+.workspace > footer { margin-top: 22px; color: var(--muted); font-size: 10px; text-align: center; }
+
+@media (max-width: 1050px) {
+  body { min-width: 720px; }
+  .sidebar { width: 210px; }
+  .workspace { width: calc(100% - 210px); margin-left: 210px; padding: 36px 28px 50px; }
+  .topbar { align-items: stretch; flex-direction: column; }
+  .search-box { width: 100%; }
+}
+
+@media (max-width: 700px) {
+  body { min-width: 0; }
+  .sidebar {
+    position: static; width: 100%; padding: 16px 14px 14px;
+    border-right: 0; border-bottom: 1px solid var(--line); backdrop-filter: blur(14px);
+  }
+  .brand { gap: 10px; padding: 0 4px 14px; }
+  .brand img { width: 40px; height: 40px; border-radius: 12px; }
+  .brand strong { font-size: 16px; }
+  nav { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+  nav button { grid-template-columns: 28px minmax(0, 1fr); gap: 8px; min-width: 0; padding: 8px; }
+  nav button:last-child { grid-column: 1 / -1; }
+  .nav-icon { width: 28px; height: 28px; border-radius: 9px; }
+  nav strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+  nav small, .sidebar-note { display: none; }
+  .workspace { width: 100%; margin-left: 0; padding: 24px 14px 36px; }
+  .topbar { gap: 18px; margin-bottom: 20px; }
+  h1 { font-size: 25px; }
+  .topbar p { font-size: 12px; line-height: 1.55; }
+  .search-box { height: 44px; }
+  .settings-card { padding: 20px 8px 14px; border-radius: 20px; }
+  .card-intro { margin: 0 10px 16px; padding-bottom: 16px; }
+  .card-intro h2 { font-size: 19px; }
+  .settings-card .el-row {
+    display: flex; min-height: 0; gap: 8px; padding: 10px 8px;
+    flex-wrap: wrap;
+  }
+  .settings-card .el-row > .el-col { max-width: 100%; flex: 0 0 100%; }
+  .settings-card .el-row > .flex-end { justify-content: flex-start; }
+  .settings-card .el-select,
+  .settings-card .el-input,
+  .settings-card .el-input-number { width: 100%; max-width: none; }
+  .settings-card .margin-left-2em { margin-right: 0 !important; margin-left: 0 !important; }
+  .settings-card .el-collapse-item__header { padding: 0 14px; }
+  .settings-card .el-collapse-item__content { padding: 4px 8px 14px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
+}

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -93,6 +93,28 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 .settings-card .el-row .popup-text { display: inline-flex; align-items: center; min-height: 34px; }
 .settings-card .lightblue { background: transparent !important; }
 .settings-card .popup-text { color: var(--ink); font-size: 13px; font-weight: 650; }
+.settings-card .settings-preference-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) clamp(220px, 32vw, 360px);
+  align-items: center;
+  gap: 18px;
+}
+.settings-card .settings-preference-row > .el-col {
+  width: auto !important;
+  max-width: none !important;
+  min-width: 0;
+  flex: 0 0 auto !important;
+}
+.settings-card .settings-preference-row > .el-col:last-child {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+.settings-card .settings-preference-row > .el-col:last-child > .el-select {
+  width: 100% !important;
+  max-width: 360px !important;
+  min-width: 0;
+}
 .settings-card .el-select, .settings-card .el-input, .settings-card .el-input-number { max-width: 360px; }
 .settings-card .el-select,
 .settings-card .el-input,
@@ -304,6 +326,13 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   }
   .settings-card .el-row > .el-col { max-width: 100%; flex: 0 0 100%; }
   .settings-card .el-row > .flex-end { justify-content: flex-start; }
+  .settings-card .settings-preference-row {
+    grid-template-columns: minmax(0, 1fr) clamp(200px, 32vw, 300px);
+    gap: 12px;
+  }
+  .settings-card .settings-preference-row > .el-col { width: auto !important; max-width: none; flex: 0 0 auto; }
+  .settings-card .settings-preference-row > .el-col:last-child { justify-content: flex-end; }
+  .settings-card .settings-preference-row > .el-col:last-child > .el-select { max-width: 100% !important; }
   .settings-card .el-select,
   .settings-card .el-input,
   .settings-card .el-input-number { width: 100%; max-width: none; }
@@ -339,6 +368,11 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 }
 
 @media (max-width: 480px) {
+  .settings-card .settings-preference-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 9px;
+  }
+  .settings-card .settings-preference-row > .el-col:last-child { justify-content: stretch; }
   .settings-card .settings-control-row {
     grid-template-columns: minmax(0, 1fr);
     gap: 9px;

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -17,11 +17,11 @@
 
 * { box-sizing: border-box; }
 html { height: 100%; scroll-behavior: smooth; }
-body { height: 100%; margin: 0; min-width: 920px; overflow: hidden; background: #f5f6fa; }
+body { height: 100%; margin: 0; min-width: 0; overflow: hidden; background: #f5f6fa; }
 button, input { font: inherit; }
 button:focus-visible, input:focus-visible { outline: 3px solid rgba(239, 71, 118, .2); outline-offset: 2px; }
 
-.settings-app { display: flex; height: 100vh; min-height: 0; overflow: hidden; }
+.settings-app { display: flex; width: 100%; height: 100vh; min-height: 0; overflow: hidden; }
 .sidebar {
   position: relative; z-index: 5; display: flex; flex: 0 0 252px; width: 252px; height: 100vh; min-height: 0; padding: 28px 20px 22px;
   flex-direction: column; border-right: 1px solid var(--line); background: rgba(255, 255, 255, .88);
@@ -45,11 +45,11 @@ nav button.active { border-color: rgba(239, 71, 118, .16); color: var(--brand-st
 .nav-icon { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; background: var(--surface); font-size: 14px; font-weight: 800; }
 nav strong { font-size: 13px; }
 nav small { margin-top: 2px; color: var(--muted); font-size: 10px; }
-.workspace { display: flex; width: min(1180px, calc(100% - 252px)); height: 100vh; min-height: 0; margin-left: 0; padding: 42px 44px 24px; flex-direction: column; }
-.topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 32px; margin-bottom: 30px; }
+.workspace { display: flex; width: auto; height: 100vh; min-width: 0; min-height: 0; margin-left: 0; padding: 30px 44px 20px; flex: 1 1 auto; flex-direction: column; overflow: hidden; }
+.topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 28px; margin-bottom: 22px; }
 .eyebrow { display: block; margin-bottom: 7px; color: var(--brand-strong); font-size: 11px; font-weight: 780; letter-spacing: .12em; }
 h1, h2, p { margin-top: 0; }
-h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.035em; }
+h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.035em; }
 .topbar p, .card-intro p { margin-bottom: 0; color: var(--muted); font-size: 13px; }
 .search-box {
   display: flex; align-items: center; gap: 10px; width: 310px; height: 46px; padding: 0 15px;
@@ -68,9 +68,9 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .search-results b { color: var(--brand-strong); font-size: 10px; }
 .search-empty { padding: 18px; text-align: center; }
 
-.settings-card { min-height: 0; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); flex: 1; overflow: auto; }
+.settings-card { width: 100%; min-height: 0; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); flex: 1 1 auto; overflow: auto; }
 .settings-card.services-view {
-  display: flex; width: calc(100% + 72px); margin-right: -36px; margin-left: -36px; padding: 0; border-right: 0; border-left: 0; border-radius: 0;
+  display: flex; width: calc(100% + 88px); margin-right: -44px; margin-left: -44px; padding: 0; border-right: 0; border-left: 0; border-radius: 0;
   flex-direction: column; overflow: hidden;
 }
 .settings-card.services-view > .card-intro { margin: 0; padding: 28px 28px 22px; }
@@ -146,22 +146,18 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .about-links a:hover { border-color: #ef9ab1; color: var(--brand-strong); transform: translateX(2px); }
 .about-links a span { color: var(--brand-strong); font-size: 16px; }
 .about-footer { margin: 0; color: var(--muted); font-size: 11px; text-align: center; }
-.workspace > footer { margin-top: 22px; color: var(--muted); font-size: 10px; text-align: center; }
-.workspace > footer { flex: 0 0 auto; }
-
 @media (max-width: 1050px) {
-  body { min-width: 720px; }
+  body { min-width: 0; }
   .sidebar { flex-basis: 210px; width: 210px; }
-  .workspace { width: calc(100% - 210px); padding: 36px 28px 24px; }
-  .settings-card.services-view { width: calc(100% + 40px); margin-right: -20px; margin-left: -20px; }
+  .workspace { width: auto; padding: 28px 28px 20px; }
+  .settings-card.services-view { width: calc(100% + 56px); margin-right: -28px; margin-left: -28px; }
   .topbar { align-items: stretch; flex-direction: column; }
   .search-box { width: 100%; }
 }
 
 @media (max-width: 700px) {
   body { min-width: 0; }
-  body { overflow: auto; }
-  .settings-app { display: block; height: auto; min-height: 100vh; overflow: visible; }
+  .settings-app { display: flex; height: 100vh; min-height: 0; flex-direction: column; overflow: hidden; }
   .sidebar {
     position: static; flex-basis: auto; width: 100%; height: auto; padding: 16px 14px 14px;
     border-right: 0; border-bottom: 1px solid var(--line); backdrop-filter: blur(14px);
@@ -177,14 +173,18 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   .nav-icon { width: 28px; height: 28px; border-radius: 9px; }
   nav strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
   nav small { display: none; }
-  .workspace { width: 100%; height: auto; min-height: 0; padding: 24px 14px 36px; }
+  .workspace { width: 100%; height: auto; min-height: 0; padding: 24px 14px; flex: 1 1 auto; overflow: hidden; }
   .topbar { gap: 18px; margin-bottom: 20px; }
   h1 { font-size: 25px; }
   .topbar p { font-size: 12px; line-height: 1.55; }
   .search-box { height: 44px; }
   .settings-card { padding: 20px 8px 14px; border-radius: 20px; }
-  .settings-card.services-view { display: block; width: 100%; margin-right: 0; margin-left: 0; border-right: 1px solid var(--line); border-left: 1px solid var(--line); border-radius: 20px; overflow: visible; }
-  .settings-card.services-view .service-catalog { height: auto !important; flex: 0 0 auto; }
+  .settings-card.services-view { display: flex; width: 100%; margin-right: 0; margin-left: 0; border-right: 1px solid var(--line); border-left: 1px solid var(--line); border-radius: 20px; overflow: hidden; }
+  .settings-card.services-view .service-catalog { height: 100% !important; min-height: 0 !important; flex: 1 1 auto; }
+  .settings-card.services-view .service-catalog .catalog-layout { display: flex; min-height: 0; flex: 1 1 auto; flex-direction: column; overflow: hidden; }
+  .settings-card.services-view .service-catalog .service-rail { min-height: 0; max-height: 190px; flex: 0 0 190px; overflow-y: auto; }
+  .settings-card.services-view .service-catalog .service-detail { min-height: 0; flex: 1 1 auto; overflow: hidden; }
+  .settings-card.services-view .service-catalog .service-configuration-slot { max-height: none; overflow-y: auto; }
   .card-intro { margin: 0 10px 16px; padding-bottom: 16px; }
   .card-intro h2 { font-size: 19px; }
   .settings-card .el-row {

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -69,10 +69,18 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .search-empty { padding: 18px; text-align: center; }
 
 .settings-card { min-height: 0; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); flex: 1; overflow: auto; }
-.settings-card.services-view { overflow: auto; }
-.settings-card.services-view { padding: 0; }
+.settings-card.services-view {
+  display: flex; width: calc(100% + 72px); margin-right: -36px; margin-left: -36px; padding: 0; border-right: 0; border-left: 0; border-radius: 0;
+  flex-direction: column; overflow: hidden;
+}
 .settings-card.services-view > .card-intro { margin: 0; padding: 28px 28px 22px; }
-.settings-card.services-view .service-catalog { margin: 0; border-right: 0; border-left: 0; border-radius: 0; }
+.settings-card.services-view > .settings-main-sections { display: flex; height: 100%; min-height: 0; flex: 1 1 0%; flex-direction: column; }
+.settings-card.services-view #settings-services { display: flex !important; min-height: 0; flex: 1 1 0%; flex-direction: column; }
+.settings-card.services-view .service-catalog { min-height: 0 !important; height: 0 !important; margin: 0; border-right: 0; border-left: 0; border-radius: 0; flex: 1 1 0%; }
+.settings-card.services-view .service-catalog .catalog-layout { min-height: 0; overflow: hidden; }
+.settings-card.services-view .service-configuration-slot .service-connection-section { margin-top: 0; padding-top: 0; border-top: 0; }
+.settings-card.services-view .service-configuration-slot .subsection-heading { margin-right: 0; margin-left: 0; }
+.settings-card.services-view .service-configuration-slot .el-row { margin-right: 0 !important; margin-left: 0 !important; }
 .card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
 .card-intro h2 { margin-bottom: 6px; font-size: 21px; }
 .settings-card > div:last-child > .el-row,
@@ -123,6 +131,7 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   body { min-width: 720px; }
   .sidebar { flex-basis: 210px; width: 210px; }
   .workspace { width: calc(100% - 210px); padding: 36px 28px 24px; }
+  .settings-card.services-view { width: calc(100% + 40px); margin-right: -20px; margin-left: -20px; }
   .topbar { align-items: stretch; flex-direction: column; }
   .search-box { width: 100%; }
 }
@@ -152,6 +161,8 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   .topbar p { font-size: 12px; line-height: 1.55; }
   .search-box { height: 44px; }
   .settings-card { padding: 20px 8px 14px; border-radius: 20px; }
+  .settings-card.services-view { display: block; width: 100%; margin-right: 0; margin-left: 0; border-right: 1px solid var(--line); border-left: 1px solid var(--line); border-radius: 20px; overflow: visible; }
+  .settings-card.services-view .service-catalog { height: auto !important; flex: 0 0 auto; }
   .card-intro { margin: 0 10px 16px; padding-bottom: 16px; }
   .card-intro h2 { font-size: 19px; }
   .settings-card .el-row {

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -119,6 +119,104 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 .settings-card .el-select__caret { color: #7d8799; font-size: 16px; }
 .settings-card .el-input-group__prepend,
 .settings-card .el-input-group__append { border-color: #e2e6ef; background: #f8f9fc; }
+
+/* 设置项使用固定的标签列与控件列，避免浏览器缩放后由 el-col 的百分比宽度互相挤压。 */
+.settings-card .settings-control-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) clamp(200px, 32vw, 360px);
+  align-items: center;
+  gap: 18px;
+  min-height: 76px;
+  margin: 0 0 12px !important;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--surface-soft);
+  box-sizing: border-box;
+}
+.settings-card .settings-control-row:hover {
+  border-color: #efb5c5;
+  background: var(--surface);
+  box-shadow: 0 8px 22px rgba(31, 40, 61, .045);
+}
+.settings-card .settings-control-row > .el-col {
+  width: auto !important;
+  max-width: none !important;
+  min-width: 0;
+  flex: 0 0 auto !important;
+}
+.settings-card .settings-control-label {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+.settings-card .settings-control-label .popup-text {
+  min-width: 0;
+  line-height: 1.45;
+}
+.settings-card .settings-control-field {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  min-width: 0;
+}
+.settings-card .settings-control-field > .el-select,
+.settings-card .settings-control-field > .el-input,
+.settings-card .settings-control-field > .el-input-number,
+.settings-card .settings-control-field > .hotkey-config {
+  width: 100% !important;
+  max-width: 360px !important;
+  min-width: 0;
+}
+.settings-card .settings-control-field > .el-switch {
+  flex: 0 0 auto;
+}
+.settings-card .settings-control-row .hotkey-config {
+  display: grid;
+  gap: 8px;
+}
+.settings-card .settings-control-row .el-select__wrapper,
+.settings-card .settings-control-row .el-input__wrapper,
+.settings-card .settings-control-row .el-input-number .el-input__wrapper {
+  min-height: 44px;
+  padding: 0 14px;
+  border-color: #dfe4ed;
+  border-radius: 13px;
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(31, 40, 61, .035);
+}
+.settings-card .settings-control-row .el-select__selected-item,
+.settings-card .settings-control-row .el-input__inner,
+.settings-card .settings-control-row .el-input-number .el-input__inner {
+  font-size: 14px;
+}
+.settings-card .settings-control-row .el-switch,
+.settings-card .settings-control-row .settings-toggle {
+  --el-switch-on-color: var(--brand);
+  --el-switch-off-color: #dfe3eb;
+  width: 52px !important;
+  height: 30px !important;
+}
+.settings-card .settings-control-row .el-switch__core {
+  width: 52px !important;
+  min-width: 52px !important;
+  height: 30px !important;
+  border: 0;
+  border-radius: 999px;
+}
+.settings-card .settings-control-row .el-switch__action {
+  width: 24px;
+  height: 24px;
+}
+.settings-card .settings-control-row .custom-hotkey-display {
+  min-height: 42px;
+  height: auto;
+  padding: 6px 7px 6px 11px;
+  border-color: #dfe4ed;
+  border-radius: 13px;
+  background: var(--surface);
+}
 .settings-card .el-collapse { margin: 18px 0 0 !important; border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
 .settings-card .el-collapse-item__header { height: 56px; padding: 0 18px; border: 0; font-size: 14px; font-weight: 700; }
 .settings-card .el-collapse-item__wrap { border: 0; }
@@ -196,6 +294,28 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .settings-card .el-select,
   .settings-card .el-input,
   .settings-card .el-input-number { width: 100%; max-width: none; }
+  .settings-card .settings-control-row {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) clamp(200px, 32vw, 300px);
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+  }
+  .settings-card .settings-control-row > .el-col {
+    width: auto !important;
+    max-width: none !important;
+    flex: 0 0 auto !important;
+  }
+  .settings-card .settings-control-row > .settings-control-field {
+    justify-content: flex-end;
+  }
+  .settings-card .settings-control-field > .el-select,
+  .settings-card .settings-control-field > .el-input,
+  .settings-card .settings-control-field > .el-input-number,
+  .settings-card .settings-control-field > .hotkey-config {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
   .settings-card .margin-left-2em { margin-right: 0 !important; margin-left: 0 !important; }
   .settings-card .el-collapse-item__header { padding: 0 14px; }
   .settings-card .el-collapse-item__content { padding: 4px 8px 14px; }
@@ -203,6 +323,16 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .about-logo { width: 64px; height: 64px; border-radius: 18px; }
   .about-hero h3 { font-size: 21px; }
   .about-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 480px) {
+  .settings-card .settings-control-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 9px;
+  }
+  .settings-card .settings-control-row > .settings-control-field {
+    justify-content: stretch;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -16,14 +16,14 @@
 }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body { margin: 0; min-width: 920px; background: #f5f6fa; }
+html { height: 100%; scroll-behavior: smooth; }
+body { height: 100%; margin: 0; min-width: 920px; overflow: hidden; background: #f5f6fa; }
 button, input { font: inherit; }
 button:focus-visible, input:focus-visible { outline: 3px solid rgba(239, 71, 118, .2); outline-offset: 2px; }
 
-.settings-app { min-height: 100vh; }
+.settings-app { display: flex; height: 100vh; min-height: 0; overflow: hidden; }
 .sidebar {
-  position: fixed; inset: 0 auto 0 0; z-index: 5; display: flex; width: 252px; padding: 28px 20px 22px;
+  position: relative; z-index: 5; display: flex; flex: 0 0 252px; width: 252px; height: 100vh; min-height: 0; padding: 28px 20px 22px;
   flex-direction: column; border-right: 1px solid var(--line); background: rgba(255, 255, 255, .88);
   backdrop-filter: blur(18px);
 }
@@ -45,7 +45,7 @@ nav button.active { border-color: rgba(239, 71, 118, .16); color: var(--brand-st
 .nav-icon { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; background: var(--surface); font-size: 14px; font-weight: 800; }
 nav strong { font-size: 13px; }
 nav small { margin-top: 2px; color: var(--muted); font-size: 10px; }
-.workspace { width: min(1180px, calc(100% - 252px)); margin-left: 252px; padding: 42px 44px 60px; }
+.workspace { display: flex; width: min(1180px, calc(100% - 252px)); height: 100vh; min-height: 0; margin-left: 0; padding: 42px 44px 24px; flex-direction: column; }
 .topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 32px; margin-bottom: 30px; }
 .eyebrow { display: block; margin-bottom: 7px; color: var(--brand-strong); font-size: 11px; font-weight: 780; letter-spacing: .12em; }
 h1, h2, p { margin-top: 0; }
@@ -68,7 +68,11 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .search-results b { color: var(--brand-strong); font-size: 10px; }
 .search-empty { padding: 18px; text-align: center; }
 
-.settings-card { min-height: 430px; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); }
+.settings-card { min-height: 0; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); flex: 1; overflow: auto; }
+.settings-card.services-view { overflow: auto; }
+.settings-card.services-view { padding: 0; }
+.settings-card.services-view > .card-intro { margin: 0; padding: 28px 28px 22px; }
+.settings-card.services-view .service-catalog { margin: 0; border-right: 0; border-left: 0; border-radius: 0; }
 .card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
 .card-intro h2 { margin-bottom: 6px; font-size: 21px; }
 .settings-card > div:last-child > .el-row,
@@ -76,30 +80,59 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .settings-card > div:last-child > div > .el-collapse {
   scroll-margin-top: 28px;
 }
-.settings-card .el-row { min-height: 52px; margin-right: 0 !important; margin-left: 0 !important; padding: 8px 12px; border-radius: 12px; }
-.settings-card .el-row:hover { background: var(--surface-soft); }
+.settings-card .el-row { min-height: 52px; margin-right: 0 !important; margin-bottom: 12px !important; margin-left: 0 !important; padding: 14px 16px; border: 1px solid #edf0f5; border-radius: 16px; background: #fbfcfe; }
+.settings-card .el-row:hover { border-color: #e5b4c2; background: #fff; box-shadow: 0 8px 22px rgba(31, 40, 61, .04); }
+.settings-card .el-row .popup-text { display: inline-flex; align-items: center; min-height: 34px; }
 .settings-card .lightblue { background: transparent !important; }
 .settings-card .popup-text { color: var(--ink); font-size: 13px; font-weight: 650; }
 .settings-card .el-select, .settings-card .el-input, .settings-card .el-input-number { max-width: 360px; }
+.settings-card .el-select,
+.settings-card .el-input,
+.settings-card .el-input-number { --el-border-color: #e2e6ef; --el-border-color-hover: #ef4776; width: 100%; }
+.settings-card .el-select__wrapper,
+.settings-card .el-input__wrapper,
+.settings-card .el-input-number .el-input__wrapper {
+  min-height: 48px; padding: 0 15px; border: 1px solid #e2e6ef; border-radius: 14px; background: #f8f9fc;
+  box-shadow: none; transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+.settings-card .el-select__wrapper:hover,
+.settings-card .el-input__wrapper:hover,
+.settings-card .el-input-number .el-input__wrapper:hover { border-color: #ef9ab1; background: #fff; }
+.settings-card .el-select__wrapper.is-focused,
+.settings-card .el-input__wrapper.is-focus,
+.settings-card .el-input-number .el-input__wrapper.is-focus {
+  border-color: var(--brand); background: #fff; box-shadow: 0 0 0 4px rgba(239, 71, 118, .1);
+}
+.settings-card .el-select__selected-item,
+.settings-card .el-input__inner,
+.settings-card .el-input-number .el-input__inner { color: var(--ink); font-size: 14px; }
+.settings-card .el-select__placeholder,
+.settings-card .el-input__inner::placeholder { color: #8992a5; }
+.settings-card .el-select__caret { color: #7d8799; font-size: 16px; }
+.settings-card .el-input-group__prepend,
+.settings-card .el-input-group__append { border-color: #e2e6ef; background: #f8f9fc; }
 .settings-card .el-collapse { margin: 18px 0 0 !important; border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
 .settings-card .el-collapse-item__header { height: 56px; padding: 0 18px; border: 0; font-size: 14px; font-weight: 700; }
 .settings-card .el-collapse-item__wrap { border: 0; }
 .settings-card .el-collapse-item__content { padding: 4px 16px 18px; }
 .settings-card .el-divider__text { color: var(--muted); font-size: 11px; }
 .workspace > footer { margin-top: 22px; color: var(--muted); font-size: 10px; text-align: center; }
+.workspace > footer { flex: 0 0 auto; }
 
 @media (max-width: 1050px) {
   body { min-width: 720px; }
-  .sidebar { width: 210px; }
-  .workspace { width: calc(100% - 210px); margin-left: 210px; padding: 36px 28px 50px; }
+  .sidebar { flex-basis: 210px; width: 210px; }
+  .workspace { width: calc(100% - 210px); padding: 36px 28px 24px; }
   .topbar { align-items: stretch; flex-direction: column; }
   .search-box { width: 100%; }
 }
 
 @media (max-width: 700px) {
   body { min-width: 0; }
+  body { overflow: auto; }
+  .settings-app { display: block; height: auto; min-height: 100vh; overflow: visible; }
   .sidebar {
-    position: static; width: 100%; padding: 16px 14px 14px;
+    position: static; flex-basis: auto; width: 100%; height: auto; padding: 16px 14px 14px;
     border-right: 0; border-bottom: 1px solid var(--line); backdrop-filter: blur(14px);
   }
   .brand { gap: 10px; padding: 0 4px 14px; }
@@ -113,7 +146,7 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   .nav-icon { width: 28px; height: 28px; border-radius: 9px; }
   nav strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
   nav small { display: none; }
-  .workspace { width: 100%; margin-left: 0; padding: 24px 14px 36px; }
+  .workspace { width: 100%; height: auto; min-height: 0; padding: 24px 14px 36px; }
   .topbar { gap: 18px; margin-bottom: 20px; }
   h1 { font-size: 25px; }
   .topbar p { font-size: 12px; line-height: 1.55; }

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -195,19 +195,32 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 .settings-card .settings-control-row .settings-toggle {
   --el-switch-on-color: var(--brand);
   --el-switch-off-color: #dfe3eb;
-  width: 52px !important;
-  height: 30px !important;
+  --el-switch-border-color: #dfe4ed;
+  width: 44px !important;
+  height: 24px !important;
 }
 .settings-card .settings-control-row .el-switch__core {
-  width: 52px !important;
-  min-width: 52px !important;
-  height: 30px !important;
-  border: 0;
+  width: 44px !important;
+  min-width: 44px !important;
+  height: 24px !important;
+  border: 1px solid var(--el-switch-border-color);
   border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(23, 32, 51, .02);
 }
 .settings-card .settings-control-row .el-switch__action {
-  width: 24px;
-  height: 24px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  box-shadow: 0 2px 5px rgba(23, 32, 51, .16);
+}
+.settings-card .settings-control-row .el-switch.is-checked .el-switch__core {
+  --el-switch-border-color: var(--brand);
+}
+.settings-card .settings-control-row .el-switch.is-checked .el-switch__action {
+  left: calc(100% - 20px);
+}
+.settings-card .settings-control-row .el-switch:hover .el-switch__core {
+  border-color: #ef9ab1;
 }
 .settings-card .settings-control-row .custom-hotkey-display {
   min-height: 42px;

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -124,6 +124,28 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .settings-card .el-collapse-item__wrap { border: 0; }
 .settings-card .el-collapse-item__content { padding: 4px 16px 18px; }
 .settings-card .el-divider__text { color: var(--muted); font-size: 11px; }
+.about-page { display: grid; gap: 24px; min-height: 100%; }
+.about-hero {
+  display: flex; align-items: center; gap: 22px; padding: 28px; border: 1px solid #f4ced9; border-radius: 22px;
+  background: linear-gradient(135deg, #fff7f9 0%, #fff 58%, #f8f9ff 100%);
+}
+.about-logo { width: 82px; height: 82px; border-radius: 24px; box-shadow: 0 16px 28px rgba(239, 71, 118, .2); }
+.about-hero h3 { margin: 0 0 8px; color: var(--ink); font-size: 25px; letter-spacing: -.03em; }
+.about-hero p { max-width: 650px; margin: 0 0 12px; color: var(--muted); font-size: 14px; line-height: 1.7; }
+.about-version { display: inline-flex; padding: 6px 10px; border-radius: 999px; color: var(--brand-strong); background: var(--brand-soft); font-size: 11px; font-weight: 750; }
+.about-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.about-panel { padding: 24px; border: 1px solid var(--line); border-radius: 20px; background: var(--surface-soft); }
+.about-panel-kicker { display: block; margin-bottom: 8px; color: var(--brand-strong); font-size: 11px; font-weight: 800; letter-spacing: .1em; }
+.about-panel h3 { margin: 0 0 8px; color: var(--ink); font-size: 19px; }
+.about-panel p { min-height: 48px; margin: 0 0 18px; color: var(--muted); font-size: 13px; line-height: 1.7; }
+.about-feature-list { display: grid; gap: 10px; }
+.about-feature-list span { display: flex; align-items: center; gap: 10px; color: var(--ink); font-size: 13px; font-weight: 650; }
+.about-feature-list b { display: inline-grid; place-items: center; width: 28px; height: 28px; border-radius: 9px; color: var(--brand-strong); background: var(--brand-soft); font-size: 11px; }
+.about-links { display: grid; gap: 8px; }
+.about-links a { display: flex; align-items: center; justify-content: space-between; padding: 11px 12px; border: 1px solid var(--line); border-radius: 12px; color: var(--ink); background: var(--surface); font-size: 13px; font-weight: 650; text-decoration: none; transition: border-color 160ms ease, color 160ms ease, transform 160ms ease; }
+.about-links a:hover { border-color: #ef9ab1; color: var(--brand-strong); transform: translateX(2px); }
+.about-links a span { color: var(--brand-strong); font-size: 16px; }
+.about-footer { margin: 0; color: var(--muted); font-size: 11px; text-align: center; }
 .workspace > footer { margin-top: 22px; color: var(--muted); font-size: 10px; text-align: center; }
 .workspace > footer { flex: 0 0 auto; }
 
@@ -177,6 +199,10 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   .settings-card .margin-left-2em { margin-right: 0 !important; margin-left: 0 !important; }
   .settings-card .el-collapse-item__header { padding: 0 14px; }
   .settings-card .el-collapse-item__content { padding: 4px 8px 14px; }
+  .about-hero { align-items: flex-start; padding: 20px; flex-direction: column; }
+  .about-logo { width: 64px; height: 64px; border-radius: 18px; }
+  .about-hero h3 { font-size: 21px; }
+  .about-grid { grid-template-columns: 1fr; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -32,7 +32,9 @@ button:focus-visible, input:focus-visible { outline: 3px solid rgba(239, 71, 118
 .brand div, nav button > span:last-child { display: flex; flex-direction: column; min-width: 0; }
 .brand strong { font-size: 18px; }
 .brand small { margin-top: 3px; color: var(--muted); font-size: 11px; }
-nav { display: grid; gap: 6px; }
+nav { display: grid; gap: 20px; overflow-y: auto; padding: 2px 0 16px; }
+.nav-group { display: grid; gap: 6px; }
+.nav-group-label { padding: 0 12px 4px; color: #9299a8; font-size: 9px; font-weight: 800; letter-spacing: .12em; }
 nav button {
   display: grid; grid-template-columns: 34px 1fr; align-items: center; gap: 11px; width: 100%; padding: 11px 12px;
   border: 1px solid transparent; border-radius: 13px; color: var(--ink); background: transparent; text-align: left; cursor: pointer;
@@ -43,11 +45,7 @@ nav button.active { border-color: rgba(239, 71, 118, .16); color: var(--brand-st
 .nav-icon { display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px; background: var(--surface); font-size: 14px; font-weight: 800; }
 nav strong { font-size: 13px; }
 nav small { margin-top: 2px; color: var(--muted); font-size: 10px; }
-.sidebar-note { margin-top: auto; padding: 15px; border: 1px solid #dceee7; border-radius: 15px; background: #f1faf6; }
-.sidebar-note span { color: #18835d; font-size: 11px; font-weight: 750; }
-.sidebar-note p { margin: 6px 0 0; color: #527064; font-size: 10px; line-height: 1.55; }
-
-.workspace { width: min(980px, calc(100% - 300px)); margin-left: 252px; padding: 48px 52px 60px; }
+.workspace { width: min(1180px, calc(100% - 252px)); margin-left: 252px; padding: 42px 44px 60px; }
 .topbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 32px; margin-bottom: 30px; }
 .eyebrow { display: block; margin-bottom: 7px; color: var(--brand-strong); font-size: 11px; font-weight: 780; letter-spacing: .12em; }
 h1, h2, p { margin-top: 0; }
@@ -70,7 +68,7 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
 .search-results b { color: var(--brand-strong); font-size: 10px; }
 .search-empty { padding: 18px; text-align: center; }
 
-.settings-card { padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); }
+.settings-card { min-height: 430px; padding: 28px 28px 18px; border: 1px solid var(--line); border-radius: 24px; background: var(--surface); box-shadow: 0 18px 50px rgba(31, 40, 61, .07); }
 .card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
 .card-intro h2 { margin-bottom: 6px; font-size: 21px; }
 .settings-card > div:last-child > .el-row,
@@ -107,12 +105,14 @@ h1 { margin-bottom: 8px; font-size: 30px; line-height: 1.25; letter-spacing: -.0
   .brand { gap: 10px; padding: 0 4px 14px; }
   .brand img { width: 40px; height: 40px; border-radius: 12px; }
   .brand strong { font-size: 16px; }
-  nav { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px; }
+  nav { display: flex; gap: 8px; padding-bottom: 2px; overflow-x: auto; overflow-y: hidden; }
+  .nav-group { display: flex; flex: 0 0 auto; gap: 6px; }
+  .nav-group-label { display: none; }
   nav button { grid-template-columns: 28px minmax(0, 1fr); gap: 8px; min-width: 0; padding: 8px; }
-  nav button:last-child { grid-column: 1 / -1; }
+  nav button { width: 150px; flex: 0 0 150px; }
   .nav-icon { width: 28px; height: 28px; border-radius: 9px; }
   nav strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
-  nav small, .sidebar-note { display: none; }
+  nav small { display: none; }
   .workspace { width: 100%; margin-left: 0; padding: 24px 14px 36px; }
   .topbar { gap: 18px; margin-bottom: 20px; }
   h1 { font-size: 25px; }

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -51,7 +51,7 @@
           aria-label="翻译服务"
           @click="toggleServicePicker"
         >
-          <span class="service-icon">译</span>
+          <ServiceIcon :service="config.service" :label="serviceLabel" />
           <span class="service-copy"><small>翻译服务</small><strong>{{ serviceLabel }}</strong></span>
           <span class="chevron" :class="{ open: servicePickerOpen }">⌄</span>
         </button>
@@ -74,7 +74,7 @@
               :aria-selected="config.service === item.value"
               @click="selectService(item.value)"
             >
-              <span class="service-option-icon">{{ serviceInitial(item.label) }}</span>
+              <ServiceIcon :service="item.value" :label="item.label" size="small" />
               <span>{{ item.label }}</span>
               <span v-if="config.service === item.value" class="service-option-check">✓</span>
             </button>
@@ -96,7 +96,7 @@
               :aria-selected="config.service === item.value"
               @click="selectService(item.value)"
             >
-              <span class="service-option-icon">{{ serviceInitial(item.label) }}</span>
+              <ServiceIcon :service="item.value" :label="item.label" size="small" />
               <span>{{ item.label }}</span>
               <span v-if="config.service === item.value" class="service-option-check">✓</span>
             </button>
@@ -243,6 +243,7 @@ import { storage } from '@wxt-dev/storage';
 import { Setting } from '@element-plus/icons-vue';
 import { Config, normalizeConfig } from '@/entrypoints/utils/model';
 import { options } from '@/entrypoints/utils/option';
+import ServiceIcon from '@/components/ServiceIcon.vue';
 
 type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
@@ -342,9 +343,6 @@ function toggleServicePicker() {
 function selectService(value: string) {
   config.value.service = value;
   servicePickerOpen.value = false;
-}
-function serviceInitial(label: string) {
-  return label.replace(/[⭐️]/g, '').trim().slice(0, 1) || '译';
 }
 onMounted(() => {
   document.addEventListener('pointerdown', closeServicePicker);

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -143,6 +143,19 @@
 
     <footer>
       <span>已完成 {{ config.count }} 次翻译</span>
+      <a
+        class="opensource-link"
+        href="https://github.com/Bistutu/FluentRead"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="在 GitHub 查看流畅阅读开源项目"
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 .3a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.26c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.74.08-.74 1.2.08 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5.99.11-.77.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.17 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.17.77.84 1.24 1.91 1.24 3.22 0 4.62-2.81 5.65-5.49 5.95.43.37.81 1.1.81 2.22v3.29c0 .32.22.69.83.57A12 12 0 0 0 12 .3" />
+        </svg>
+        <span>开源项目</span>
+        <span class="external-mark" aria-hidden="true">↗</span>
+      </a>
       <button type="button" :disabled="clearingCache" @click="clearCache">{{ clearingCache ? '清理中…' : '清除缓存' }}</button>
     </footer>
 

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -281,11 +281,13 @@ async function broadcast(message: Record<string, unknown>) {
 function setPluginEnabled(enabled: boolean) {
   config.value.on = enabled;
   if (!enabled) {
-    config.value.disableFloatingBall = true;
-    config.value.selectionTranslatorMode = 'disabled';
     void broadcast({ type: 'toggleFloatingBall', isEnabled: false });
     void broadcast({ type: 'updateSelectionTranslatorMode', mode: 'disabled' });
+    return;
   }
+
+  void broadcast({ type: 'toggleFloatingBall', isEnabled: !config.value.disableFloatingBall });
+  void broadcast({ type: 'updateSelectionTranslatorMode', mode: config.value.selectionTranslatorMode });
 }
 
 function openDrawer(name: DrawerName) { activeDrawer.value = name; drawerVisible.value = true; }

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -10,7 +10,7 @@
       </div>
       <div class="header-actions">
         <span class="status-pill" :class="{ active: config.on }"><i />{{ config.on ? '已启用' : '已暂停' }}</span>
-        <button class="icon-button" type="button" title="完整设置" @click="openOptions">
+        <button class="icon-button" type="button" title="完整设置" @click="openOptions()">
           <Setting />
         </button>
       </div>
@@ -115,7 +115,7 @@
     <section class="features">
       <div class="section-heading">
         <div><span class="eyebrow">快捷功能</span><h2>按你的阅读习惯工作</h2></div>
-        <button type="button" @click="openOptions">全部设置</button>
+        <button type="button" @click="openOptions()">全部设置</button>
       </div>
       <div class="feature-grid">
         <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('hover')">
@@ -241,7 +241,7 @@
         </label>
       </div>
 
-      <button class="drawer-settings-link" type="button" @click="openOptions">在完整设置中查看全部选项 ↗</button>
+      <button class="drawer-settings-link" type="button" @click="openOptions(drawerSettingsSection[activeDrawer])">在完整设置中查看全部选项 ↗</button>
     </el-drawer>
 
     <CustomHotkeyInput v-model="showCustomHotkeyDialog" :current-value="config.customFloatingBallHotkey" @confirm="confirmFloatingHotkey" @cancel="cancelFloatingHotkey" />
@@ -259,6 +259,7 @@ import { options } from '@/entrypoints/utils/option';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
 type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance';
+type SettingsSection = 'settings-general' | 'settings-shortcuts';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 const version = process.env.VUE_APP_VERSION;
 const config = ref(new Config());
@@ -278,6 +279,12 @@ const hydrated = ref(false);
 let lastSerialized = '';
 let noticeTimer: ReturnType<typeof setTimeout> | undefined;
 const darkMode = window.matchMedia('(prefers-color-scheme: dark)');
+const drawerSettingsSection: Record<DrawerName, SettingsSection> = {
+  hover: 'settings-shortcuts',
+  selection: 'settings-shortcuts',
+  floating: 'settings-shortcuts',
+  appearance: 'settings-general',
+};
 
 const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
 const popularServiceValues = ['microsoft', 'google', 'deepL', 'deeplx', 'deepseek', 'openai', 'gemini', 'claude'];
@@ -393,7 +400,14 @@ function setPluginEnabled(enabled: boolean) {
 }
 
 function openDrawer(name: DrawerName) { activeDrawer.value = name; drawerVisible.value = true; }
-async function openOptions() { await browser.runtime.openOptionsPage(); window.close(); }
+async function openOptions(section?: SettingsSection) {
+  if (section) {
+    await browser.tabs.create({ url: `${browser.runtime.getURL('options.html')}#${section}` });
+  } else {
+    await browser.runtime.openOptionsPage();
+  }
+  window.close();
+}
 
 async function togglePageTranslation() {
   translating.value = true;

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -1,64 +1,342 @@
 <template>
-  <div>
-    <el-container>
-      <el-header class="custom-padding">
-        <Header/>
-      </el-header>
-      <el-main class="custom-padding" style="min-height: 320px">
-        <Main/>
-      </el-main>
-      <el-footer class="custom-padding">
-        <Footer/>
-      </el-footer>
-    </el-container>
-  </div>
+  <main class="popup-shell">
+    <header class="popup-header">
+      <div class="brand">
+        <img src="/icon/128.png" alt="" />
+        <div>
+          <strong>流畅阅读</strong>
+          <small>FluentRead · V{{ version }}</small>
+        </div>
+      </div>
+      <div class="header-actions">
+        <span class="status-pill" :class="{ active: config.on }"><i />{{ config.on ? '已启用' : '已暂停' }}</span>
+        <button class="icon-button" type="button" title="完整设置" @click="openOptions">
+          <Setting />
+        </button>
+      </div>
+    </header>
+
+    <section class="hero-card">
+      <div class="hero-heading">
+        <div>
+          <span class="eyebrow">网页翻译</span>
+          <h1>{{ config.on ? '让阅读自然地流动' : '翻译功能已暂停' }}</h1>
+        </div>
+        <button class="switch" type="button" role="switch" :aria-checked="config.on" :aria-label="config.on ? '暂停插件' : '启用插件'" @click="setPluginEnabled(!config.on)"><i /></button>
+      </div>
+
+      <div class="language-pair">
+        <label>
+          <span>源语言</span>
+          <select v-model="config.from" :disabled="!config.on">
+            <option v-for="item in options.form" :key="item.value" :value="item.value">{{ item.label }}</option>
+          </select>
+        </label>
+        <span class="arrow">→</span>
+        <label>
+          <span>目标语言</span>
+          <select v-model="config.to" :disabled="!config.on">
+            <option v-for="item in options.to" :key="item.value" :value="item.value">{{ item.label }}</option>
+          </select>
+        </label>
+      </div>
+
+      <label class="service-field">
+        <span class="service-icon">译</span>
+        <span class="service-copy"><small>翻译服务</small><strong>{{ serviceLabel }}</strong></span>
+        <select v-model="config.service" :disabled="!config.on" aria-label="翻译服务">
+          <option v-for="item in serviceOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+        </select>
+        <span class="chevron">›</span>
+      </label>
+
+      <button class="translate-button" type="button" :disabled="!config.on || translating" @click="togglePageTranslation">
+        <span v-if="translating" class="spinner" />
+        <span v-else class="translate-glyph">A↔译</span>
+        {{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}
+      </button>
+      <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>
+    </section>
+
+    <section class="features">
+      <div class="section-heading">
+        <div><span class="eyebrow">快捷功能</span><h2>按你的阅读习惯工作</h2></div>
+        <button type="button" @click="openOptions">全部设置</button>
+      </div>
+      <div class="feature-grid">
+        <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('hover')">
+          <span class="feature-icon rose">↖</span>
+          <span><strong>悬停翻译</strong><small>{{ hoverSummary }}</small></span>
+          <i :class="{ active: config.hotkey !== 'none' }" />
+        </button>
+        <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('selection')">
+          <span class="feature-icon violet">I</span>
+          <span><strong>划词翻译</strong><small>{{ selectionSummary }}</small></span>
+          <i :class="{ active: config.selectionTranslatorMode !== 'disabled' }" />
+        </button>
+        <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('floating')">
+          <span class="feature-icon blue">◉</span>
+          <span><strong>全文悬浮球</strong><small>{{ config.disableFloatingBall ? '已关闭' : floatingSummary }}</small></span>
+          <i :class="{ active: !config.disableFloatingBall }" />
+        </button>
+        <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('appearance')">
+          <span class="feature-icon amber">Aa</span>
+          <span><strong>译文显示</strong><small>{{ displaySummary }}</small></span>
+          <b>›</b>
+        </button>
+      </div>
+    </section>
+
+    <footer>
+      <span>已完成 {{ config.count }} 次翻译</span>
+      <button type="button" :disabled="clearingCache" @click="clearCache">{{ clearingCache ? '清理中…' : '清除缓存' }}</button>
+    </footer>
+
+    <el-drawer
+      v-model="drawerVisible"
+      direction="btt"
+      size="auto"
+      :with-header="false"
+      :append-to-body="true"
+      modal-class="popup-drawer-modal"
+      class="popup-drawer"
+    >
+      <div class="drawer-handle" />
+      <header class="drawer-header">
+        <div><span class="eyebrow">快捷设置</span><h2>{{ drawerTitle }}</h2><p>{{ drawerDescription }}</p></div>
+        <button type="button" aria-label="关闭" @click="drawerVisible = false">×</button>
+      </header>
+
+      <div v-if="activeDrawer === 'hover'" class="drawer-content">
+        <div class="interaction-preview"><span class="cursor">↖</span><span>＋</span><kbd>{{ hoverKey }}</kbd><span>＝</span><strong>即时翻译</strong></div>
+        <div class="setting-row">
+          <span><strong>启用鼠标悬停翻译</strong><small>按住快捷键并悬停在文本上</small></span>
+          <button class="switch compact" type="button" role="switch" :aria-checked="config.hotkey !== 'none'" aria-label="启用或关闭鼠标悬停翻译" @click="toggleHover"><i /></button>
+        </div>
+        <div class="choice-block">
+          <label>触发快捷键</label>
+          <div class="chips two">
+            <button v-for="item in hoverChoices" :key="item.value" type="button" :class="{ selected: config.hotkey === item.value }" @click="setHoverHotkey(item.value)">{{ item.label }}</button>
+          </div>
+          <button v-if="config.hotkey === 'custom'" class="secondary-action" type="button" @click="showCustomMouseHotkeyDialog = true">
+            {{ config.customHotkey ? `当前：${config.customHotkey}` : '录制自定义快捷键' }}
+          </button>
+        </div>
+      </div>
+
+      <div v-else-if="activeDrawer === 'selection'" class="drawer-content">
+        <div class="interaction-preview"><span class="selection-box">选择文字</span><span>＋</span><i class="pink-dot" /><span>＝</span><strong>翻译所选内容</strong></div>
+        <div class="choice-block">
+          <label>显示方式</label>
+          <div class="chips three">
+            <button v-for="item in selectionModes" :key="item.value" type="button" :class="{ selected: config.selectionTranslatorMode === item.value }" @click="setSelectionMode(item.value)">{{ item.label }}</button>
+          </div>
+        </div>
+      </div>
+
+      <div v-else-if="activeDrawer === 'floating'" class="drawer-content">
+        <div class="setting-row">
+          <span><strong>启用全文翻译悬浮球</strong><small>在页面边缘快速翻译或恢复全文</small></span>
+          <button class="switch compact" type="button" role="switch" :aria-checked="!config.disableFloatingBall" aria-label="启用或关闭全文翻译悬浮球" @click="setFloatingEnabled(config.disableFloatingBall)"><i /></button>
+        </div>
+        <div class="choice-block">
+          <label>悬浮位置</label>
+          <div class="chips two">
+            <button type="button" :class="{ selected: config.floatingBallPosition === 'left' }" @click="config.floatingBallPosition = 'left'">页面左侧</button>
+            <button type="button" :class="{ selected: config.floatingBallPosition === 'right' }" @click="config.floatingBallPosition = 'right'">页面右侧</button>
+          </div>
+        </div>
+        <label class="select-row">
+          <span><strong>全文翻译快捷键</strong><small>无需点击悬浮球即可切换</small></span>
+          <select v-model="config.floatingBallHotkey" @change="handleFloatingHotkeyChange">
+            <option v-for="item in options.floatingBallHotkeys" :key="item.value" :value="item.value">{{ item.label }}</option>
+          </select>
+        </label>
+        <button v-if="config.floatingBallHotkey === 'custom'" class="secondary-action" type="button" @click="showCustomHotkeyDialog = true">
+          {{ config.customFloatingBallHotkey ? `当前：${config.customFloatingBallHotkey}` : '录制自定义快捷键' }}
+        </button>
+      </div>
+
+      <div v-else class="drawer-content">
+        <div class="choice-block">
+          <label>翻译模式</label>
+          <div class="chips two">
+            <button v-for="item in options.display" :key="item.value" type="button" :class="{ selected: config.display === item.value }" @click="config.display = item.value">{{ item.label }}</button>
+          </div>
+        </div>
+        <label v-if="config.display === 1" class="select-row">
+          <span><strong>译文样式</strong><small>双语对照时译文的视觉效果</small></span>
+          <select v-model.number="config.style"><option v-for="item in styleOptions" :key="item.value" :value="item.value">{{ item.label }}</option></select>
+        </label>
+        <label class="select-row">
+          <span><strong>界面主题</strong><small>同时应用到完整设置页面</small></span>
+          <select v-model="config.theme"><option v-for="item in options.theme" :key="item.value" :value="item.value">{{ item.label }}</option></select>
+        </label>
+      </div>
+
+      <button class="drawer-settings-link" type="button" @click="openOptions">在完整设置中查看全部选项 ↗</button>
+    </el-drawer>
+
+    <CustomHotkeyInput v-model="showCustomHotkeyDialog" :current-value="config.customFloatingBallHotkey" @confirm="confirmFloatingHotkey" @cancel="cancelFloatingHotkey" />
+    <CustomHotkeyInput v-model="showCustomMouseHotkeyDialog" :current-value="config.customHotkey" @confirm="confirmMouseHotkey" @cancel="cancelMouseHotkey" />
+  </main>
 </template>
 
 <script lang="ts" setup>
-import Header from '../../components/Header.vue';
-import Main from "../../components/Main.vue";
-import Footer from "../../components/Footer.vue";
-import '../../styles/theme.css';
-// Element Plus 基础与暗色变量
-import 'element-plus/theme-chalk/base.css';
-import 'element-plus/theme-chalk/dark/css-vars.css';
+import { computed, defineAsyncComponent, onUnmounted, ref, watch } from 'vue';
+import browser from 'webextension-polyfill';
+import { storage } from '@wxt-dev/storage';
+import { Setting } from '@element-plus/icons-vue';
+import { Config, normalizeConfig } from '@/entrypoints/utils/model';
+import { options } from '@/entrypoints/utils/option';
 
+type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance';
+const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
+const version = process.env.VUE_APP_VERSION;
+const config = ref(new Config());
+const drawerVisible = ref(false);
+const activeDrawer = ref<DrawerName>('hover');
+const translating = ref(false);
+const pageTranslated = ref(false);
+const clearingCache = ref(false);
+const notice = ref('');
+const noticeType = ref<'success' | 'error'>('success');
+const showCustomHotkeyDialog = ref(false);
+const showCustomMouseHotkeyDialog = ref(false);
+const hydrated = ref(false);
+let lastSerialized = '';
+let noticeTimer: ReturnType<typeof setTimeout> | undefined;
+const darkMode = window.matchMedia('(prefers-color-scheme: dark)');
+
+const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
+const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
+const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
+const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');
+const hoverKey = computed(() => config.value.hotkey === 'custom' ? (config.value.customHotkey || '自定义') : config.value.hotkey);
+const hoverSummary = computed(() => config.value.hotkey === 'none' ? '已关闭' : `${hoverKey.value} + 悬停`);
+const selectionSummary = computed(() => ({ disabled: '已关闭', bilingual: '双语显示', 'translation-only': '仅显示译文' }[config.value.selectionTranslatorMode] || '双语显示'));
+const floatingSummary = computed(() => `${config.value.floatingBallPosition === 'left' ? '页面左侧' : '页面右侧'} · ${config.value.floatingBallHotkey}`);
+const displaySummary = computed(() => config.value.display === 1 ? `双语 · ${styleLabel.value}` : '仅显示译文');
+const drawerTitle = computed(() => ({ hover: '悬停翻译设置', selection: '划词翻译设置', floating: '全文悬浮球设置', appearance: '译文显示设置' }[activeDrawer.value]));
+const drawerDescription = computed(() => ({
+  hover: '把鼠标停在文本上，用轻量快捷键获取即时译文。',
+  selection: '选中文字后，按你的偏好显示原文与译文。',
+  floating: '把全文翻译入口固定在最顺手的位置。',
+  appearance: '调整双语布局、译文样式与界面主题。',
+}[activeDrawer.value]));
+const hoverChoices = [
+  { value: 'Control', label: 'Ctrl' },
+  { value: 'Alt', label: 'Alt / Option' },
+  { value: 'Shift', label: 'Shift' },
+  { value: 'custom', label: '自定义' },
+];
+const selectionModes = [
+  { value: 'disabled', label: '关闭' },
+  { value: 'bilingual', label: '双语显示' },
+  { value: 'translation-only', label: '仅译文' },
+];
+
+function applyTheme(theme: string) {
+  document.documentElement.classList.toggle('dark', theme === 'dark' || (theme === 'auto' && darkMode.matches));
+}
+
+async function hydrate() {
+  const value = await storage.getItem('local:config');
+  if (typeof value === 'string' && value) Object.assign(config.value, normalizeConfig(JSON.parse(value)));
+  lastSerialized = JSON.stringify(config.value);
+  hydrated.value = true;
+  applyTheme(config.value.theme || 'auto');
+}
+void hydrate();
+
+storage.watch('local:config', (value: any) => {
+  if (typeof value !== 'string' || !value || value === lastSerialized) return;
+  lastSerialized = value;
+  Object.assign(config.value, normalizeConfig(JSON.parse(value)));
+});
+
+watch(config, async value => {
+  if (!hydrated.value) return;
+  const serialized = JSON.stringify(value);
+  if (serialized === lastSerialized) return;
+  lastSerialized = serialized;
+  await storage.setItem('local:config', serialized);
+}, { deep: true });
+watch(() => config.value.theme, theme => applyTheme(theme || 'auto'));
+darkMode.onchange = () => { if (config.value.theme === 'auto') applyTheme('auto'); };
+onUnmounted(() => { darkMode.onchange = null; if (noticeTimer) clearTimeout(noticeTimer); });
+
+function showNotice(message: string, type: 'success' | 'error' = 'success') {
+  notice.value = message;
+  noticeType.value = type;
+  if (noticeTimer) clearTimeout(noticeTimer);
+  noticeTimer = setTimeout(() => { notice.value = ''; }, 2200);
+}
+
+async function broadcast(message: Record<string, unknown>) {
+  const tabs = await browser.tabs.query({});
+  await Promise.allSettled(tabs.filter(tab => tab.id).map(tab => browser.tabs.sendMessage(tab.id!, message)));
+}
+
+function setPluginEnabled(enabled: boolean) {
+  config.value.on = enabled;
+  if (!enabled) {
+    config.value.disableFloatingBall = true;
+    config.value.selectionTranslatorMode = 'disabled';
+    void broadcast({ type: 'toggleFloatingBall', isEnabled: false });
+    void broadcast({ type: 'updateSelectionTranslatorMode', mode: 'disabled' });
+  }
+}
+
+function openDrawer(name: DrawerName) { activeDrawer.value = name; drawerVisible.value = true; }
+async function openOptions() { await browser.runtime.openOptionsPage(); window.close(); }
+
+async function togglePageTranslation() {
+  translating.value = true;
+  try {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) throw new Error('No active tab');
+    const response = await browser.tabs.sendMessage(tab.id, { type: 'contextMenuTranslate', action: pageTranslated.value ? 'restore' : 'fullPage' }) as { status?: string } | undefined;
+    if (response?.status === 'disabled') throw new Error('Plugin disabled');
+    pageTranslated.value = !pageTranslated.value;
+    showNotice(pageTranslated.value ? '正在翻译当前网页' : '已恢复网页原文');
+  } catch (error) {
+    console.error(error);
+    showNotice('当前页面暂不支持翻译，请刷新后重试', 'error');
+  } finally { translating.value = false; }
+}
+
+async function clearCache() {
+  clearingCache.value = true;
+  try {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) throw new Error('No active tab');
+    await browser.tabs.sendMessage(tab.id, { message: 'clearCache' });
+    showNotice('当前页面的翻译缓存已清除');
+  } catch (error) {
+    console.error(error);
+    showNotice('缓存清除失败', 'error');
+  } finally { clearingCache.value = false; }
+}
+
+function toggleHover() { config.value.hotkey = config.value.hotkey === 'none' ? 'Control' : 'none'; }
+function setHoverHotkey(value: string) {
+  config.value.hotkey = value;
+  if (value === 'custom' && !config.value.customHotkey) showCustomMouseHotkeyDialog.value = true;
+}
+function setSelectionMode(mode: string) {
+  config.value.selectionTranslatorMode = mode;
+  void broadcast({ type: 'updateSelectionTranslatorMode', mode });
+}
+function setFloatingEnabled(enabled: boolean) {
+  config.value.disableFloatingBall = !enabled;
+  void broadcast({ type: 'toggleFloatingBall', isEnabled: enabled });
+}
+function handleFloatingHotkeyChange() {
+  if (config.value.floatingBallHotkey === 'custom' && !config.value.customFloatingBallHotkey) showCustomHotkeyDialog.value = true;
+}
+function confirmFloatingHotkey(hotkey: string) { config.value.customFloatingBallHotkey = hotkey; config.value.floatingBallHotkey = 'custom'; }
+function cancelFloatingHotkey() { if (!config.value.customFloatingBallHotkey) config.value.floatingBallHotkey = 'Alt+T'; }
+function confirmMouseHotkey(hotkey: string) { config.value.customHotkey = hotkey; config.value.hotkey = 'custom'; }
+function cancelMouseHotkey() { if (!config.value.customHotkey) config.value.hotkey = 'Control'; }
 </script>
-
-<style scoped>
-@media screen and (max-height: 800px) {
-  .popup-container {
-    max-height: 90vh;
-  }
-}
-
-@media screen and (max-width: 480px) {
-  .popup-container {
-    width: 95vw;
-  }
-}
-
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #ddd;
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-track {
-  background: #f5f5f5;
-  border-radius: 3px;
-}
-
-.el-main {
-  min-height: 460px;
-  height: auto;
-}
-
-.custom-padding {
-  padding: 12px 16px;
-}
-</style>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -41,14 +41,68 @@
         </label>
       </div>
 
-      <label class="service-field">
-        <span class="service-icon">译</span>
-        <span class="service-copy"><small>翻译服务</small><strong>{{ serviceLabel }}</strong></span>
-        <select v-model="config.service" :disabled="!config.on" aria-label="翻译服务">
-          <option v-for="item in serviceOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
-        </select>
-        <span class="chevron">›</span>
-      </label>
+      <div ref="servicePicker" class="service-picker">
+        <button
+          class="service-field"
+          type="button"
+          :disabled="!config.on"
+          aria-haspopup="listbox"
+          :aria-expanded="servicePickerOpen"
+          aria-label="翻译服务"
+          @click="toggleServicePicker"
+        >
+          <span class="service-icon">译</span>
+          <span class="service-copy"><small>翻译服务</small><strong>{{ serviceLabel }}</strong></span>
+          <span class="chevron" :class="{ open: servicePickerOpen }">⌄</span>
+        </button>
+
+        <div v-if="servicePickerOpen" class="service-picker-panel" role="listbox" aria-label="翻译服务列表">
+          <div class="service-picker-heading">
+            <div><strong>选择翻译服务</strong><small>常用服务优先，更多服务已收起</small></div>
+            <span>{{ serviceOptions.length }}</span>
+          </div>
+
+          <div class="service-group">
+            <span class="service-group-label">常用服务</span>
+            <button
+              v-for="item in popularServiceOptions"
+              :key="item.value"
+              class="service-option"
+              type="button"
+              role="option"
+              :data-service-value="item.value"
+              :aria-selected="config.service === item.value"
+              @click="selectService(item.value)"
+            >
+              <span class="service-option-icon">{{ serviceInitial(item.label) }}</span>
+              <span>{{ item.label }}</span>
+              <span v-if="config.service === item.value" class="service-option-check">✓</span>
+            </button>
+          </div>
+
+          <button class="service-more-toggle" type="button" :aria-expanded="moreServicesOpen" @click="moreServicesOpen = !moreServicesOpen">
+            <span>更多服务</span>
+            <span class="service-more-meta">{{ moreServiceOptions.length }} 项 <b :class="{ open: moreServicesOpen }">⌄</b></span>
+          </button>
+
+          <div v-if="moreServicesOpen" class="service-group service-group-more">
+            <button
+              v-for="item in moreServiceOptions"
+              :key="item.value"
+              class="service-option"
+              type="button"
+              role="option"
+              :data-service-value="item.value"
+              :aria-selected="config.service === item.value"
+              @click="selectService(item.value)"
+            >
+              <span class="service-option-icon">{{ serviceInitial(item.label) }}</span>
+              <span>{{ item.label }}</span>
+              <span v-if="config.service === item.value" class="service-option-check">✓</span>
+            </button>
+          </div>
+        </div>
+      </div>
 
       <button class="translate-button" type="button" :disabled="!config.on || translating" @click="togglePageTranslation">
         <span v-if="translating" class="spinner" />
@@ -183,7 +237,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineAsyncComponent, onUnmounted, ref, watch } from 'vue';
+import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from 'vue';
 import browser from 'webextension-polyfill';
 import { storage } from '@wxt-dev/storage';
 import { Setting } from '@element-plus/icons-vue';
@@ -203,12 +257,20 @@ const notice = ref('');
 const noticeType = ref<'success' | 'error'>('success');
 const showCustomHotkeyDialog = ref(false);
 const showCustomMouseHotkeyDialog = ref(false);
+const servicePicker = ref<HTMLElement | null>(null);
+const servicePickerOpen = ref(false);
+const moreServicesOpen = ref(false);
 const hydrated = ref(false);
 let lastSerialized = '';
 let noticeTimer: ReturnType<typeof setTimeout> | undefined;
 const darkMode = window.matchMedia('(prefers-color-scheme: dark)');
 
 const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
+const popularServiceValues = ['microsoft', 'google', 'deepL', 'deeplx', 'deepseek', 'openai', 'gemini', 'claude'];
+const popularServiceOptions = computed(() => popularServiceValues
+  .map(value => serviceOptions.value.find((item: any) => item.value === value))
+  .filter((item): item is any => Boolean(item)));
+const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !popularServiceValues.includes(item.value)));
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
 const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');
@@ -264,7 +326,36 @@ watch(config, async value => {
 }, { deep: true });
 watch(() => config.value.theme, theme => applyTheme(theme || 'auto'));
 darkMode.onchange = () => { if (config.value.theme === 'auto') applyTheme('auto'); };
-onUnmounted(() => { darkMode.onchange = null; if (noticeTimer) clearTimeout(noticeTimer); });
+
+function closeServicePicker(event?: Event) {
+  if (event && servicePicker.value?.contains(event.target as Node)) return;
+  servicePickerOpen.value = false;
+}
+function handleServicePickerKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') closeServicePicker();
+}
+function toggleServicePicker() {
+  if (!config.value.on) return;
+  servicePickerOpen.value = !servicePickerOpen.value;
+  if (servicePickerOpen.value) moreServicesOpen.value = !popularServiceValues.includes(config.value.service);
+}
+function selectService(value: string) {
+  config.value.service = value;
+  servicePickerOpen.value = false;
+}
+function serviceInitial(label: string) {
+  return label.replace(/[⭐️]/g, '').trim().slice(0, 1) || '译';
+}
+onMounted(() => {
+  document.addEventListener('pointerdown', closeServicePicker);
+  document.addEventListener('keydown', handleServicePickerKeydown);
+});
+onUnmounted(() => {
+  document.removeEventListener('pointerdown', closeServicePicker);
+  document.removeEventListener('keydown', handleServicePickerKeydown);
+  darkMode.onchange = null;
+  if (noticeTimer) clearTimeout(noticeTimer);
+});
 
 function showNotice(message: string, type: 'success' | 'error' = 'success') {
   notice.value = message;

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -104,7 +104,14 @@
         </div>
       </div>
 
-      <button class="translate-button" type="button" :disabled="!config.on || translating" @click="togglePageTranslation">
+      <button
+        class="translate-button"
+        :class="{ translated: pageTranslated }"
+        type="button"
+        :disabled="!config.on || translating"
+        :aria-pressed="pageTranslated"
+        @click="togglePageTranslation"
+      >
         <span v-if="translating" class="spinner" />
         <span v-else class="translate-glyph">A↔译</span>
         {{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}
@@ -408,12 +415,13 @@ async function openOptions(section?: SettingsSection) {
 
 async function togglePageTranslation() {
   translating.value = true;
+  const action = pageTranslated.value ? 'restore' : 'fullPage';
   try {
     const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
     if (!tab?.id) throw new Error('No active tab');
-    const response = await browser.tabs.sendMessage(tab.id, { type: 'contextMenuTranslate', action: pageTranslated.value ? 'restore' : 'fullPage' }) as { status?: string } | undefined;
-    if (response?.status === 'disabled') throw new Error('Plugin disabled');
-    pageTranslated.value = !pageTranslated.value;
+    const response = await browser.tabs.sendMessage(tab.id, { type: 'contextMenuTranslate', action }) as { status?: string } | undefined;
+    if (response?.status !== 'success') throw new Error(response?.status === 'disabled' ? 'Plugin disabled' : 'Translation failed');
+    pageTranslated.value = action === 'fullPage';
     showNotice(pageTranslated.value ? '正在翻译当前网页' : '已恢复网页原文');
   } catch (error) {
     console.error(error);

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -9,9 +9,9 @@
         </div>
       </div>
       <div class="header-actions">
-        <span class="status-pill" :class="{ active: config.on }"><i />{{ config.on ? '已启用' : '已暂停' }}</span>
-        <button class="icon-button" type="button" title="完整设置" @click="openOptions()">
+        <button class="settings-button" type="button" title="完整设置" aria-label="打开完整设置" @click="openOptions()">
           <Setting />
+          <span>设置</span>
         </button>
       </div>
     </header>
@@ -113,10 +113,7 @@
     </section>
 
     <section class="features">
-      <div class="section-heading">
-        <div><span class="eyebrow">快捷功能</span><h2>按你的阅读习惯工作</h2></div>
-        <button type="button" @click="openOptions()">全部设置</button>
-      </div>
+      <span class="eyebrow features-eyebrow">快捷功能</span>
       <div class="feature-grid">
         <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('hover')">
           <span class="feature-icon rose">↖</span>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -27,7 +27,8 @@ import {
   ElButton,
   ElDialog,
   ElDivider,
-  ElInputNumber
+  ElInputNumber,
+  ElDrawer
 } from 'element-plus'
 
 const app = createApp(App);
@@ -55,7 +56,8 @@ const components = [
   ElButton,
   ElDialog,
   ElDivider,
-  ElInputNumber
+  ElInputNumber,
+  ElDrawer
 ]
 
 components.forEach(component => {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -153,6 +153,8 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
   transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
 .translate-button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
+.translate-button.translated { background: linear-gradient(135deg, #35b98a, #15966e); box-shadow: 0 10px 22px rgba(21, 150, 110, .24); }
+.translate-button.translated:hover:not(:disabled) { box-shadow: 0 13px 26px rgba(21, 150, 110, .3); }
 .translate-glyph { font-size: 11px; font-weight: 850; }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -117,10 +117,16 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 }
 .arrow { display: grid; place-items: center; height: 39px; color: var(--muted); }
 
+.service-picker { position: relative; margin-top: 10px; }
 .service-field {
-  position: relative; display: flex; align-items: center; gap: 10px; min-height: 50px; margin-top: 10px;
-  padding: 9px 38px 9px 10px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface-soft); cursor: pointer;
+  position: relative; display: flex; align-items: center; gap: 10px; width: 100%; min-height: 50px;
+  padding: 9px 38px 9px 10px; border: 1px solid var(--line); border-radius: 14px; color: var(--ink);
+  background: var(--surface-soft); text-align: left; cursor: pointer; transition: border-color 160ms ease, box-shadow 160ms ease;
 }
+.service-field:hover:not(:disabled), .service-field[aria-expanded="true"] {
+  border-color: rgba(239, 71, 118, .48); box-shadow: 0 0 0 3px rgba(239, 71, 118, .08);
+}
+.service-field:disabled { cursor: not-allowed; opacity: .5; }
 .service-icon {
   display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px;
   color: var(--brand-strong); background: var(--brand-soft); font-size: 14px; font-weight: 800;
@@ -128,8 +134,37 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-copy { display: flex; flex: 1; flex-direction: column; min-width: 0; }
 .service-copy small { color: var(--muted); font-size: 9px; }
 .service-copy strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-.service-field select { position: absolute; inset: 0; width: 100%; opacity: 0; cursor: pointer; }
-.chevron { position: absolute; right: 14px; color: var(--muted); font-size: 20px; }
+.chevron { position: absolute; right: 14px; color: var(--muted); font-size: 18px; line-height: 1; transform: translateY(-2px); transition: transform 160ms ease; }
+.chevron.open { transform: translateY(1px) rotate(180deg); }
+.service-picker-panel {
+  position: absolute; z-index: 30; top: calc(100% + 8px); right: 0; left: 0; max-height: 318px; overflow: auto;
+  padding: 10px; border: 1px solid var(--line); border-radius: 18px; background: var(--surface);
+  box-shadow: 0 18px 36px rgba(27, 36, 57, .18); scrollbar-width: thin;
+}
+.service-picker-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 2px 4px 9px; }
+.service-picker-heading div { display: flex; flex-direction: column; gap: 2px; }
+.service-picker-heading strong { font-size: 12px; }
+.service-picker-heading small, .service-picker-heading > span, .service-group-label, .service-more-meta { color: var(--muted); font-size: 9px; }
+.service-picker-heading > span { padding-top: 2px; }
+.service-group { display: grid; gap: 4px; }
+.service-group-label { padding: 4px 6px 3px; font-weight: 700; }
+.service-group-more { padding-top: 6px; border-top: 1px solid var(--line); }
+.service-option, .service-more-toggle {
+  display: flex; align-items: center; width: 100%; min-height: 36px; gap: 8px; padding: 5px 7px; border: 1px solid transparent;
+  border-radius: 11px; color: var(--ink); background: transparent; text-align: left; cursor: pointer; transition: background 140ms ease, border-color 140ms ease;
+}
+.service-option:hover, .service-option[aria-selected="true"] { border-color: rgba(239, 71, 118, .22); background: var(--brand-soft); }
+.service-option > span:nth-child(2) { overflow: hidden; flex: 1; font-size: 11px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.service-option-icon {
+  display: grid; place-items: center; flex: none; width: 25px; height: 25px; border-radius: 8px;
+  color: var(--brand-strong); background: var(--brand-soft); font-size: 10px; font-weight: 800;
+}
+.service-option-check { color: var(--brand-strong); font-size: 14px; font-weight: 800; }
+.service-more-toggle { justify-content: space-between; margin-top: 7px; border-color: var(--line); background: var(--surface-soft); font-size: 10px; font-weight: 700; }
+.service-more-toggle:hover { border-color: rgba(239, 71, 118, .32); background: var(--brand-soft); }
+.service-more-meta { display: inline-flex; align-items: center; gap: 4px; }
+.service-more-meta b { color: var(--muted); font-size: 15px; line-height: .7; font-weight: 500; transform: translateY(-1px); transition: transform 160ms ease; }
+.service-more-meta b.open { transform: translateY(1px) rotate(180deg); }
 
 .translate-button {
   display: flex; align-items: center; justify-content: center; gap: 9px; width: 100%; height: 42px; margin-top: 11px;

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -1,59 +1,227 @@
 :root {
-    font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-    line-height: 1.5;
-    font-weight: 400;
-    /* 颜色与主题交由 styles/theme.css 控制 */
-    color: var(--fr-text-color);
-    background-color: var(--fr-bg-color);
-    font-synthesis: none;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-text-size-adjust: 100%;
+  font-family: Inter, "SF Pro Display", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  color: #172033;
+  background: #f6f7fb;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --brand: #ef4776;
+  --brand-strong: #dc315f;
+  --brand-soft: #fff0f4;
+  --ink: #172033;
+  --muted: #737c8f;
+  --line: #e7e9f0;
+  --surface: #fff;
+  --surface-soft: #f7f8fb;
 }
 
-/* 标题样式 */
-.title {
-    font-size: 1.5em;
-    font-weight: 600;
-    margin: 1em 0;
-    color: var(--fr-text-color);
+:root.dark {
+  color-scheme: dark;
+  color: #f4f5f8;
+  background: #14161b;
+  --ink: #f4f5f8;
+  --muted: #a7adba;
+  --line: #30333c;
+  --surface: #1d2027;
+  --surface-soft: #252830;
+  --brand-soft: rgba(239, 71, 118, .15);
 }
 
-.rounded-corner {
-    border-radius: 5px;
+* { box-sizing: border-box; }
+html, body, #app { width: 400px; min-width: 400px; min-height: 560px; margin: 0; overflow-x: hidden; background: #f6f7fb; }
+:root.dark body, :root.dark #app { background: #14161b; }
+button, select { font: inherit; }
+button { color: inherit; }
+button:focus-visible, select:focus-visible { outline: 3px solid rgba(239, 71, 118, .22); outline-offset: 2px; }
+
+.popup-shell {
+  min-height: 560px;
+  padding: 14px 16px;
+  background:
+    radial-gradient(circle at 92% 0, rgba(239, 71, 118, .12), transparent 30%),
+    linear-gradient(180deg, #fff 0, #f7f8fb 165px, #f6f7fb 100%);
+}
+:root.dark .popup-shell {
+  background:
+    radial-gradient(circle at 92% 0, rgba(239, 71, 118, .16), transparent 32%),
+    linear-gradient(180deg, #1b1d23 0, #14161b 180px);
 }
 
-/*popup选项框文字*/
-.popup-text {
-    font-size: 15px;
-    font-weight: 500;
-}
+.popup-header, .brand, .header-actions, .hero-heading, .section-heading, footer,
+.setting-row, .select-row, .drawer-header { display: flex; align-items: center; justify-content: space-between; }
+.popup-header { margin-bottom: 12px; }
+.brand, .header-actions { gap: 9px; }
+.brand img { width: 38px; height: 38px; border-radius: 12px; box-shadow: 0 8px 18px rgba(239, 71, 118, .2); }
+.brand div { display: flex; flex-direction: column; }
+.brand strong { font-size: 15px; line-height: 1.25; font-weight: 760; }
+.brand small { margin-top: 2px; color: var(--muted); font-size: 10px; }
 
-.popup-vertical-left {
-    display: flex;
-    align-items: center;
-    justify-content: left;
-    height: 100%;
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  background: var(--surface);
+  font-size: 10px;
+  font-weight: 650;
 }
-
-.margin-left-2em {
-    margin-left: 2em;
+.status-pill i, .feature-card > i {
+  width: 7px; height: 7px; border-radius: 50%; background: #b8bec9;
 }
-
-.margin-bottom {
-    margin-bottom: 10px;
+.status-pill.active i, .feature-card > i.active {
+  background: #24b47e;
+  box-shadow: 0 0 0 4px rgba(36, 180, 126, .12);
 }
-
-.custom-padding {
-    padding: 10px !important;
+.icon-button {
+  display: grid; place-items: center; width: 34px; height: 34px; padding: 8px;
+  border: 1px solid var(--line); border-radius: 11px; background: var(--surface); cursor: pointer;
 }
+.icon-button:hover { border-color: rgba(239, 71, 118, .35); background: var(--brand-soft); }
+.icon-button svg { width: 17px; }
 
-#app {
-    min-width: 340px;
-    margin: 0 auto;
-    padding: 0;
-    text-align: center;
+.hero-card {
+  padding: 15px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: 0 14px 34px rgba(27, 36, 57, .08);
 }
+.hero-heading { align-items: flex-start; }
+.eyebrow { display: block; margin-bottom: 4px; color: var(--brand-strong); font-size: 10px; font-weight: 760; letter-spacing: .1em; }
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 0; font-size: 18px; line-height: 1.35; letter-spacing: -.02em; }
+h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01em; }
 
-/* 由 .dark 类与变量控制主题，这里不再强制全局颜色 */
+.switch {
+  position: relative; flex: none; width: 44px; height: 26px; padding: 3px; border: 0;
+  border-radius: 999px; background: #cfd3dc; cursor: pointer; transition: background 180ms ease;
+}
+.switch i {
+  display: block; width: 20px; height: 20px; border-radius: 50%; background: #fff;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, .18); transition: transform 220ms cubic-bezier(.2, .8, .2, 1);
+}
+.switch[aria-checked="true"] { background: var(--brand); }
+.switch[aria-checked="true"] i { transform: translateX(18px); }
+.switch.compact { width: 40px; height: 24px; }
+.switch.compact i { width: 18px; height: 18px; }
+.switch.compact[aria-checked="true"] i { transform: translateX(16px); }
+
+.language-pair { display: grid; grid-template-columns: 1fr 34px 1fr; align-items: end; gap: 7px; margin-top: 14px; }
+.language-pair label > span, .choice-block > label { display: block; margin: 0 0 7px 3px; color: var(--muted); font-size: 10px; font-weight: 650; }
+.language-pair select, .select-row select {
+  width: 100%; height: 39px; padding: 0 28px 0 11px; border: 1px solid var(--line); border-radius: 11px;
+  color: var(--ink); background: var(--surface-soft); font-size: 11px; font-weight: 650; cursor: pointer;
+}
+.arrow { display: grid; place-items: center; height: 39px; color: var(--muted); }
+
+.service-field {
+  position: relative; display: flex; align-items: center; gap: 10px; min-height: 50px; margin-top: 10px;
+  padding: 9px 38px 9px 10px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface-soft); cursor: pointer;
+}
+.service-icon {
+  display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px;
+  color: var(--brand-strong); background: var(--brand-soft); font-size: 14px; font-weight: 800;
+}
+.service-copy { display: flex; flex: 1; flex-direction: column; min-width: 0; }
+.service-copy small { color: var(--muted); font-size: 9px; }
+.service-copy strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.service-field select { position: absolute; inset: 0; width: 100%; opacity: 0; cursor: pointer; }
+.chevron { position: absolute; right: 14px; color: var(--muted); font-size: 20px; }
+
+.translate-button {
+  display: flex; align-items: center; justify-content: center; gap: 9px; width: 100%; height: 42px; margin-top: 11px;
+  border: 0; border-radius: 14px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
+  box-shadow: 0 10px 22px rgba(233, 50, 103, .24); font-size: 13px; font-weight: 750; cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+}
+.translate-button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
+.translate-glyph { font-size: 11px; font-weight: 850; }
+.spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.notice { margin: 10px 0 -2px; color: #16855e; font-size: 10px; text-align: center; }
+.notice.error { color: #d9345e; }
+
+.features { margin-top: 16px; }
+.section-heading { margin: 0 2px 11px; }
+.section-heading > button, footer button {
+  padding: 0; border: 0; color: var(--brand-strong); background: none; font-size: 10px; font-weight: 700; cursor: pointer;
+}
+.feature-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
+.feature-card {
+  display: grid; grid-template-columns: 36px 1fr auto; align-items: center; gap: 9px; min-height: 64px; padding: 9px 11px;
+  border: 1px solid var(--line); border-radius: 16px; background: var(--surface); text-align: left; cursor: pointer;
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+.feature-card:hover:not(:disabled) { border-color: rgba(239, 71, 118, .32); transform: translateY(-1px); box-shadow: 0 8px 20px rgba(25, 32, 50, .07); }
+.feature-icon { display: grid; place-items: center; width: 36px; height: 36px; border-radius: 11px; font-size: 13px; font-weight: 750; }
+.feature-icon.rose { color: #e73a6c; background: #fff0f4; font-size: 22px; }
+.feature-icon.violet { color: #6f55d9; background: #f1edff; font-family: Georgia, serif; font-size: 19px; }
+.feature-icon.blue { color: #2678c9; background: #eaf4ff; font-size: 18px; }
+.feature-icon.amber { color: #a75f16; background: #fff4df; }
+:root.dark .feature-icon.rose { background: rgba(231, 58, 108, .14); }
+:root.dark .feature-icon.violet { background: rgba(111, 85, 217, .17); }
+:root.dark .feature-icon.blue { background: rgba(38, 120, 201, .17); }
+:root.dark .feature-icon.amber { background: rgba(177, 104, 29, .17); }
+.feature-card > span:nth-child(2) { display: flex; flex-direction: column; min-width: 0; }
+.feature-card strong { font-size: 11.5px; line-height: 1.4; }
+.feature-card small { margin-top: 2px; overflow: hidden; color: var(--muted); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.feature-card > i { width: 6px; height: 6px; }
+.feature-card > b { color: var(--muted); font-size: 18px; font-weight: 400; }
+.feature-card:disabled, .translate-button:disabled, select:disabled { cursor: not-allowed; opacity: .48; }
+footer { margin-top: 12px; padding: 0 3px; color: var(--muted); font-size: 9.5px; }
+
+.popup-drawer-modal { background: rgba(17, 20, 29, .48) !important; backdrop-filter: blur(2px); }
+.popup-drawer {
+  width: 400px !important; min-height: 260px !important; max-height: 88vh;
+  margin: 0 auto !important; padding: 8px 20px 18px; overflow: auto;
+  border-radius: 24px 24px 0 0 !important; background: var(--surface) !important;
+  box-shadow: 0 -18px 46px rgba(13, 17, 28, .18);
+}
+.popup-drawer .el-drawer__body { padding: 0; overflow: visible; color: var(--ink); }
+.drawer-handle { width: 36px; height: 4px; margin: 2px auto 14px; border-radius: 99px; background: var(--line); }
+.drawer-header { align-items: flex-start; gap: 16px; }
+.drawer-header h2 { font-size: 19px; }
+.drawer-header p { max-width: 300px; margin: 5px 0 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
+.drawer-header > button {
+  display: grid; place-items: center; width: 34px; height: 34px; padding: 0; border: 0; border-radius: 11px;
+  color: var(--muted); background: var(--surface-soft); font-size: 24px; font-weight: 300; cursor: pointer;
+}
+.drawer-content { margin-top: 16px; }
+.interaction-preview {
+  display: flex; align-items: center; justify-content: center; gap: 12px; min-height: 86px; padding: 15px;
+  border: 1px solid var(--line); border-radius: 16px; background: var(--surface-soft); font-size: 13px;
+}
+.interaction-preview strong { font-size: 11px; }
+.interaction-preview .cursor { color: var(--brand); font-size: 25px; transform: rotate(-20deg); }
+.interaction-preview kbd { padding: 9px 13px; border-radius: 10px; color: #fff; background: #252832; box-shadow: 0 5px 10px rgba(0, 0, 0, .18); font-size: 11px; }
+.selection-box { padding: 7px 9px; border: 1px dashed var(--brand); color: var(--brand-strong); }
+.pink-dot { width: 18px; height: 18px; border-radius: 50%; background: var(--brand); }
+.setting-row, .select-row {
+  gap: 18px; min-height: 66px; margin-top: 12px; padding: 13px 14px;
+  border: 1px solid var(--line); border-radius: 15px; background: var(--surface-soft);
+}
+.setting-row > span, .select-row > span { display: flex; flex: 1; flex-direction: column; }
+.setting-row strong, .select-row strong { font-size: 12px; }
+.setting-row small, .select-row small { margin-top: 3px; color: var(--muted); font-size: 9.5px; line-height: 1.4; }
+.choice-block { margin-top: 16px; }
+.chips { display: grid; gap: 8px; }
+.chips.two { grid-template-columns: repeat(2, 1fr); }
+.chips.three { grid-template-columns: repeat(3, 1fr); }
+.chips button {
+  min-height: 40px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 11px;
+  background: var(--surface); font-size: 11px; cursor: pointer;
+}
+.chips button.selected { border-color: var(--brand); color: var(--brand-strong); background: var(--brand-soft); box-shadow: 0 6px 16px rgba(239, 71, 118, .1); font-weight: 700; }
+.select-row select { width: 145px; flex: none; }
+.secondary-action, .drawer-settings-link {
+  width: 100%; min-height: 40px; margin-top: 10px; border: 1px solid var(--line); border-radius: 11px;
+  color: var(--brand-strong); background: var(--surface); font-size: 11px; font-weight: 700; cursor: pointer;
+}
+.drawer-settings-link { margin-top: 16px; border: 0; background: var(--surface-soft); }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition-duration: .01ms !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+}

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -36,7 +36,7 @@ button:focus-visible, select:focus-visible { outline: 3px solid rgba(239, 71, 11
 
 .popup-shell {
   min-height: 560px;
-  padding: 14px 16px;
+  padding: 14px 16px 5px;
   background:
     radial-gradient(circle at 92% 0, rgba(239, 71, 118, .12), transparent 30%),
     linear-gradient(180deg, #fff 0, #f7f8fb 165px, #f6f7fb 100%);
@@ -198,7 +198,29 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .feature-card > i { width: 6px; height: 6px; }
 .feature-card > b { color: var(--muted); font-size: 18px; font-weight: 400; }
 .feature-card:disabled, .translate-button:disabled, select:disabled { cursor: not-allowed; opacity: .48; }
-footer { margin-top: 12px; padding: 0 3px; color: var(--muted); font-size: 9.5px; }
+footer { display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); align-items: center; gap: 6px; margin-top: 12px; padding: 0 3px 1px; color: var(--muted); font-size: 9.5px; }
+footer > span { min-width: 0; }
+footer > button { justify-self: end; }
+.opensource-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 22px;
+  padding: 2px 6px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 9.5px;
+  font-weight: 650;
+  text-decoration: none;
+  transition: color .18s ease, background-color .18s ease, border-color .18s ease;
+}
+.opensource-link:hover { border-color: rgba(239, 71, 118, .25); color: var(--brand-strong); background: var(--brand-soft); }
+.opensource-link:focus-visible { outline: 3px solid rgba(239, 71, 118, .22); outline-offset: 2px; }
+.opensource-link svg { width: 12px; height: 12px; fill: currentColor; }
+.opensource-link .external-mark { color: var(--brand-strong); font-size: 12px; line-height: 1; }
+:root.dark .opensource-link:hover { border-color: rgba(255, 111, 151, .35); color: #ff9ab6; background: rgba(239, 71, 118, .14); }
 
 .popup-drawer-modal { background: rgba(17, 20, 29, .48) !important; backdrop-filter: blur(2px); }
 .popup-drawer {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -47,7 +47,7 @@ button:focus-visible, select:focus-visible { outline: 3px solid rgba(239, 71, 11
     linear-gradient(180deg, #1b1d23 0, #14161b 180px);
 }
 
-.popup-header, .brand, .header-actions, .hero-heading, .section-heading, footer,
+.popup-header, .brand, .header-actions, .hero-heading, footer,
 .setting-row, .select-row, .drawer-header { display: flex; align-items: center; justify-content: space-between; }
 .popup-header { margin-bottom: 12px; }
 .brand, .header-actions { gap: 9px; }
@@ -56,31 +56,19 @@ button:focus-visible, select:focus-visible { outline: 3px solid rgba(239, 71, 11
 .brand strong { font-size: 15px; line-height: 1.25; font-weight: 760; }
 .brand small { margin-top: 2px; color: var(--muted); font-size: 10px; }
 
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 9px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  color: var(--muted);
-  background: var(--surface);
-  font-size: 10px;
-  font-weight: 650;
-}
-.status-pill i, .feature-card > i {
+.feature-card > i {
   width: 7px; height: 7px; border-radius: 50%; background: #b8bec9;
 }
-.status-pill.active i, .feature-card > i.active {
+.feature-card > i.active {
   background: #24b47e;
   box-shadow: 0 0 0 4px rgba(36, 180, 126, .12);
 }
-.icon-button {
-  display: grid; place-items: center; width: 34px; height: 34px; padding: 8px;
-  border: 1px solid var(--line); border-radius: 11px; background: var(--surface); cursor: pointer;
+.settings-button {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-width: 68px; height: 34px; padding: 0 11px;
+  border: 1px solid var(--line); border-radius: 11px; color: var(--ink); background: var(--surface); font-size: 11px; font-weight: 700; cursor: pointer;
 }
-.icon-button:hover { border-color: rgba(239, 71, 118, .35); background: var(--brand-soft); }
-.icon-button svg { width: 17px; }
+.settings-button:hover { border-color: rgba(239, 71, 118, .35); color: var(--brand-strong); background: var(--brand-soft); }
+.settings-button svg { width: 17px; height: 17px; flex: none; }
 
 .hero-card {
   padding: 15px;
@@ -172,8 +160,8 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .notice.error { color: #d9345e; }
 
 .features { margin-top: 16px; }
-.section-heading { margin: 0 2px 11px; }
-.section-heading > button, footer button {
+.features-eyebrow { margin: 0 2px 10px; }
+footer button {
   padding: 0; border: 0; color: var(--brand-strong); background: none; font-size: 10px; font-weight: 700; cursor: pointer;
 }
 .feature-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -127,10 +127,6 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
   border-color: rgba(239, 71, 118, .48); box-shadow: 0 0 0 3px rgba(239, 71, 118, .08);
 }
 .service-field:disabled { cursor: not-allowed; opacity: .5; }
-.service-icon {
-  display: grid; place-items: center; width: 34px; height: 34px; border-radius: 10px;
-  color: var(--brand-strong); background: var(--brand-soft); font-size: 14px; font-weight: 800;
-}
 .service-copy { display: flex; flex: 1; flex-direction: column; min-width: 0; }
 .service-copy small { color: var(--muted); font-size: 9px; }
 .service-copy strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
@@ -155,10 +151,6 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 }
 .service-option:hover, .service-option[aria-selected="true"] { border-color: rgba(239, 71, 118, .22); background: var(--brand-soft); }
 .service-option > span:nth-child(2) { overflow: hidden; flex: 1; font-size: 11px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
-.service-option-icon {
-  display: grid; place-items: center; flex: none; width: 25px; height: 25px; border-radius: 8px;
-  color: var(--brand-strong); background: var(--brand-soft); font-size: 10px; font-weight: 800;
-}
 .service-option-check { color: var(--brand-strong); font-size: 14px; font-weight: 800; }
 .service-more-toggle { justify-content: space-between; margin-top: 7px; border-color: var(--line); background: var(--surface-soft); font-size: 10px; font-weight: 700; }
 .service-more-toggle:hover { border-color: rgba(239, 71, 118, .32); background: var(--brand-soft); }

--- a/entrypoints/utils/config-transfer.ts
+++ b/entrypoints/utils/config-transfer.ts
@@ -1,0 +1,49 @@
+import { isCustomBodyMapping } from './custom-body'
+import { defaultOption } from './option'
+
+type ConfigRecord = Record<string, any>
+
+const requiredConfigFields = ['on', 'service', 'display', 'from', 'to'] as const
+
+function isRecord(value: unknown): value is ConfigRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function isConfigImportValid(value: unknown): value is ConfigRecord {
+  if (!isRecord(value)) return false
+  if (!requiredConfigFields.every((field) => field in value)) return false
+  if (typeof value.service !== 'string') return false
+  return !('customBody' in value) || isCustomBodyMapping(value.customBody)
+}
+
+function removeDefaultEntries(target: ConfigRecord, key: 'system_role' | 'user_role', defaultValue: string) {
+  const entries = target[key]
+  if (!isRecord(entries)) return
+
+  for (const [service, value] of Object.entries(entries)) {
+    if (value === defaultValue) delete entries[service]
+  }
+
+  if (Object.keys(entries).length === 0) delete target[key]
+}
+
+function removeEmptyCustomBodies(target: ConfigRecord) {
+  const entries = target.customBody
+  if (!isRecord(entries)) return
+
+  for (const [service, value] of Object.entries(entries)) {
+    if (typeof value !== 'string' || !value.trim()) delete entries[service]
+  }
+
+  if (Object.keys(entries).length === 0) delete target.customBody
+}
+
+export function sanitizeConfigForExport(value: unknown): ConfigRecord {
+  if (!isRecord(value)) throw new Error('配置必须是 JSON 对象')
+
+  const sanitized = JSON.parse(JSON.stringify(value)) as ConfigRecord
+  removeDefaultEntries(sanitized, 'system_role', defaultOption.system_role)
+  removeDefaultEntries(sanitized, 'user_role', defaultOption.user_role)
+  removeEmptyCustomBodies(sanitized)
+  return sanitized
+}

--- a/entrypoints/utils/floatingBall.ts
+++ b/entrypoints/utils/floatingBall.ts
@@ -1,12 +1,18 @@
-import { createApp } from 'vue';
 import FloatingBall from '@/components/FloatingBall.vue';
 import { config } from '@/entrypoints/utils/config';
 import browser from 'webextension-polyfill';
 import { storage } from '@wxt-dev/storage';
 import { autoTranslateEnglishPage, restoreOriginalContent } from '@/entrypoints/main/trans';
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
+import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
 
 let floatingBallInstance: any = null;
 let app: any = null;
+let floatingBallUi: ShadowRootContentScriptUi<VueShadowMount> | null = null;
+let mountingPromise: Promise<any> | null = null;
+let mountRequestId = 0;
+let contentScriptContext: ContentScriptContext | null = null;
 let isTranslated = false; // 添加状态变量跟踪翻译状态
 
 /**
@@ -14,70 +20,82 @@ let isTranslated = false; // 添加状态变量跟踪翻译状态
  * @param position 悬浮球位置 'left' | 'right'，如果不传入则使用配置中的值
  * @returns 
  */
-export function mountFloatingBall(position?: 'left' | 'right') {
+export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' | 'right') {
+  if (ctx) contentScriptContext = ctx;
+
   // 如果配置禁用了悬浮球或已存在实例，则不创建
-  if (config.disableFloatingBall || floatingBallInstance) {
-    return;
+  if (config.disableFloatingBall || floatingBallInstance || mountingPromise) {
+    return mountingPromise;
   }
+
+  if (!contentScriptContext) return;
 
   // 使用传入的位置参数或配置中的位置
   const ballPosition = position || config.floatingBallPosition || 'right';
+  const requestId = ++mountRequestId;
   // 更新配置
   config.floatingBallPosition = ballPosition;
 
-  // 创建容器元素
-  const container = document.createElement('div');
-  container.id = 'fluent-read-floating-ball-container';
-  document.body.appendChild(container);
+  mountingPromise = createVueShadowUi(contentScriptContext, {
+    name: 'fluent-read-floating-ball-ui',
+    hostId: 'fluent-read-floating-ball-container',
+    component: FloatingBall,
+    props: {
+      position: ballPosition,
+      showMenu: true,
+      onDocClick: () => {
+      },
+      onSettingsClick: () => {
+        browser.runtime.sendMessage({ type: 'openOptionsPage' });
+      },
+      // 添加位置变化事件监听
+      onPositionChanged: (newPosition: 'left' | 'right') => {
+        // 保存位置到配置
+        config.floatingBallPosition = newPosition;
 
-  // 创建 Vue 应用实例
-  app = createApp(FloatingBall, {
-    position: ballPosition,
-    showMenu: true,
-    onDocClick: () => {
-    },
-    onSettingsClick: () => {
-      browser.runtime.sendMessage({ type: 'openOptionsPage' });
-    },
-    // 添加位置变化事件监听
-    onPositionChanged: (newPosition: 'left' | 'right') => {
-      // 保存位置到配置
-      config.floatingBallPosition = newPosition;
-      
-      // 保存配置到存储
-      saveConfig();
+        // 保存配置到存储
+        saveConfig();
+      },
+      // 添加翻译状态变化事件监听
+      onTranslationToggle: (isTranslating: boolean) => {
+        if (isTranslating && !isTranslated) {
+          // 触发翻译开始事件
+          document.dispatchEvent(new CustomEvent('fluentread-translation-started'));
 
-    },
-    // 添加翻译状态变化事件监听
-    onTranslationToggle: (isTranslating: boolean) => {
-      if (isTranslating && !isTranslated) {
-        // 触发翻译开始事件
-        document.dispatchEvent(new CustomEvent('fluentread-translation-started'));
+          // 触发即时翻译
+          autoTranslateEnglishPage();
+          isTranslated = true;
+        } else if (!isTranslating && isTranslated) {
+          // 触发翻译结束事件
+          document.dispatchEvent(new CustomEvent('fluentread-translation-ended'));
 
-        // 触发即时翻译
-        autoTranslateEnglishPage();
-        isTranslated = true;
-      } else if (!isTranslating && isTranslated) {
-        // 触发翻译结束事件
-        document.dispatchEvent(new CustomEvent('fluentread-translation-ended'));
-        
-        // 恢复原文
-        restoreOriginalContent();
-        isTranslated = false;
-        
-        // 恢复后确保状态同步
-        floatingBallInstance.$el.classList.remove('is-translating');
-      }
+          // 恢复原文
+          restoreOriginalContent();
+          isTranslated = false;
+
+          // 恢复后确保状态同步
+          floatingBallInstance.$el.classList.remove('is-translating');
+        }
+      },
+    },
+  }).then((ui) => {
+    if (requestId !== mountRequestId || config.disableFloatingBall) {
+      ui.remove();
+      return null;
     }
+
+    floatingBallUi = ui;
+    app = ui.mounted?.app ?? null;
+    floatingBallInstance = ui.mounted?.instance ?? null;
+
+    // 监听自定义事件，用于通过快捷键触发悬浮球
+    document.addEventListener('fluentread-toggle-translation', toggleFloatingBallTranslation);
+    return floatingBallInstance;
+  }).finally(() => {
+    mountingPromise = null;
   });
 
-  // 挂载应用
-  floatingBallInstance = app.mount(container);
-  
-  // 监听自定义事件，用于通过快捷键触发悬浮球
-  document.addEventListener('fluentread-toggle-translation', toggleFloatingBallTranslation);
-
-  return floatingBallInstance;
+  return mountingPromise;
 }
 
 /**
@@ -199,22 +217,15 @@ function saveConfig() {
  * 卸载悬浮球
  */
 export function unmountFloatingBall() {
-  if (floatingBallInstance && app) {
+  mountRequestId++;
+  if (floatingBallUi || (floatingBallInstance && app)) {
     // 移除事件监听
     document.removeEventListener('fluentread-toggle-translation', toggleFloatingBallTranslation);
     
-    // 获取容器
-    const container = document.getElementById('fluent-read-floating-ball-container');
-    
-    // 卸载 Vue 应用
-    app.unmount();
+    floatingBallUi?.remove();
+    floatingBallUi = null;
     floatingBallInstance = null;
     app = null;
-    
-    // 移除容器
-    if (container) {
-      container.remove();
-    }
   }
 }
 
@@ -242,11 +253,11 @@ export function toggleFloatingBallPosition() {
   if (floatingBallInstance) {
     unmountFloatingBall();
     config.floatingBallPosition = newPosition;
-    mountFloatingBall(newPosition);
+    mountFloatingBall(undefined, newPosition);
   } else {
     config.floatingBallPosition = newPosition;
   }
   
   // 保存配置到存储
   saveConfig();
-} 
+}

--- a/entrypoints/utils/selectionTranslator.ts
+++ b/entrypoints/utils/selectionTranslator.ts
@@ -1,51 +1,63 @@
-import { createApp } from 'vue';
 import SelectionTranslator from '@/components/SelectionTranslator.vue';
 import { config } from '@/entrypoints/utils/config';
 import { storage } from '@wxt-dev/storage';
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
+import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
 
 let selectionTranslatorInstance: any = null;
 let app: any = null;
+let selectionTranslatorUi: ShadowRootContentScriptUi<VueShadowMount> | null = null;
+let mountingPromise: Promise<any> | null = null;
+let mountRequestId = 0;
+let contentScriptContext: ContentScriptContext | null = null;
 
 /**
  * 挂载选词翻译组件
  */
-export function mountSelectionTranslator() {
+export function mountSelectionTranslator(ctx?: ContentScriptContext) {
+  if (ctx) contentScriptContext = ctx;
+
   // 如果已存在实例或配置禁用了此功能，则不创建
-  if (selectionTranslatorInstance || config.disableSelectionTranslator || config.selectionTranslatorMode === 'disabled') {
-    return;
+  if (selectionTranslatorInstance || mountingPromise || config.disableSelectionTranslator || config.selectionTranslatorMode === 'disabled') {
+    return mountingPromise;
   }
 
-  // 创建容器元素
-  const container = document.createElement('div');
-  container.id = 'fluent-read-selection-translator-container';
-  document.body.appendChild(container);
+  if (!contentScriptContext) return;
 
-  // 创建Vue应用实例
-  app = createApp(SelectionTranslator);
+  const requestId = ++mountRequestId;
+  mountingPromise = createVueShadowUi(contentScriptContext, {
+    name: 'fluent-read-selection-translator-ui',
+    hostId: 'fluent-read-selection-translator-container',
+    component: SelectionTranslator,
+    zIndex: 2_147_483_646,
+  }).then((ui) => {
+    if (requestId !== mountRequestId || config.disableSelectionTranslator || config.selectionTranslatorMode === 'disabled') {
+      ui.remove();
+      return null;
+    }
 
-  // 挂载应用
-  selectionTranslatorInstance = app.mount(container);
+    selectionTranslatorUi = ui;
+    app = ui.mounted?.app ?? null;
+    selectionTranslatorInstance = ui.mounted?.instance ?? null;
+    return selectionTranslatorInstance;
+  }).finally(() => {
+    mountingPromise = null;
+  });
 
-  return selectionTranslatorInstance;
+  return mountingPromise;
 }
 
 /**
  * 卸载选词翻译组件
  */
 export function unmountSelectionTranslator() {
-  if (selectionTranslatorInstance && app) {
-    // 获取容器
-    const container = document.getElementById('fluent-read-selection-translator-container');
-    
-    // 卸载Vue应用
-    app.unmount();
+  mountRequestId++;
+  if (selectionTranslatorUi || (selectionTranslatorInstance && app)) {
+    selectionTranslatorUi?.remove();
+    selectionTranslatorUi = null;
     selectionTranslatorInstance = null;
     app = null;
-    
-    // 移除容器
-    if (container) {
-      container.remove();
-    }
   }
 }
 
@@ -73,4 +85,4 @@ function saveConfig() {
   storage.setItem('local:config', JSON.stringify(config)).catch((error) => {
     console.error('Failed to save config:', error);
   });
-} 
+}

--- a/entrypoints/utils/serviceCatalog.ts
+++ b/entrypoints/utils/serviceCatalog.ts
@@ -1,0 +1,56 @@
+export interface ServiceOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export interface ServiceGroup {
+  id: string
+  label: string
+  items: ServiceOption[]
+}
+
+export function cleanServiceLabel(label: string) {
+  return label.replace(/[⭐️★]+/gu, '').trim()
+}
+
+export function buildServiceGroups(options: ServiceOption[]): ServiceGroup[] {
+  const groups: ServiceGroup[] = []
+  let current: ServiceGroup = { id: 'other', label: '其他服务', items: [] }
+
+  for (const option of options) {
+    if (option.disabled) {
+      if (current.items.length) groups.push(current)
+      current = {
+        id: option.value,
+        label: cleanServiceLabel(option.label),
+        items: [],
+      }
+      continue
+    }
+    current.items.push({ ...option, label: cleanServiceLabel(option.label) })
+  }
+
+  if (current.items.length) groups.push(current)
+  return groups
+}
+
+export function filterServiceGroups(groups: ServiceGroup[], query: string) {
+  const keyword = query.trim().toLocaleLowerCase()
+  if (!keyword) return groups
+
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) =>
+        `${item.label}${item.value}`.toLocaleLowerCase().includes(keyword),
+      ),
+    }))
+    .filter((group) => group.items.length > 0)
+}
+
+export function filterModels(modelOptions: string[], query: string) {
+  const keyword = query.trim().toLocaleLowerCase()
+  if (!keyword) return modelOptions
+  return modelOptions.filter((model) => model.toLocaleLowerCase().includes(keyword))
+}

--- a/entrypoints/utils/serviceCatalog.ts
+++ b/entrypoints/utils/serviceCatalog.ts
@@ -54,3 +54,16 @@ export function filterModels(modelOptions: string[], query: string) {
   if (!keyword) return modelOptions
   return modelOptions.filter((model) => model.toLocaleLowerCase().includes(keyword))
 }
+
+export function splitModelOptions(modelOptions: string[], selectedModel = '', visibleCount = 4) {
+  const common = modelOptions.slice(0, visibleCount)
+
+  if (selectedModel && modelOptions.includes(selectedModel) && !common.includes(selectedModel)) {
+    common.splice(Math.max(visibleCount - 1, 0), 1, selectedModel)
+  }
+
+  return {
+    common,
+    more: modelOptions.filter((model) => !common.includes(model)),
+  }
+}

--- a/entrypoints/utils/shadowUi.ts
+++ b/entrypoints/utils/shadowUi.ts
@@ -1,0 +1,82 @@
+import { createApp, type App as VueApp, type Component } from 'vue';
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import {
+  createShadowRootUi,
+  type ShadowRootContentScriptUi,
+} from 'wxt/utils/content-script-ui/shadow-root';
+
+export interface VueShadowMount {
+  app: VueApp;
+  instance: any;
+}
+
+interface VueShadowUiOptions {
+  name: string;
+  hostId: string;
+  component: Component;
+  props?: Record<string, unknown>;
+  zIndex?: number;
+}
+
+const SHADOW_FOUNDATION = `
+  :host {
+    all: initial !important;
+    display: block !important;
+    position: relative !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: visible !important;
+    contain: none !important;
+    color-scheme: light dark;
+  }
+
+  html,
+  body {
+    width: 0 !important;
+    height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: visible !important;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+`;
+
+/**
+ * Mount a Vue widget into an isolated Shadow DOM tree.
+ *
+ * The host remains in the page document, but both WXT's reset and the explicit
+ * host foundation prevent inherited page styles from leaking into the widget.
+ */
+export async function createVueShadowUi(
+  ctx: ContentScriptContext,
+  options: VueShadowUiOptions,
+): Promise<ShadowRootContentScriptUi<VueShadowMount>> {
+  const ui = await createShadowRootUi<VueShadowMount>(ctx, {
+    name: options.name,
+    position: 'overlay',
+    alignment: 'top-left',
+    zIndex: options.zIndex ?? 2_147_483_647,
+    mode: 'open',
+    inheritStyles: false,
+    isolateEvents: ['keydown', 'keyup', 'keypress'],
+    css: SHADOW_FOUNDATION,
+    onMount(container) {
+      const app = createApp(options.component, options.props ?? {});
+      const instance = app.mount(container);
+      return { app, instance };
+    },
+    onRemove(mounted) {
+      mounted?.app.unmount();
+    },
+  });
+
+  ui.shadowHost.id = options.hostId;
+  ui.shadowHost.setAttribute('data-fluent-read-ui', options.name);
+  ui.mount();
+  return ui;
+}

--- a/tests/configTransfer.test.ts
+++ b/tests/configTransfer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { defaultOption } from '@/entrypoints/utils/option'
+import {
+  isConfigImportValid,
+  sanitizeConfigForExport,
+} from '@/entrypoints/utils/config-transfer'
+
+const validConfig = {
+  on: true,
+  service: 'openai',
+  display: 1,
+  from: 'auto',
+  to: 'zh-Hans',
+}
+
+describe('configuration transfer helpers', () => {
+  it('accepts the minimum import shape and rejects malformed values', () => {
+    expect(isConfigImportValid(validConfig)).toBe(true)
+    expect(isConfigImportValid({ ...validConfig, service: 42 })).toBe(false)
+    expect(isConfigImportValid({ ...validConfig, customBody: { openai: '{}' } })).toBe(true)
+    expect(isConfigImportValid({ ...validConfig, customBody: { openai: null } })).toBe(false)
+    expect(isConfigImportValid({ ...validConfig, to: undefined })).toBe(true)
+    expect(isConfigImportValid({ service: 'openai' })).toBe(false)
+    expect(isConfigImportValid(null)).toBe(false)
+  })
+
+  it('removes default-only fields without mutating the source', () => {
+    const source = {
+      ...validConfig,
+      system_role: {
+        openai: defaultOption.system_role,
+        deepseek: 'Translate with a concise tone.',
+      },
+      user_role: {
+        openai: defaultOption.user_role,
+      },
+      customBody: {
+        openai: '   ',
+        deepseek: '{"thinking":{"type":"disabled"}}',
+      },
+    }
+
+    const sanitized = sanitizeConfigForExport(source)
+
+    expect(sanitized).toEqual({
+      ...validConfig,
+      system_role: { deepseek: 'Translate with a concise tone.' },
+      customBody: { deepseek: '{"thinking":{"type":"disabled"}}' },
+    })
+    expect(source.system_role).toHaveProperty('openai')
+    expect(source.user_role).toHaveProperty('openai')
+    expect(source.customBody).toHaveProperty('openai')
+  })
+
+  it('removes empty maps after cleaning their entries', () => {
+    const sanitized = sanitizeConfigForExport({
+      ...validConfig,
+      system_role: { openai: defaultOption.system_role },
+      user_role: { openai: defaultOption.user_role },
+      customBody: { openai: '' },
+    })
+
+    expect(sanitized).toEqual(validConfig)
+  })
+})

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -4,6 +4,7 @@ import {
   cleanServiceLabel,
   filterModels,
   filterServiceGroups,
+  splitModelOptions,
 } from '@/entrypoints/utils/serviceCatalog'
 
 const options = [
@@ -52,5 +53,21 @@ describe('service catalog helpers', () => {
 
   it('removes decorative recommendation stars from labels', () => {
     expect(cleanServiceLabel('硅基流动⭐️')).toBe('硅基流动')
+  })
+
+  it('keeps common models short and promotes the current selection', () => {
+    const models = ['one', 'two', 'three', 'four', 'five', 'six']
+
+    expect(splitModelOptions(models, 'six')).toEqual({
+      common: ['one', 'two', 'three', 'six'],
+      more: ['four', 'five'],
+    })
+  })
+
+  it('does not create a more group for a short model list', () => {
+    expect(splitModelOptions(['one', 'two'], 'two')).toEqual({
+      common: ['one', 'two'],
+      more: [],
+    })
   })
 })

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -6,6 +6,7 @@ import {
   filterServiceGroups,
   splitModelOptions,
 } from '@/entrypoints/utils/serviceCatalog'
+import { customModelString, models, servicesType } from '@/entrypoints/utils/option'
 
 const options = [
   { value: 'machine', label: '机器翻译', disabled: true },
@@ -69,5 +70,12 @@ describe('service catalog helpers', () => {
       common: ['one', 'two'],
       more: [],
     })
+  })
+
+  it('为所有需要模型的 AI 服务提供自定义模型入口', () => {
+    for (const service of servicesType.useModel) {
+      expect(models.get(service), `${service} 缺少模型列表`).toBeDefined()
+      expect(models.get(service), `${service} 缺少自定义模型`).toContain(customModelString)
+    }
   })
 })

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildServiceGroups,
+  cleanServiceLabel,
+  filterModels,
+  filterServiceGroups,
+} from '@/entrypoints/utils/serviceCatalog'
+
+const options = [
+  { value: 'machine', label: '机器翻译', disabled: true },
+  { value: 'microsoft', label: '微软翻译' },
+  { value: 'chromeTranslator', label: 'Chrome内置AI翻译⭐' },
+  { value: 'ai', label: 'AI翻译', disabled: true },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'deepseek', label: 'DeepSeek️' },
+]
+
+describe('service catalog helpers', () => {
+  it('preserves divider-based service grouping', () => {
+    expect(buildServiceGroups(options)).toEqual([
+      {
+        id: 'machine',
+        label: '机器翻译',
+        items: [
+          { value: 'microsoft', label: '微软翻译' },
+          { value: 'chromeTranslator', label: 'Chrome内置AI翻译' },
+        ],
+      },
+      {
+        id: 'ai',
+        label: 'AI翻译',
+        items: [
+          { value: 'openai', label: 'OpenAI' },
+          { value: 'deepseek', label: 'DeepSeek' },
+        ],
+      },
+    ])
+  })
+
+  it('filters services without losing their category', () => {
+    expect(filterServiceGroups(buildServiceGroups(options), 'open')).toEqual([
+      { id: 'ai', label: 'AI翻译', items: [{ value: 'openai', label: 'OpenAI' }] },
+    ])
+  })
+
+  it('filters model identifiers case-insensitively', () => {
+    expect(filterModels(['gpt-5-mini', 'GPT-4o', '自定义模型'], 'gpt')).toEqual([
+      'gpt-5-mini',
+      'GPT-4o',
+    ])
+  })
+
+  it('removes decorative recommendation stars from labels', () => {
+    expect(cleanServiceLabel('硅基流动⭐️')).toBe('硅基流动')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./.wxt/tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "node"
-  }
+  "extends": "./.wxt/tsconfig.json"
 }


### PR DESCRIPTION
## 概要
- 重塑 400×600 扩展弹窗，保留现有翻译、语言、服务、缓存与功能开关
- 增加沉浸式底部快捷设置抽屉，覆盖悬停、划词、悬浮球和译文显示
- 新增现代化完整设置页、搜索与响应式导航
- 修复 options page 创建失败和开发重载时右键菜单重复 ID
- 增加可访问名称、暗色主题及减少动态效果适配

## 验证
- pnpm dev：开发构建并打开 WXT 隔离浏览器
- pnpm compile
- pnpm test：30/30
- pnpm build：Chrome MV3
- pnpm build:firefox：Firefox MV2
- FluentRead UI Skill：10 类断言通过，0 errors，0 warnings
- 真实浏览器翻译回归：译文节点 1 → 0 → 1，翻译/还原/再次翻译通过

## 说明
- 参考沉浸式翻译与阅读蛙的交互组织方式，按 FluentRead 的 Vue/WXT 架构独立实现
- 未修改参考仓库

## Summary by Sourcery

通过全新的沉浸式 UI、底部抽屉式快捷设置，以及完整响应式选项页面，对扩展的弹窗和设置体验进行现代化改造，同时改进上下文菜单处理和可访问性。

新功能：
- 引入重新设计的弹窗布局，将语言选择、服务选择以及一键整页翻译控制集成到同一界面中。
- 添加沉浸式底部抽屉，用于快速配置悬停翻译、选中翻译、悬浮球行为以及翻译显示样式。
- 创建专用的完整选项页面，包含侧边栏导航、可搜索的设置分区以及响应式布局。

缺陷修复：
- 通过在重新创建扩展菜单之前清理现有扩展菜单，避免在开发环境重新加载时产生重复的上下文菜单 ID。
- 确保上下文菜单状态只在成功完成初始化后再更新，并通过就绪标志来保护更新过程，避免错误。
- 添加选项页面入口点，并将其与弹窗和后台脚本的打开逻辑连接，修复选项页面创建失败的问题。

增强：
- 在弹窗中持久化并跨标签页广播配置变更，包括插件启用状态、选择模式以及悬浮球状态。
- 为弹窗和选项页面 UI 应用明/暗主题模型，以尊重系统的配色方案和减少动画偏好设置。
- 通过添加分区锚点和标签改进设置表单结构，以支持从选项页面进行导航和搜索。

构建：
- 注册 Element Plus 抽屉组件以及新弹窗和选项 UI 所需的其他组件。
- 在扩展构建配置中添加独立的选项入口点（HTML、TS 启动脚本和样式）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modernize the extension’s popup and settings experience with a new immersive UI, bottom drawer quick settings, and a full responsive options page, while improving context menu handling and accessibility.

New Features:
- Introduce a redesigned popup layout with inline language, service selection, and one-click page translation controls.
- Add an immersive bottom drawer for quick configuration of hover translation, selection translation, floating ball behavior, and translation appearance.
- Create a dedicated full options page with sidebar navigation, searchable settings sections, and responsive layout.

Bug Fixes:
- Prevent duplicate context menu IDs during development reloads by clearing existing extension menus before recreating them.
- Ensure context menu state updates only after successful setup and avoid errors by guarding updates with a readiness flag.
- Add an options-page entrypoint and wiring for opening it from the popup and background script, fixing options page creation failures.

Enhancements:
- Persist and broadcast configuration changes across tabs from the popup, including plugin enablement, selection mode, and floating ball state.
- Apply a light/dark theming model to popup and options UIs that respects system color scheme and reduced-motion preferences.
- Improve settings form structure by adding section anchors and labels to support navigation and search from the options page.

Build:
- Register Element Plus drawer and other components required by the new popup and options UIs.
- Add a standalone options entrypoint (HTML, TS bootstrap, and styles) to the extension build configuration.

</details>