### PR TITLE
feat: 增加 DeepLX 免费备用站点

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -232,13 +232,21 @@
     <el-row v-show="compute.showDeepLX" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
-          content="DeepLX API 服务地址，默认为本地地址。如果使用远程 DeepLX 服务，请修改为对应的服务地址" placement="top-start"
+          content="DeepLX 是非官方免费服务。可填写多个地址，每行或逗号分隔；请求会按顺序故障转移。公共站点可能记录翻译文本，敏感内容建议使用本地或自建服务。"
+          placement="top-start"
           :show-after="500">
           <span class="popup-text popup-vertical-left">服务地址</span>
         </el-tooltip>
       </el-col>
       <el-col :span="12">
-        <el-input v-model="config.deeplx" placeholder="http://localhost:1188/translate" />
+        <el-input
+          v-model="config.deeplx"
+          type="textarea"
+          :rows="3"
+          resize="vertical"
+          placeholder="https://deeplx.1stg.me/translate&#10;http://localhost:1188/translate"
+        />
+        <div class="deeplx-hint">每行或逗号分隔，按顺序尝试；默认使用已验证的公共站点。</div>
       </el-col>
     </el-row>
 
@@ -1683,5 +1691,12 @@ const validateConfig = (configData: any): boolean => {
   font-size: 12px;
   margin-top: 4px;
   line-height: 1.4;
+}
+
+.deeplx-hint {
+  color: var(--fr-secondary-text-color, #909399);
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 4px;
 }
 </style>

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -8,11 +8,22 @@
 - **Microsoft 翻译**：免费且无需配置，开箱即用，支持多种语言互译
 - **Google 翻译**：免费且无需配置，支持多种语言，国内暂不支持使用
 - **DeepL (免费版)**：每月 50 万字符免费额度，[开发者平台](https://www.deepl.com/pro-api)
-- **DeepLX**：免费的 DeepL 翻译代理服务，需自行部署，[项目地址](https://deeplx.owo.network/)
+- **DeepLX（免费非官方）**：无需官方 API Key 的 DeepL 兼容服务。默认使用已验证的公共站点，也支持在设置中填入本地、自建或多个备用地址；公共站点可能记录文本，敏感内容建议使用自建服务。[项目文档](https://deeplx.owo.network/)
 - **小牛翻译**：[API 文档](https://niutrans.com/dev-page?type=text)
 - **有道翻译**：新用户可获体验资金，具体额度以[官方计费规则](https://ai.youdao.com/DOCSIRMA/html/trans/price/wbfy/index.html)为准
 - **腾讯云文本翻译**：每月 500 万字符免费额度，[产品页面](https://cloud.tencent.com/product/tmt)
 - **Chrome 内置 AI 翻译**：使用浏览器内置 Translator API，无需 API Key，仅支持 Google Chrome 138 Stable 及以上版本，[开发文档](https://developer.chrome.com/docs/ai/translator-api?hl=zh-cn)
+
+#### DeepLX 备用地址
+
+在 DeepLX 的“服务地址”中可以填写多个地址，每行或逗号分隔。插件会按填写顺序请求，当前地址失败或返回无效响应时自动尝试下一个地址：
+
+```text
+https://deeplx.1stg.me/translate
+http://localhost:1188/translate
+```
+
+`deeplx.1stg.me` 是当前验证可用的公共实例；公共实例属于非官方服务，可能限流、停用或记录请求内容。敏感文本建议使用本地或自建 DeepLX 服务。
 
 ### AI 大模型
 - **OpenAI（推荐⭐️）**：国际领先的大模型服务，支持 GPT-4o 和 GPT-o1-mini 等，[API 文档](https://platform.openai.com/docs/api-reference)

--- a/entrypoints/service/deeplx.ts
+++ b/entrypoints/service/deeplx.ts
@@ -1,47 +1,150 @@
-import {method} from "../utils/constant";
 import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
+import {getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
 
-async function deeplx(message: any) {
-    // deeplx 不支持 zh-Hans，需要转换为 zh
-    let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
-    let sourceLang = config.from === 'auto' ? 'auto' : config.from;
-    
-    // 判断是否使用代理或自定义URL
-    let url: string = config.proxy[config.service] ? config.proxy[config.service] : config.deeplx || 'http://localhost:1188/translate';
+const DEEPLX_TOTAL_TIMEOUT_MS = 20_000;
+const DEEPLX_ATTEMPT_TIMEOUT_MS = 8_000;
+const DEEPLX_ERROR_BODY_PREVIEW_LENGTH = 200;
 
-    // 构建请求头
-    let headers: HeadersInit = {
-        'Content-Type': 'application/json'
-    };
-
-    // 如果有 token，则添加 Authorization 头
-    if (config.token[services.deeplx] && config.token[services.deeplx].trim() !== '') {
-        headers['Authorization'] = `Bearer ${config.token[services.deeplx]}`;
+function normalizeLanguage(language: string): string {
+    const normalized = language.toLowerCase();
+    if (normalized === "auto") {
+        return "AUTO";
     }
+    if (normalized === "zh-hans" || normalized === "zh-cn") {
+        return "ZH";
+    }
+    if (normalized === "zh-tw" || normalized === "zh-hant") {
+        return "ZH-HANT";
+    }
+    return language.toUpperCase();
+}
 
-    const resp = await fetch(url, {
-        method: method.POST,
-        headers: headers,
-        body: JSON.stringify({
-            text: message.origin,
-            source_lang: sourceLang.toUpperCase(),
-            target_lang: targetLang.toUpperCase()
-        })
-    });
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
 
-    if (resp.ok) {
-        let result = await resp.json();
-        // DeepLX 返回格式通常是 { code: 200, data: "translated text" }
-        if (result.code === 200) {
-            return result.data;
-        } else {
-            throw new Error(`DeepLX 翻译失败: ${result.message || '未知错误'}`);
+function formatResponseBody(responseBody: string): string {
+    const compactBody = responseBody.replace(/\s+/g, " ").trim();
+    return compactBody.slice(0, DEEPLX_ERROR_BODY_PREVIEW_LENGTH);
+}
+
+async function fetchDeepLX(url: string, requestInit: RequestInit, timeoutMs: number): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        return await fetch(url, {...requestInit, signal: controller.signal});
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw new Error(`请求超时（${timeoutMs / 1000} 秒）`);
         }
-    } else {
-        console.log("DeepLX 翻译失败：", resp);
-        throw new Error(`DeepLX 翻译失败: ${resp.status} ${resp.statusText} body: ${await resp.text()}`);
+        throw new Error(`网络错误: ${getErrorMessage(error)}`);
+    } finally {
+        clearTimeout(timeout);
     }
+}
+
+async function translateFromDeepLX(
+    url: string,
+    text: string,
+    sourceLang: string,
+    targetLang: string,
+    token: string,
+    timeoutMs: number,
+): Promise<string> {
+    const headers: HeadersInit = {
+        "Content-Type": "application/json",
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetchDeepLX(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+            text,
+            source_lang: sourceLang,
+            target_lang: targetLang,
+        }),
+    }, timeoutMs);
+
+    const responseBody = await response.text();
+    if (!response.ok) {
+        const preview = formatResponseBody(responseBody);
+        throw new Error(`HTTP ${response.status} ${response.statusText}${preview ? `，响应: ${preview}` : ""}`);
+    }
+
+    let result: unknown;
+    try {
+        result = JSON.parse(responseBody);
+    } catch (error) {
+        throw new Error(`返回的不是 JSON: ${getErrorMessage(error)}`);
+    }
+
+    if (!result || typeof result !== "object") {
+        throw new Error("返回格式异常");
+    }
+
+    const responseData = result as {code?: unknown; data?: unknown; message?: unknown};
+    if (responseData.code !== undefined && responseData.code !== 200) {
+        throw new Error(`DeepLX 返回错误: ${String(responseData.message || `code ${String(responseData.code)}`)}`);
+    }
+    if (typeof responseData.data !== "string" || responseData.data.trim().length === 0) {
+        throw new Error("返回格式异常：缺少译文");
+    }
+
+    return responseData.data;
+}
+
+export function normalizeDeepLXLanguage(language: string): string {
+    return normalizeLanguage(language);
+}
+
+export function getDeepLXRequestLanguages(from: string, to: string): {sourceLang: string; targetLang: string} {
+    return {
+        sourceLang: normalizeLanguage(from),
+        targetLang: normalizeLanguage(to),
+    };
+}
+
+async function deeplx(message: {origin: string}) {
+    if (typeof message.origin !== "string") {
+        throw new Error("DeepLX 翻译仅支持单条文本");
+    }
+
+    const endpoints = getDeepLXEndpoints(
+        config.deeplx,
+        config.proxy[config.service],
+    );
+    const token = config.token[services.deeplx]?.trim() || "";
+    const {sourceLang, targetLang} = getDeepLXRequestLanguages(config.from, config.to);
+    const deadline = Date.now() + DEEPLX_TOTAL_TIMEOUT_MS;
+    const failures: string[] = [];
+
+    for (const [index, endpoint] of endpoints.entries()) {
+        const remainingTime = deadline - Date.now();
+        if (remainingTime <= 0) {
+            break;
+        }
+
+        try {
+            return await translateFromDeepLX(
+                endpoint,
+                message.origin,
+                sourceLang,
+                targetLang,
+                token,
+                Math.min(DEEPLX_ATTEMPT_TIMEOUT_MS, remainingTime),
+            );
+        } catch (error) {
+            failures.push(`备用站点 ${index + 1}: ${getErrorMessage(error)}`);
+        }
+    }
+
+    const failureSummary = failures.length > 0 ? failures.join("；") : "总请求时间已耗尽";
+    throw new Error(`DeepLX 所有备用站点均失败：${failureSummary}`);
 }
 
 export default deeplx;

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -1,9 +1,10 @@
 import { services } from "./option";
+import {DEFAULT_DEEPLX_ENDPOINT} from "./deeplx";
 
 // 常量工具类
 export const urls: any = {
     [services.deepL]: "https://api-free.deepl.com/v2/translate",
-    [services.deeplx]: "http://localhost:1188/translate",
+    [services.deeplx]: DEFAULT_DEEPLX_ENDPOINT,
     [services.openai]: "https://api.openai.com/v1/chat/completions",
     [services.azureOpenai]: "https://your-resource-name.openai.azure.com/openai/deployments/your-deployment-name/chat/completions?api-version=2024-02-15-preview",
     [services.moonshot]: "https://api.moonshot.cn/v1/chat/completions",

--- a/entrypoints/utils/deeplx.ts
+++ b/entrypoints/utils/deeplx.ts
@@ -1,0 +1,25 @@
+/**
+ * The public endpoint is an unofficial DeepLX deployment. Keep it explicit so
+ * users can replace it with a local or self-hosted endpoint at any time.
+ */
+export const DEFAULT_DEEPLX_ENDPOINT = "https://deeplx.1stg.me/translate"
+
+const DEEPLX_ENDPOINT_SEPARATOR = /[\n,]+/
+
+export function parseDeepLXEndpoints(value: unknown): string[] {
+  if (typeof value !== "string") {
+    return []
+  }
+
+  return [...new Set(value.split(DEEPLX_ENDPOINT_SEPARATOR).map((endpoint) => endpoint.trim()).filter(Boolean))]
+}
+
+export function getDeepLXEndpoints(configuredURL: unknown, proxyURL: unknown): string[] {
+  const proxyEndpoints = parseDeepLXEndpoints(proxyURL)
+  if (proxyEndpoints.length > 0) {
+    return proxyEndpoints
+  }
+
+  const configuredEndpoints = parseDeepLXEndpoints(configuredURL)
+  return configuredEndpoints.length > 0 ? configuredEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
+}

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -93,7 +93,7 @@ export class Config {
         this.customFloatingBallHotkey = ''; // 自定义快捷键为空
         this.customHotkey = ''; // 自定义鼠标悬浮快捷键为空
         this.disableSelectionTranslator = false; // 默认不禁用划词翻译
-        this.deeplx = ''; // DeepLX 默认服务地址
+        this.deeplx = defaultOption.deeplx; // DeepLX 默认服务地址
         this.selectionTranslatorMode = 'bilingual'; // 默认双语显示模式
         this.newApiUrl = 'http://localhost:3000'; // NewAPI 默认地址
         this.maxConcurrentTranslations = 6; // 默认最大并发数为6

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -1,3 +1,5 @@
+import {DEFAULT_DEEPLX_ENDPOINT} from "./deeplx";
+
 export const services = {
     // 机器翻译
     microsoft: "microsoft",
@@ -296,7 +298,7 @@ export const options = {
         {value: services.microsoft, label: "微软翻译"},
         {value: services.google, label: "谷歌翻译"},
         {value: services.deepL, label: "DeepL"},
-        {value: services.deeplx, label: "DeepLX"},
+        {value: services.deeplx, label: "DeepLX（免费非官方）"},
         {value: services.xiaoniu, label: "小牛翻译"},
         {value: services.youdao, label: "有道翻译"},
         {value: services.tencent, label: "腾讯云翻译"},
@@ -435,7 +437,7 @@ export const defaultOption = {
     hotkey: "Control",
     service: services.microsoft,
     custom: "http://localhost:11434/v1/chat/completions",
-    deeplx: "http://localhost:1188/translate",
+    deeplx: DEFAULT_DEEPLX_ENDPOINT,
     system_role:
         "You are a professional, authentic machine translation engine.",
     user_role: `Translate the following text into {{to}}, If translation is unnecessary (e.g. proper nouns, codes, etc.), return the original text. NO explanations. NO notes:

--- a/tests/deeplx.test.ts
+++ b/tests/deeplx.test.ts
@@ -1,0 +1,126 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+const {mockConfig} = vi.hoisted(() => ({
+    mockConfig: {
+        from: "auto",
+        to: "zh-Hans",
+        service: "deeplx",
+        deeplx: "",
+        proxy: {} as Record<string, string>,
+        token: {} as Record<string, string>,
+    },
+}));
+
+vi.mock("@/entrypoints/utils/config", () => ({config: mockConfig}));
+
+import deeplx, {
+    getDeepLXRequestLanguages,
+    normalizeDeepLXLanguage,
+} from "@/entrypoints/service/deeplx";
+import {DEFAULT_DEEPLX_ENDPOINT, getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function mockResponse(body: unknown, overrides: Partial<Response> = {}): Response {
+    return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+        ...overrides,
+    } as unknown as Response;
+}
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    mockConfig.from = "auto";
+    mockConfig.to = "zh-Hans";
+    mockConfig.deeplx = "";
+    mockConfig.proxy = {};
+    mockConfig.token = {};
+    vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe("DeepLX endpoint configuration", () => {
+    it("uses the verified public endpoint when no URL is configured", () => {
+        expect(getDeepLXEndpoints("", "")).toEqual([DEFAULT_DEEPLX_ENDPOINT]);
+    });
+
+    it("parses comma- and newline-separated URLs and gives proxy URLs priority", () => {
+        expect(getDeepLXEndpoints("https://one.example/translate,\nhttps://two.example/translate", ""))
+            .toEqual(["https://one.example/translate", "https://two.example/translate"]);
+        expect(getDeepLXEndpoints("https://configured.example/translate", "https://proxy.example/translate"))
+            .toEqual(["https://proxy.example/translate"]);
+    });
+});
+
+describe("DeepLX adapter", () => {
+    it("sends the expected request and parses a successful response", async () => {
+        fetchMock.mockResolvedValue(mockResponse({code: 200, data: "你好"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("你好");
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0]!;
+        expect(url).toBe(DEFAULT_DEEPLX_ENDPOINT);
+        expect(init).toMatchObject({method: "POST"});
+        expect(init?.headers).toEqual({"Content-Type": "application/json"});
+        expect(JSON.parse(String(init?.body))).toEqual({
+            text: "Hello",
+            source_lang: "AUTO",
+            target_lang: "ZH",
+        });
+    });
+
+    it("falls back to the next configured URL after an HTTP failure", async () => {
+        mockConfig.deeplx = "https://primary.example/translate,\nhttps://backup.example/translate";
+        fetchMock
+            .mockResolvedValueOnce(mockResponse({message: "busy"}, {
+                ok: false,
+                status: 503,
+                statusText: "Service Unavailable",
+                text: vi.fn().mockResolvedValue("busy"),
+            }))
+            .mockResolvedValueOnce(mockResponse({code: 200, data: "备用译文"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("备用译文");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1]?.[0]).toBe("https://backup.example/translate");
+    });
+
+    it("falls back after an invalid DeepLX response", async () => {
+        mockConfig.deeplx = "https://invalid.example/translate,https://valid.example/translate";
+        fetchMock
+            .mockResolvedValueOnce(mockResponse({code: 200, data: ""}))
+            .mockResolvedValueOnce(mockResponse({code: 200, data: "有效译文"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("有效译文");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("adds an optional bearer token without exposing it in the URL", async () => {
+        mockConfig.token = {deeplx: "test-token"};
+        fetchMock.mockResolvedValue(mockResponse({code: 200, data: "你好"}));
+
+        await deeplx({origin: "Hello"});
+
+        expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+        });
+    });
+
+    it("normalizes Chinese language variants", () => {
+        expect(normalizeDeepLXLanguage("zh-Hans")).toBe("ZH");
+        expect(normalizeDeepLXLanguage("zh-TW")).toBe("ZH-HANT");
+        expect(getDeepLXRequestLanguages("auto", "zh-Hans")).toEqual({
+            sourceLang: "AUTO",
+            targetLang: "ZH",
+        });
+    });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
             'https://translate.google.com/*',
             'https://translate.google.co.uk/*',
             'https://translate.googleapis.com/*',
+            'https://deeplx.1stg.me/*',
         ],
     },
 


### PR DESCRIPTION
## 变更

- FluentRead 原本已有 DeepLX 服务；本 PR 将其完善为可用的免费非官方翻译服务。
- 默认使用已实测可用的公共端点 https://deeplx.1stg.me/translate。
- 服务地址支持逗号或换行分隔，按顺序故障转移；每次请求有超时和响应格式校验。
- 保留代理地址优先级，支持可选 Bearer Token，并加入 DeepLX host permission、设置页提示、文档和单元测试。
- 公共 DeepLX 站点可能限流、停用或记录文本；敏感内容建议配置本地或自建服务。

## 调研结论

- 官方 DeepL Free API 端点仍需要 Authorization/API Key，不能作为无 Key 备用站点。
- 低频实测通过的公共无 Key 端点仅保留 deeplx.1stg.me；其他候选出现停用、DNS/TLS、鉴权或非翻译响应，因此没有硬编码进默认列表。
- 参考资料：[DeepLX/DLX](https://github.com/OwO-Network/DLX)、[un-ts/deeplx](https://github.com/un-ts/deeplx)、[Read Frog DeepLX 文档](https://www.readfrog.app/en/docs/providers/deeplx)。

## 验证

- pnpm test：82 个测试通过。
- pnpm compile：通过。
- pnpm build：通过。
- 真实 Microsoft Edge 加载 pnpm dev 生成的 .output/chrome-mv3-dev：翻译—恢复—再次翻译计数为 [1,0,1]，相邻段落均为 [0,0,0]。
- 真实浏览器备用链测试：第一个无效地址失败后，第二个 deeplx.1stg.me 成功，切换结果同样为 [1,0,1]。

请审核后再决定是否合并。

## Summary by Sourcery

引入更健壮的 DeepLX 集成：默认使用已验证的公共端点，并支持带有超时和校验的多地址回退机制。

新特性：
- 支持使用逗号或换行分隔多个 DeepLX 服务地址，并按顺序在端点之间进行故障切换。
- 暴露一个默认的非官方 DeepLX 公共端点，使 DeepL 兼容的翻译在无需本地部署的情况下即可开箱即用。

增强：
- 改进 DeepLX 适配器的错误处理、响应校验，以及针对多种中文变体的语言规范化处理。
- 更新 UI 标签和提示，明确 DeepLX 是非官方的免费服务，并解释多端点配置方式及隐私相关注意事项。
- 将 DeepLX 端点解析与默认配置集中管理，并使默认选项和常量与共享助手保持一致。

部署：
- 在扩展的 manifest 中为默认 DeepLX 公共端点授予 host 权限，使浏览器能够发起请求。

文档：
- 扩展翻译引擎文档，描述 DeepLX 的使用方式、默认公共端点以及多端点回退行为。

测试：
- 添加单元测试，覆盖 DeepLX 端点解析、默认选择、语言规范化、token 处理以及跨端点的故障切换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a more robust DeepLX integration that uses a verified public endpoint by default and supports multiple fallback addresses with timeouts and validation.

New Features:
- Support multiple DeepLX service addresses separated by commas or newlines, with ordered failover between endpoints.
- Expose a default unofficial DeepLX public endpoint so DeepL-compatible translation works out of the box without local deployment.

Enhancements:
- Improve DeepLX adapter error handling, response validation, and language normalization for various Chinese variants.
- Update UI labels and hints to clarify DeepLX as a non-official free service and explain multi-endpoint configuration and privacy considerations.
- Centralize DeepLX endpoint parsing and default configuration, and align default options and constants with the shared helper.

Deployment:
- Grant host permission for the default DeepLX public endpoint in the extension manifest so requests can be made from the browser.

Documentation:
- Extend translation engine documentation to describe DeepLX usage, default public endpoint, and multi-endpoint fallback behavior.

Tests:
- Add unit tests covering DeepLX endpoint parsing, default selection, language normalization, token handling, and failover across endpoints.

</details>