### PR TITLE
fix: preserve hover translation DOM state

### DIFF
--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -17,6 +17,7 @@ import {
     restoreAllTranslations,
     restoreTranslation,
     setBilingualContent,
+    setRenderedStyleAttribute,
     setSpinner,
     setTranslatedHTML,
 } from "@/entrypoints/main/translationState";
@@ -255,6 +256,7 @@ async function renderBilingualResult(
 
         const content = appendBilingualTranslation(node, text);
         setBilingualContent(node, content);
+        setRenderedStyleAttribute(node);
     } catch (error) {
         markAttemptError(node, attempt, spinner, error);
     }
@@ -371,15 +373,17 @@ export function singleTranslate(node: unknown): void {
     const attempt = beginTranslation(target, 'single');
     if (!attempt) return;
 
-    const spinner = insertLoadingSpinner(target);
-    setSpinner(target, spinner);
-
     const cached = cache.localGet(attempt.state.sourceOuterHTML);
     const translation = cached
         ? Promise.resolve(cached)
         : config.service === services.microsoft
             ? translateMicrosoftHtml(target)
             : translateText(origin, document.title);
+
+    // 先创建翻译请求，再插入 loading 节点。微软 HTML 翻译会克隆目标
+    // 元素；如果顺序相反，loading 节点也会被带进服务响应和最终译文。
+    const spinner = insertLoadingSpinner(target);
+    setSpinner(target, spinner);
 
     void renderSingleResult(target, attempt, origin, translation, Boolean(cached));
 }

