### PR TITLE
docs: 修正 Windows Ollama 启动命令

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -14,13 +14,20 @@
    ```bash
    OLLAMA_ORIGINS="*" ollama serve
    ```
-   
+
  - Windows：打开系统环境变量（用户变量）新建 2 个变量，然后启动 App：
    - 变量名：`OLLAMA_HOST`，变量值：`0.0.0.0`
    - 变量名：`OLLAMA_ORIGINS`，变量值：`*`
 
-   ```bash
-   OLLAMA_ORIGINS="*" ollama serve
+   在命令提示符（CMD）中也可以临时设置后启动：
+   ```bat
+   set "OLLAMA_ORIGINS=*"
+   ollama serve
+   ```
+   如果使用 PowerShell，请执行：
+   ```powershell
+   $env:OLLAMA_ORIGINS = "*"
+   ollama serve
    ```
 
  - Linux：直接命令行启动。
@@ -86,4 +93,4 @@ http://localhost:11434/v1/chat/completions
 2. 已正确配置跨域访问，并在日志中确认生效
 3. 接口地址完全正确，包括 `/v1/chat/completions` 路径
 4. 本地已安装了相应的模型（可通过 `ollama list` 查看已安装模型）
-::: 
+:::


### PR DESCRIPTION
Fixes #179

## 变更
- 修正 FAQ 中 Windows 段落误用 Unix 风格环境变量前缀的问题。
- 分别补充 CMD 与 PowerShell 的可执行示例。

## 验证
- `git diff --check`
- `pnpm docs:build`

这只更新文档，不改变 Ollama 配置流程。

## Summary by Sourcery

文档：
- 使用正确的 CMD 和 PowerShell 示例，澄清 Windows 常见问题 (FAQ) 部分，说明如何设置 Ollama 环境变量并启动服务器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify Windows FAQ section with proper CMD and PowerShell examples for setting Ollama environment variables and starting the server.

</details>