### PR TITLE
fix: 修复 Edge 内容脚本加载导致快捷键失效

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,6 +6,33 @@ import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
 
+/**
+ * Edge 的扩展内容脚本加载器会拒绝产物中的 Unicode 非字符 U+FFFE/U+FFFF，
+ * 并把它们误报成“不是 UTF-8 编码”。部分第三方解析器会把源码中的转义
+ * 序列展开成这些字符，因此在最终 JavaScript chunk 中重新写成 ASCII 转义，
+ * 保持运行时值不变，同时避免扩展加载失败。
+ */
+function escapeExtensionNoncharacters() {
+    const escapeActualNoncharacters = (code: string) => code.replace(/[\uFFFE\uFFFF]/g, (character) => {
+        const codePoint = character.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0');
+        return `\\u${codePoint}`;
+    });
+
+    return {
+        name: 'escape-extension-noncharacters',
+        generateBundle(_options: unknown, bundle: Record<string, {type: string; code?: string}>) {
+            // 部分构建阶段会在 renderChunk 之后再次序列化字符串，因此在
+            // 写入扩展目录前再检查一次最终 chunk，覆盖后台脚本等产物。
+            for (const chunk of Object.values(bundle)) {
+                if (chunk.type !== 'chunk' || chunk.code === undefined) continue;
+
+                const escaped = escapeActualNoncharacters(chunk.code);
+                if (escaped !== chunk.code) chunk.code = escaped;
+            }
+        },
+    };
+}
+
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
@@ -16,7 +43,7 @@ export default defineConfig({
         },
     },
     vite: () => ({
-        plugins: [vue()],
+        plugins: [vue(), escapeExtensionNoncharacters()],
         define: {
             'process.env.VUE_APP_VERSION': JSON.stringify(packageJson.version),
         }


### PR DESCRIPTION
## 变更\n\n- 在 WXT 最终 JavaScript chunk 写出前，将 U+FFFE/U+FFFF 非字符改写为 ASCII Unicode 转义。\n- 修复 Edge 将内容脚本误报为非 UTF-8、导致悬浮翻译与全文快捷键均不注册的问题。\n\n## 验证\n\n- pnpm compile\n- pnpm test（12 个文件，128 项）\n- pnpm build --browser edge\n- pnpm dev + 屏幕外隔离 Microsoft Edge\n- Control 悬浮翻译：1 → 0 → 1；相邻段落始终 0\n- Alt+T 全文翻译：3 → 0 → 3；页面错误为空\n- 生产与 dev 产物共检查 JavaScript 文件，均无实际 U+FFFE/U+FFFF\n\n测试使用独立临时 Edge profile，未操作用户当前浏览器。

## Summary by Sourcery

增强功能：
- 添加一个 Vite 插件，将生成的 JavaScript chunk 中的 U+FFFE/U+FFFF 非字符重写为 ASCII 形式的 Unicode 转义，以防止在 Edge 中加载内容脚本时出现失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add a Vite plugin to rewrite U+FFFE/U+FFFF noncharacters in generated JavaScript chunks as ASCII Unicode escapes to prevent Edge content script loading failures.

</details>