--- a/entrypoints/main/translationState.ts
+++ b/entrypoints/main/translationState.ts
@@ -15,6 +15,10 @@ export interface TranslationState {
     sourceText: string;
     sourceHTML: string;
     sourceOuterHTML: string;
+    /** 翻译开始前的内联 style 属性，用于可条件恢复。 */
+    originalStyleAttribute: string | null;
+    /** 插件完成渲染后记录的 style 属性；undefined 表示尚未改动样式。 */
+    renderedStyleAttribute?: string | null;
     translatedHTML?: string;
     /**
      * 仅译文模式会暂时移除这些原始子节点。
@@ -58,6 +62,7 @@ export function beginTranslation(
         sourceText: node.textContent ?? "",
         sourceHTML: node.innerHTML,
         sourceOuterHTML: node.outerHTML,
+        originalStyleAttribute: node.getAttribute("style"),
         originalChildren: Array.from(node.childNodes),
         controller: new AbortController(),
     };
@@ -119,6 +124,17 @@ export function setBilingualContent(node: HTMLElement, content: HTMLElement): vo
     if (state) state.bilingualContent = content;
 }
 
+/**
+ * 记录插件完成渲染后的内联样式。
+ *
+ * 恢复时只有当节点仍保持这个值，才会写回原始样式；如果网站已经
+ * 修改过 style，则保留网站的新值，避免翻译恢复覆盖宿主页面更新。
+ */
+export function setRenderedStyleAttribute(node: HTMLElement): void {
+    const state = states.get(node);
+    if (state) state.renderedStyleAttribute = node.getAttribute("style");
+}
+
 function removeExtensionNode(node: Node | undefined): void {
     if (node?.parentNode) node.parentNode.removeChild(node);
 }
@@ -135,6 +151,17 @@ function clearState(node: HTMLElement): void {
 
 function removeCurrentChildren(node: HTMLElement): void {
     while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function restoreOriginalStyle(node: HTMLElement, state: TranslationState): void {
+    if (state.renderedStyleAttribute === undefined) return;
+    if (node.getAttribute("style") !== state.renderedStyleAttribute) return;
+
+    if (state.originalStyleAttribute === null) {
+        node.removeAttribute("style");
+    } else {
+        node.setAttribute("style", state.originalStyleAttribute);
+    }
 }
 
 /**
@@ -158,6 +185,8 @@ export function restoreTranslation(node: HTMLElement): boolean {
             state.originalChildren.forEach((child) => node.appendChild(child));
         }
     }
+
+    restoreOriginalStyle(node, state);
 
     node.classList.remove("fluent-read-bilingual", "fluent-read-failure");
     clearState(node);

--- a/tests/translationState.test.ts
+++ b/tests/translationState.test.ts
@@ -5,6 +5,7 @@ import {
     isCurrentTranslation,
     markTranslationError,
     restoreTranslation,
+    setRenderedStyleAttribute,
 } from "@/entrypoints/main/translationState";
 
 /**
@@ -18,6 +19,7 @@ class FakeElement {
     outerHTML = "<p>Original text</p>";
     childNodes: object[] = [{ type: "original-child" }];
     classList = { remove: vi.fn() };
+    attributes = new Map<string, string>();
     controller?: AbortController;
 
     get firstChild(): object | undefined {
@@ -33,6 +35,18 @@ class FakeElement {
     appendChild(child: object): object {
         this.childNodes.push(child);
         return child;
+    }
+
+    getAttribute(name: string): string | null {
+        return this.attributes.get(name) ?? null;
+    }
+
+    setAttribute(name: string, value: string): void {
+        this.attributes.set(name, value);
+    }
+
+    removeAttribute(name: string): void {
+        this.attributes.delete(name);
     }
 
     querySelectorAll(): object[] {
@@ -124,5 +138,41 @@ describe("指定节点翻译状态机", () => {
         )).toBe(false);
         expect(getTranslationState(node as unknown as HTMLElement)).toBe(attempt!.state);
         expect(attempt!.state.phase).toBe("loading");
+    });
+
+    it("恢复双语翻译时还原插件临时修改的内联样式", () => {
+        node.setAttribute("style", "display: -webkit-box; -webkit-line-clamp: 2; max-height: 4px;");
+        const attempt = beginTranslation(node as unknown as HTMLElement, "bilingual");
+        expect(attempt).not.toBeNull();
+
+        node.setAttribute("style", "display: -webkit-box; -webkit-line-clamp: unset; max-height: unset;");
+        setRenderedStyleAttribute(node as unknown as HTMLElement);
+
+        expect(restoreTranslation(node as unknown as HTMLElement)).toBe(true);
+        expect(node.getAttribute("style")).toBe("display: -webkit-box; -webkit-line-clamp: 2; max-height: 4px;");
+    });
+
+    it("网站在翻译后更新样式时，恢复不会覆盖网站的新值", () => {
+        node.setAttribute("style", "max-height: 4px;");
+        const attempt = beginTranslation(node as unknown as HTMLElement, "bilingual");
+        expect(attempt).not.toBeNull();
+
+        node.setAttribute("style", "max-height: unset;");
+        setRenderedStyleAttribute(node as unknown as HTMLElement);
+        node.setAttribute("style", "max-height: none;");
+
+        expect(restoreTranslation(node as unknown as HTMLElement)).toBe(true);
+        expect(node.getAttribute("style")).toBe("max-height: none;");
+    });
+
+    it("原节点没有 style 属性时，恢复会移除插件临时创建的 style", () => {
+        const attempt = beginTranslation(node as unknown as HTMLElement, "bilingual");
+        expect(attempt).not.toBeNull();
+
+        node.setAttribute("style", "-webkit-line-clamp: unset; max-height: unset;");
+        setRenderedStyleAttribute(node as unknown as HTMLElement);
+
+        expect(restoreTranslation(node as unknown as HTMLElement)).toBe(true);
+        expect(node.getAttribute("style")).toBeNull();
     });
 });


### PR DESCRIPTION
## 说明

这是 PR #242 的 follow-up，仅包含本轮针对性修复，不替代原 PR #242。基础分支使用 PR #242 的来源分支，便于按差异审查；合并顺序应为先合并 #242，再处理本 PR。

## 本轮修复

- 翻译前保存目标节点的内联 style，恢复时仅在节点仍保持插件渲染值的情况下还原，避免覆盖网站后续样式更新。
- 修复微软 HTML/仅译文模式的请求顺序：先克隆原始目标，再插入 loading 节点，避免 loading 节点被带入译文 HTML。
- 增加状态机样式恢复和宿主样式变更的单元测试。

## 验证

- pnpm test：97 项通过。
- pnpm compile：通过。
- pnpm build：通过。
- pnpm build:firefox：通过。
- 屏幕外隔离 Edge：微软仅译文模式翻译—恢复—再次翻译通过，loading 节点未进入译文，原始 style 和相邻段落保持不变。
- example.com：微软双语 Control 三态切换 [1, 0, 1]，相邻段落 [0, 0, 0]。

不会自动合并。

## Summary by Sourcery

在还原翻译时保留并有条件地恢复行内样式属性，并修复 Microsoft HTML 单篇翻译的加载行为。

Bug 修复：
- 确保在恢复翻译时，仅当节点仍然具有由插件渲染的样式值时才重写行内样式，从而保留站点后续对样式的更新。
- 调整 Microsoft HTML 单篇翻译流程，使加载动画在创建翻译请求之后插入，防止加载动画被克隆进已翻译的 HTML 中。

增强功能：
- 在翻译状态中跟踪原始和插件渲染的行内样式属性，以支持在还原操作中安全恢复样式。

测试：
- 添加单元测试，覆盖行内样式的条件恢复，包括具有原始样式、站点更新样式以及不含初始样式属性的节点等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and conditionally restore inline style attributes when reverting translations, and fix Microsoft HTML single-translation loading behavior.

Bug Fixes:
- Ensure translation restoration only rewrites inline styles when the node still has the plugin-rendered style value, preserving subsequent site style updates.
- Adjust Microsoft HTML single-translation flow so the loading spinner is inserted after creating the translation request, preventing the spinner from being cloned into the translated HTML.

Enhancements:
- Track original and plugin-rendered inline style attributes in translation state to support safe style restoration on revert.

Tests:
- Add unit tests covering conditional restoration of inline styles, including cases with original styles, site-updated styles, and nodes without initial style attributes.

</details>