### PR TITLE
feat: 增加 DeepLX 推荐站点预设

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -246,7 +246,22 @@
           resize="vertical"
           placeholder="https://deeplx.1stg.me/translate&#10;http://localhost:1188/translate"
         />
-        <div class="deeplx-hint">每行或逗号分隔，按顺序尝试；默认使用已验证的公共站点。</div>
+        <div class="deeplx-hint">每行或逗号分隔，按顺序尝试；带 &#123;&#123;apiKey&#125;&#125; 的地址会使用上方访问令牌。</div>
+        <el-select
+          v-model="selectedDeepLXPreset"
+          class="deeplx-presets"
+          size="small"
+          clearable
+          placeholder="快速添加推荐站点"
+          @change="appendDeepLXPreset"
+        >
+          <el-option
+            v-for="preset in DEEPLX_ENDPOINT_PRESETS"
+            :key="preset.url"
+            :label="preset.label"
+            :value="preset.url"
+          />
+        </el-select>
       </el-col>
     </el-row>
 
@@ -744,6 +759,7 @@ import {
   isCustomBodyMapping,
   isValidCustomBody,
 } from '@/entrypoints/utils/custom-body';
+import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
 
 // 初始化深色模式媒体查询
 const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -764,6 +780,19 @@ function updateTheme(theme: string) {
 
 // 配置信息
 let config = ref(new Config());
+const selectedDeepLXPreset = ref('');
+
+const appendDeepLXPreset = (endpoint: string | undefined) => {
+  if (!endpoint) {
+    return;
+  }
+
+  const endpoints = parseDeepLXEndpoints(config.value.deeplx);
+  if (!endpoints.includes(endpoint)) {
+    config.value.deeplx = [...endpoints, endpoint].join('\n');
+  }
+  selectedDeepLXPreset.value = '';
+};
 
 // 从 storage 中获取本地配置
 storage.getItem('local:config').then((value: any) => {
@@ -1698,5 +1727,10 @@ const validateConfig = (configData: any): boolean => {
   font-size: 12px;
   line-height: 1.4;
   margin-top: 4px;
+}
+
+.deeplx-presets {
+  margin-top: 6px;
+  width: 100%;
 }
 </style>

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -232,13 +232,21 @@
     <el-row v-show="compute.showDeepLX" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark"
-          content="DeepLX API 服务地址，默认为本地地址。如果使用远程 DeepLX 服务，请修改为对应的服务地址" placement="top-start"
+          content="DeepLX 是非官方免费服务。可填写多个地址，每行或逗号分隔；请求会按顺序故障转移。公共站点可能记录翻译文本，敏感内容建议使用本地或自建服务。"
+          placement="top-start"
           :show-after="500">
           <span class="popup-text popup-vertical-left">服务地址</span>
         </el-tooltip>
       </el-col>
       <el-col :span="12">
-        <el-input v-model="config.deeplx" placeholder="http://localhost:1188/translate" />
+        <el-input
+          v-model="config.deeplx"
+          type="textarea"
+          :rows="3"
+          resize="vertical"
+          placeholder="https://deeplx.1stg.me/translate&#10;http://localhost:1188/translate"
+        />
+        <div class="deeplx-hint">每行或逗号分隔，按顺序尝试；默认使用已验证的公共站点。</div>
       </el-col>
     </el-row>
 
@@ -1683,5 +1691,12 @@ const validateConfig = (configData: any): boolean => {
   font-size: 12px;
   margin-top: 4px;
   line-height: 1.4;
+}
+
+.deeplx-hint {
+  color: var(--fr-secondary-text-color, #909399);
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 4px;
 }
 </style>

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -8,11 +8,22 @@
 - **Microsoft 翻译**：免费且无需配置，开箱即用，支持多种语言互译
 - **Google 翻译**：免费且无需配置，支持多种语言，国内暂不支持使用
 - **DeepL (免费版)**：每月 50 万字符免费额度，[开发者平台](https://www.deepl.com/pro-api)
-- **DeepLX**：免费的 DeepL 翻译代理服务，需自行部署，[项目地址](https://deeplx.owo.network/)
+- **DeepLX（免费非官方）**：无需官方 API Key 的 DeepL 兼容服务。默认使用已验证的公共站点，也支持在设置中填入本地、自建或多个备用地址；公共站点可能记录文本，敏感内容建议使用自建服务。[项目文档](https://deeplx.owo.network/)
 - **小牛翻译**：[API 文档](https://niutrans.com/dev-page?type=text)
 - **有道翻译**：新用户可获体验资金，具体额度以[官方计费规则](https://ai.youdao.com/DOCSIRMA/html/trans/price/wbfy/index.html)为准
 - **腾讯云文本翻译**：每月 500 万字符免费额度，[产品页面](https://cloud.tencent.com/product/tmt)
 - **Chrome 内置 AI 翻译**：使用浏览器内置 Translator API，无需 API Key，仅支持 Google Chrome 138 Stable 及以上版本，[开发文档](https://developer.chrome.com/docs/ai/translator-api?hl=zh-cn)
+
+#### DeepLX 备用地址
+
+在 DeepLX 的“服务地址”中可以填写多个地址，每行或逗号分隔。插件会按填写顺序请求，当前地址失败或返回无效响应时自动尝试下一个地址：
+
+```text
+https://deeplx.1stg.me/translate
+http://localhost:1188/translate
+```
+
+`deeplx.1stg.me` 是当前验证可用的公共实例；公共实例属于非官方服务，可能限流、停用或记录请求内容。敏感文本建议使用本地或自建 DeepLX 服务。
 
 ### AI 大模型
 - **OpenAI（推荐⭐️）**：国际领先的大模型服务，支持 GPT-4o 和 GPT-o1-mini 等，[API 文档](https://platform.openai.com/docs/api-reference)

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -16,14 +16,18 @@
 
 #### DeepLX 备用地址
 
-在 DeepLX 的“服务地址”中可以填写多个地址，每行或逗号分隔。插件会按填写顺序请求，当前地址失败或返回无效响应时自动尝试下一个地址：
+在 DeepLX 的“服务地址”中可以填写多个地址，每行或逗号分隔。设置页提供“快速添加推荐站点”，插件会按填写顺序请求，当前地址失败或返回无效响应时自动尝试下一个地址：
 
 ```text
 https://deeplx.1stg.me/translate
+https://freeapi.fanyimao.cn/translate?token={{apiKey}}
+https://api.deeplx.org/{{apiKey}}/translate
 http://localhost:1188/translate
 ```
 
-`deeplx.1stg.me` 是当前验证可用的公共实例；公共实例属于非官方服务，可能限流、停用或记录请求内容。敏感文本建议使用本地或自建 DeepLX 服务。
+`deeplx.1stg.me` 是当前验证可用且无需 Token 的公共实例。`freeapi.fanyimao.cn` 也已验证可返回译文，但需要用户自己的站点 Token；`api.deeplx.org` 需要个人 Token。地址中的 `{{apiKey}}` 会替换为设置页的“访问令牌”，不会把 Token 写入插件代码。
+
+这些公共实例都属于非官方服务，可能限流、停用或记录请求内容。公开列表中的其他候选站点当前出现了 401、404、530、DNS/TLS 错误或已暂停，因此没有加入默认备用链。敏感文本建议使用本地或自建 DeepLX 服务。
 
 ### AI 大模型
 - **OpenAI（推荐⭐️）**：国际领先的大模型服务，支持 GPT-4o 和 GPT-o1-mini 等，[API 文档](https://platform.openai.com/docs/api-reference)

--- a/entrypoints/service/deeplx.ts
+++ b/entrypoints/service/deeplx.ts
@@ -1,47 +1,150 @@
-import {method} from "../utils/constant";
 import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
+import {getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
 
-async function deeplx(message: any) {
-    // deeplx 不支持 zh-Hans，需要转换为 zh
-    let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
-    let sourceLang = config.from === 'auto' ? 'auto' : config.from;
-    
-    // 判断是否使用代理或自定义URL
-    let url: string = config.proxy[config.service] ? config.proxy[config.service] : config.deeplx || 'http://localhost:1188/translate';
+const DEEPLX_TOTAL_TIMEOUT_MS = 20_000;
+const DEEPLX_ATTEMPT_TIMEOUT_MS = 8_000;
+const DEEPLX_ERROR_BODY_PREVIEW_LENGTH = 200;
 
-    // 构建请求头
-    let headers: HeadersInit = {
-        'Content-Type': 'application/json'
-    };
-
-    // 如果有 token，则添加 Authorization 头
-    if (config.token[services.deeplx] && config.token[services.deeplx].trim() !== '') {
-        headers['Authorization'] = `Bearer ${config.token[services.deeplx]}`;
+function normalizeLanguage(language: string): string {
+    const normalized = language.toLowerCase();
+    if (normalized === "auto") {
+        return "AUTO";
     }
+    if (normalized === "zh-hans" || normalized === "zh-cn") {
+        return "ZH";
+    }
+    if (normalized === "zh-tw" || normalized === "zh-hant") {
+        return "ZH-HANT";
+    }
+    return language.toUpperCase();
+}
 
-    const resp = await fetch(url, {
-        method: method.POST,
-        headers: headers,
-        body: JSON.stringify({
-            text: message.origin,
-            source_lang: sourceLang.toUpperCase(),
-            target_lang: targetLang.toUpperCase()
-        })
-    });
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
 
-    if (resp.ok) {
-        let result = await resp.json();
-        // DeepLX 返回格式通常是 { code: 200, data: "translated text" }
-        if (result.code === 200) {
-            return result.data;
-        } else {
-            throw new Error(`DeepLX 翻译失败: ${result.message || '未知错误'}`);
+function formatResponseBody(responseBody: string): string {
+    const compactBody = responseBody.replace(/\s+/g, " ").trim();
+    return compactBody.slice(0, DEEPLX_ERROR_BODY_PREVIEW_LENGTH);
+}
+
+async function fetchDeepLX(url: string, requestInit: RequestInit, timeoutMs: number): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+        return await fetch(url, {...requestInit, signal: controller.signal});
+    } catch (error) {
+        if (controller.signal.aborted) {
+            throw new Error(`请求超时（${timeoutMs / 1000} 秒）`);
         }
-    } else {
-        console.log("DeepLX 翻译失败：", resp);
-        throw new Error(`DeepLX 翻译失败: ${resp.status} ${resp.statusText} body: ${await resp.text()}`);
+        throw new Error(`网络错误: ${getErrorMessage(error)}`);
+    } finally {
+        clearTimeout(timeout);
     }
+}
+
+async function translateFromDeepLX(
+    url: string,
+    text: string,
+    sourceLang: string,
+    targetLang: string,
+    token: string,
+    timeoutMs: number,
+): Promise<string> {
+    const headers: HeadersInit = {
+        "Content-Type": "application/json",
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetchDeepLX(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+            text,
+            source_lang: sourceLang,
+            target_lang: targetLang,
+        }),
+    }, timeoutMs);
+
+    const responseBody = await response.text();
+    if (!response.ok) {
+        const preview = formatResponseBody(responseBody);
+        throw new Error(`HTTP ${response.status} ${response.statusText}${preview ? `，响应: ${preview}` : ""}`);
+    }
+
+    let result: unknown;
+    try {
+        result = JSON.parse(responseBody);
+    } catch (error) {
+        throw new Error(`返回的不是 JSON: ${getErrorMessage(error)}`);
+    }
+
+    if (!result || typeof result !== "object") {
+        throw new Error("返回格式异常");
+    }
+
+    const responseData = result as {code?: unknown; data?: unknown; message?: unknown};
+    if (responseData.code !== undefined && responseData.code !== 200) {
+        throw new Error(`DeepLX 返回错误: ${String(responseData.message || `code ${String(responseData.code)}`)}`);
+    }
+    if (typeof responseData.data !== "string" || responseData.data.trim().length === 0) {
+        throw new Error("返回格式异常：缺少译文");
+    }
+
+    return responseData.data;
+}
+
+export function normalizeDeepLXLanguage(language: string): string {
+    return normalizeLanguage(language);
+}
+
+export function getDeepLXRequestLanguages(from: string, to: string): {sourceLang: string; targetLang: string} {
+    return {
+        sourceLang: normalizeLanguage(from),
+        targetLang: normalizeLanguage(to),
+    };
+}
+
+async function deeplx(message: {origin: string}) {
+    if (typeof message.origin !== "string") {
+        throw new Error("DeepLX 翻译仅支持单条文本");
+    }
+
+    const endpoints = getDeepLXEndpoints(
+        config.deeplx,
+        config.proxy[config.service],
+    );
+    const token = config.token[services.deeplx]?.trim() || "";
+    const {sourceLang, targetLang} = getDeepLXRequestLanguages(config.from, config.to);
+    const deadline = Date.now() + DEEPLX_TOTAL_TIMEOUT_MS;
+    const failures: string[] = [];
+
+    for (const [index, endpoint] of endpoints.entries()) {
+        const remainingTime = deadline - Date.now();
+        if (remainingTime <= 0) {
+            break;
+        }
+
+        try {
+            return await translateFromDeepLX(
+                endpoint,
+                message.origin,
+                sourceLang,
+                targetLang,
+                token,
+                Math.min(DEEPLX_ATTEMPT_TIMEOUT_MS, remainingTime),
+            );
+        } catch (error) {
+            failures.push(`备用站点 ${index + 1}: ${getErrorMessage(error)}`);
+        }
+    }
+
+    const failureSummary = failures.length > 0 ? failures.join("；") : "总请求时间已耗尽";
+    throw new Error(`DeepLX 所有备用站点均失败：${failureSummary}`);
 }
 
 export default deeplx;

--- a/entrypoints/service/deeplx.ts
+++ b/entrypoints/service/deeplx.ts
@@ -114,11 +114,12 @@ async function deeplx(message: {origin: string}) {
         throw new Error("DeepLX 翻译仅支持单条文本");
     }
 
+    const token = config.token[services.deeplx]?.trim() || "";
     const endpoints = getDeepLXEndpoints(
         config.deeplx,
         config.proxy[config.service],
+        token,
     );
-    const token = config.token[services.deeplx]?.trim() || "";
     const {sourceLang, targetLang} = getDeepLXRequestLanguages(config.from, config.to);
     const deadline = Date.now() + DEEPLX_TOTAL_TIMEOUT_MS;
     const failures: string[] = [];

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -1,9 +1,10 @@
 import { services } from "./option";
+import {DEFAULT_DEEPLX_ENDPOINT} from "./deeplx";
 
 // 常量工具类
 export const urls: any = {
     [services.deepL]: "https://api-free.deepl.com/v2/translate",
-    [services.deeplx]: "http://localhost:1188/translate",
+    [services.deeplx]: DEFAULT_DEEPLX_ENDPOINT,
     [services.openai]: "https://api.openai.com/v1/chat/completions",
     [services.azureOpenai]: "https://your-resource-name.openai.azure.com/openai/deployments/your-deployment-name/chat/completions?api-version=2024-02-15-preview",
     [services.moonshot]: "https://api.moonshot.cn/v1/chat/completions",

--- a/entrypoints/utils/deeplx.ts
+++ b/entrypoints/utils/deeplx.ts
@@ -4,6 +4,27 @@
  */
 export const DEFAULT_DEEPLX_ENDPOINT = "https://deeplx.1stg.me/translate"
 
+export const DEEPLX_ENDPOINT_PRESETS = [
+  {
+    label: "1stG 公共站点（免 Key，已验证）",
+    url: DEFAULT_DEEPLX_ENDPOINT,
+  },
+  {
+    label: "Fanyimao 公共站点（需站点 Token，已验证）",
+    url: "https://freeapi.fanyimao.cn/translate?token={{apiKey}}",
+  },
+  {
+    label: "DeepLX 社区站点（需个人 Token）",
+    url: "https://api.deeplx.org/{{apiKey}}/translate",
+  },
+  {
+    label: "本地 DeepLX（需自行运行）",
+    url: "http://localhost:1188/translate",
+  },
+] as const
+
+const DEEPLX_TOKEN_PLACEHOLDER = /\{\{(?:apiKey|token)\}\}/g
+
 const DEEPLX_ENDPOINT_SEPARATOR = /[\n,]+/
 
 export function parseDeepLXEndpoints(value: unknown): string[] {
@@ -14,12 +35,25 @@ export function parseDeepLXEndpoints(value: unknown): string[] {
   return [...new Set(value.split(DEEPLX_ENDPOINT_SEPARATOR).map((endpoint) => endpoint.trim()).filter(Boolean))]
 }
 
-export function getDeepLXEndpoints(configuredURL: unknown, proxyURL: unknown): string[] {
+function resolveDeepLXEndpoint(endpoint: string, token: string): string | null {
+  if (DEEPLX_TOKEN_PLACEHOLDER.test(endpoint) && !token) {
+    DEEPLX_TOKEN_PLACEHOLDER.lastIndex = 0
+    return null
+  }
+
+  DEEPLX_TOKEN_PLACEHOLDER.lastIndex = 0
+  return endpoint.replace(DEEPLX_TOKEN_PLACEHOLDER, encodeURIComponent(token))
+}
+
+export function getDeepLXEndpoints(configuredURL: unknown, proxyURL: unknown, token = ""): string[] {
   const proxyEndpoints = parseDeepLXEndpoints(proxyURL)
   if (proxyEndpoints.length > 0) {
-    return proxyEndpoints
+    const resolvedProxyEndpoints = proxyEndpoints.map((endpoint) => resolveDeepLXEndpoint(endpoint, token)).filter((endpoint): endpoint is string => endpoint !== null)
+    return resolvedProxyEndpoints.length > 0 ? resolvedProxyEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
   }
 
   const configuredEndpoints = parseDeepLXEndpoints(configuredURL)
-  return configuredEndpoints.length > 0 ? configuredEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
+  const endpoints = configuredEndpoints.length > 0 ? configuredEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
+  const resolvedEndpoints = endpoints.map((endpoint) => resolveDeepLXEndpoint(endpoint, token)).filter((endpoint): endpoint is string => endpoint !== null)
+  return resolvedEndpoints.length > 0 ? resolvedEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
 }

--- a/entrypoints/utils/deeplx.ts
+++ b/entrypoints/utils/deeplx.ts
@@ -1,0 +1,25 @@
+/**
+ * The public endpoint is an unofficial DeepLX deployment. Keep it explicit so
+ * users can replace it with a local or self-hosted endpoint at any time.
+ */
+export const DEFAULT_DEEPLX_ENDPOINT = "https://deeplx.1stg.me/translate"
+
+const DEEPLX_ENDPOINT_SEPARATOR = /[\n,]+/
+
+export function parseDeepLXEndpoints(value: unknown): string[] {
+  if (typeof value !== "string") {
+    return []
+  }
+
+  return [...new Set(value.split(DEEPLX_ENDPOINT_SEPARATOR).map((endpoint) => endpoint.trim()).filter(Boolean))]
+}
+
+export function getDeepLXEndpoints(configuredURL: unknown, proxyURL: unknown): string[] {
+  const proxyEndpoints = parseDeepLXEndpoints(proxyURL)
+  if (proxyEndpoints.length > 0) {
+    return proxyEndpoints
+  }
+
+  const configuredEndpoints = parseDeepLXEndpoints(configuredURL)
+  return configuredEndpoints.length > 0 ? configuredEndpoints : [DEFAULT_DEEPLX_ENDPOINT]
+}

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -93,7 +93,7 @@ export class Config {
         this.customFloatingBallHotkey = ''; // 自定义快捷键为空
         this.customHotkey = ''; // 自定义鼠标悬浮快捷键为空
         this.disableSelectionTranslator = false; // 默认不禁用划词翻译
-        this.deeplx = ''; // DeepLX 默认服务地址
+        this.deeplx = defaultOption.deeplx; // DeepLX 默认服务地址
         this.selectionTranslatorMode = 'bilingual'; // 默认双语显示模式
         this.newApiUrl = 'http://localhost:3000'; // NewAPI 默认地址
         this.maxConcurrentTranslations = 6; // 默认最大并发数为6

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -1,3 +1,5 @@
+import {DEFAULT_DEEPLX_ENDPOINT} from "./deeplx";
+
 export const services = {
     // 机器翻译
     microsoft: "microsoft",
@@ -296,7 +298,7 @@ export const options = {
         {value: services.microsoft, label: "微软翻译"},
         {value: services.google, label: "谷歌翻译"},
         {value: services.deepL, label: "DeepL"},
-        {value: services.deeplx, label: "DeepLX"},
+        {value: services.deeplx, label: "DeepLX（免费非官方）"},
         {value: services.xiaoniu, label: "小牛翻译"},
         {value: services.youdao, label: "有道翻译"},
         {value: services.tencent, label: "腾讯云翻译"},
@@ -435,7 +437,7 @@ export const defaultOption = {
     hotkey: "Control",
     service: services.microsoft,
     custom: "http://localhost:11434/v1/chat/completions",
-    deeplx: "http://localhost:1188/translate",
+    deeplx: DEFAULT_DEEPLX_ENDPOINT,
     system_role:
         "You are a professional, authentic machine translation engine.",
     user_role: `Translate the following text into {{to}}, If translation is unnecessary (e.g. proper nouns, codes, etc.), return the original text. NO explanations. NO notes:

--- a/tests/deeplx.test.ts
+++ b/tests/deeplx.test.ts
@@ -1,0 +1,126 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+const {mockConfig} = vi.hoisted(() => ({
+    mockConfig: {
+        from: "auto",
+        to: "zh-Hans",
+        service: "deeplx",
+        deeplx: "",
+        proxy: {} as Record<string, string>,
+        token: {} as Record<string, string>,
+    },
+}));
+
+vi.mock("@/entrypoints/utils/config", () => ({config: mockConfig}));
+
+import deeplx, {
+    getDeepLXRequestLanguages,
+    normalizeDeepLXLanguage,
+} from "@/entrypoints/service/deeplx";
+import {DEFAULT_DEEPLX_ENDPOINT, getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function mockResponse(body: unknown, overrides: Partial<Response> = {}): Response {
+    return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+        ...overrides,
+    } as unknown as Response;
+}
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    mockConfig.from = "auto";
+    mockConfig.to = "zh-Hans";
+    mockConfig.deeplx = "";
+    mockConfig.proxy = {};
+    mockConfig.token = {};
+    vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe("DeepLX endpoint configuration", () => {
+    it("uses the verified public endpoint when no URL is configured", () => {
+        expect(getDeepLXEndpoints("", "")).toEqual([DEFAULT_DEEPLX_ENDPOINT]);
+    });
+
+    it("parses comma- and newline-separated URLs and gives proxy URLs priority", () => {
+        expect(getDeepLXEndpoints("https://one.example/translate,\nhttps://two.example/translate", ""))
+            .toEqual(["https://one.example/translate", "https://two.example/translate"]);
+        expect(getDeepLXEndpoints("https://configured.example/translate", "https://proxy.example/translate"))
+            .toEqual(["https://proxy.example/translate"]);
+    });
+});
+
+describe("DeepLX adapter", () => {
+    it("sends the expected request and parses a successful response", async () => {
+        fetchMock.mockResolvedValue(mockResponse({code: 200, data: "你好"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("你好");
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0]!;
+        expect(url).toBe(DEFAULT_DEEPLX_ENDPOINT);
+        expect(init).toMatchObject({method: "POST"});
+        expect(init?.headers).toEqual({"Content-Type": "application/json"});
+        expect(JSON.parse(String(init?.body))).toEqual({
+            text: "Hello",
+            source_lang: "AUTO",
+            target_lang: "ZH",
+        });
+    });
+
+    it("falls back to the next configured URL after an HTTP failure", async () => {
+        mockConfig.deeplx = "https://primary.example/translate,\nhttps://backup.example/translate";
+        fetchMock
+            .mockResolvedValueOnce(mockResponse({message: "busy"}, {
+                ok: false,
+                status: 503,
+                statusText: "Service Unavailable",
+                text: vi.fn().mockResolvedValue("busy"),
+            }))
+            .mockResolvedValueOnce(mockResponse({code: 200, data: "备用译文"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("备用译文");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1]?.[0]).toBe("https://backup.example/translate");
+    });
+
+    it("falls back after an invalid DeepLX response", async () => {
+        mockConfig.deeplx = "https://invalid.example/translate,https://valid.example/translate";
+        fetchMock
+            .mockResolvedValueOnce(mockResponse({code: 200, data: ""}))
+            .mockResolvedValueOnce(mockResponse({code: 200, data: "有效译文"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("有效译文");
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("adds an optional bearer token without exposing it in the URL", async () => {
+        mockConfig.token = {deeplx: "test-token"};
+        fetchMock.mockResolvedValue(mockResponse({code: 200, data: "你好"}));
+
+        await deeplx({origin: "Hello"});
+
+        expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+            "Content-Type": "application/json",
+            Authorization: "Bearer test-token",
+        });
+    });
+
+    it("normalizes Chinese language variants", () => {
+        expect(normalizeDeepLXLanguage("zh-Hans")).toBe("ZH");
+        expect(normalizeDeepLXLanguage("zh-TW")).toBe("ZH-HANT");
+        expect(getDeepLXRequestLanguages("auto", "zh-Hans")).toEqual({
+            sourceLang: "AUTO",
+            targetLang: "ZH",
+        });
+    });
+});

--- a/tests/deeplx.test.ts
+++ b/tests/deeplx.test.ts
@@ -17,7 +17,7 @@ import deeplx, {
     getDeepLXRequestLanguages,
     normalizeDeepLXLanguage,
 } from "@/entrypoints/service/deeplx";
-import {DEFAULT_DEEPLX_ENDPOINT, getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
+import {DEFAULT_DEEPLX_ENDPOINT, DEEPLX_ENDPOINT_PRESETS, getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -56,6 +56,13 @@ describe("DeepLX endpoint configuration", () => {
             .toEqual(["https://one.example/translate", "https://two.example/translate"]);
         expect(getDeepLXEndpoints("https://configured.example/translate", "https://proxy.example/translate"))
             .toEqual(["https://proxy.example/translate"]);
+    });
+
+    it("resolves token placeholders without returning a secret in the configured URL", () => {
+        expect(getDeepLXEndpoints(DEEPLX_ENDPOINT_PRESETS[1].url, "", "site-token"))
+            .toEqual(["https://freeapi.fanyimao.cn/translate?token=site-token"]);
+        expect(getDeepLXEndpoints(DEEPLX_ENDPOINT_PRESETS[2].url, "", ""))
+            .toEqual([DEFAULT_DEEPLX_ENDPOINT]);
     });
 });
 
@@ -113,6 +120,16 @@ describe("DeepLX adapter", () => {
             "Content-Type": "application/json",
             Authorization: "Bearer test-token",
         });
+    });
+
+    it("supports a token placeholder in a preset endpoint", async () => {
+        mockConfig.deeplx = DEEPLX_ENDPOINT_PRESETS[1].url;
+        mockConfig.token = {deeplx: "site-token"};
+        fetchMock.mockResolvedValue(mockResponse({code: 200, data: "你好"}));
+
+        await expect(deeplx({origin: "Hello"})).resolves.toBe("你好");
+
+        expect(fetchMock.mock.calls[0]?.[0]).toBe("https://freeapi.fanyimao.cn/translate?token=site-token");
     });
 
     it("normalizes Chinese language variants", () => {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
             'https://translate.google.com/*',
             'https://translate.google.co.uk/*',
             'https://translate.googleapis.com/*',
+            'https://deeplx.1stg.me/*',
         ],
     },
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
             'https://translate.google.co.uk/*',
             'https://translate.googleapis.com/*',
             'https://deeplx.1stg.me/*',
+            'https://freeapi.fanyimao.cn/*',
+            'https://api.deeplx.org/*',
         ],
     },
 


### PR DESCRIPTION
## 说明

本 PR 基于并包含 PR #239 的 DeepLX 故障转移实现，作为 #239 的替代/补充 PR；不会自动关闭或修改 #239。若合并本 PR，#239 中的基础改动也会一并包含。

## 新增内容

- 设置页增加“快速添加推荐站点”下拉框。
- 增加 4 个预设：1stG 免 Key 公共站点、Fanyimao 免费站点、DeepLX 社区站点、本地 DeepLX。
- Fanyimao 和 api.deeplx.org 使用 {{apiKey}} URL 占位符，从访问令牌配置中安全替换，不把第三方 Token 写入代码。
- 增加对应 host permissions、文档说明和单元测试。
- 保留多地址顺序故障转移、超时、响应格式校验和代理优先级。

## 接口核验

- deeplx.1stg.me：无需 Key，当前低频实测 HTTP 200 并返回中文译文。
- freeapi.fanyimao.cn：当前低频实测在提供站点 Token 后 HTTP 200 并返回译文。
- api.deeplx.org：需要个人 Token，未作为无 Key 默认地址。
- 其他公开列表候选当前出现 401、404、530、DNS/TLS 错误或已暂停，因此没有盲目加入默认链。

参考：[DeepLX/DLX](https://github.com/OwO-Network/DLX)、[DeepLX 客户端与 1stG 服务](https://github.com/un-ts/deeplx)、[Read Frog DeepLX 配置说明](https://www.readfrog.app/en/docs/providers/deeplx)。

## 验证

- pnpm test：84 个测试通过。
- pnpm compile：通过。
- pnpm build：通过。
- 真实 Microsoft Edge 加载 pnpm dev 产物：翻译—恢复—再次翻译 [1,0,1]，相邻段落 [0,0,0]。
- 真实 Edge popup：选择 DeepLX 后预设下拉框显示 4 个选项，选择 Fanyimao 后 URL 成功写入地址框。
- 通用 UI 脚本因当前仓库清单缺少 options_page/options_ui.page 在启动前停止；该问题属于现有基线，本 PR 未扩大范围修改清单结构。

请审核后再决定是否合并。

## Summary by Sourcery

添加多端点 DeepLX 集成，启用已验证的公共默认与回退行为，并提供用于配置推荐站点和令牌的 UI 预设及文档。

新功能：
- 支持多个 DeepLX 服务端点，提供有序故障切换和每次请求的超时设置。
- 引入 DeepLX 端点预设，覆盖已验证的公共、社区和本地部署，并在需要时使用令牌占位符。

改进：
- 改善 DeepLX 语言标准化和响应校验，实现更健壮的错误处理。
- 更新默认 DeepLX 配置，将其改为使用已验证的公共端点，而不是空或纯本地 URL。
- 在引擎选项 UI 和提示文本中明确说明 DeepLX 是非官方的免费服务，并强调隐私和自托管选项。

构建：
- 扩展扩展宿主权限，以涵盖推荐的 DeepLX 公共端点。

文档：
- 扩充翻译引擎文档，描述 DeepLX 回退端点、推荐公共实例以及令牌占位符的行为。

测试：
- 添加单元测试，覆盖 DeepLX 端点解析、令牌替换、默认/预设行为以及适配器故障切换逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multi-endpoint DeepLX integration with verified public default and fallback behavior, plus UI presets and documentation for configuring recommended sites and tokens.

New Features:
- Support multiple DeepLX service endpoints with ordered failover and per-attempt timeouts.
- Introduce DeepLX endpoint presets for verified public, community, and local deployments, using token placeholders where needed.

Enhancements:
- Improve DeepLX language normalization and response validation for more robust error handling.
- Update default DeepLX configuration to use a verified public endpoint instead of an empty or purely local URL.
- Clarify DeepLX as a non-official free service in the engine options UI and hint text, emphasizing privacy and self-hosting options.

Build:
- Extend extension host permissions to cover the recommended DeepLX public endpoints.

Documentation:
- Expand translation engine docs to describe DeepLX fallback endpoints, recommended public instances, and token placeholder behavior.

Tests:
- Add unit tests covering DeepLX endpoint parsing, token substitution, default/preset behavior, and adapter failover logic.

</details>