### PR TITLE
refactor: centralize config storage and synchronization

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -45,11 +45,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, reactive, ref } from 'vue';
+import { computed, onUnmounted, reactive, ref } from 'vue';
 import { Star, Loading, Coffee } from "@element-plus/icons-vue";
 import { Config } from "../entrypoints/utils/model";
-import { storage } from '@wxt-dev/storage';
 import browser from 'webextension-polyfill';
+import { config, configReady, subscribeConfig } from '@/entrypoints/utils/config';
 
 // 实际上是 el-link 而不是 el-button
 const buttonDisabled = ref(false);
@@ -94,16 +94,11 @@ async function clearCache() {
   }
 }
 
-// 获取配置，用于显示翻译次数
-let localConfig = reactive(new Config());
-
-storage.getItem('local:config').then((value) => {
-  if (typeof value === 'string' && value) Object.assign(localConfig, JSON.parse(value));
-});
-
-storage.watch('local:config', (newValue, oldValue) => {
-  if (typeof newValue === 'string' && newValue) Object.assign(localConfig, JSON.parse(newValue));
-});
+// 只订阅统一配置状态，避免 Footer 再注册一套独立的存储读取和监听。
+const localConfig = reactive(new Config());
+void configReady.then(() => Object.assign(localConfig, config));
+const unsubscribeConfig = subscribeConfig((nextConfig) => Object.assign(localConfig, nextConfig));
+onUnmounted(unsubscribeConfig);
 
 const computedCount = computed(() => localConfig.count);
 

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -504,7 +504,6 @@
 import { computed, ref, watch, onUnmounted } from 'vue'
 import { models, options, resolveConfiguredModel, servicesType, defaultOption } from "../entrypoints/utils/option";
 import { Config, normalizeConfig } from "@/entrypoints/utils/model";
-import { storage } from '@wxt-dev/storage';
 import { InfoFilled, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import browser from 'webextension-polyfill';
@@ -519,6 +518,12 @@ import {
 } from '@/entrypoints/utils/custom-body';
 import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
 import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
+import {
+  config as runtimeConfig,
+  configReady,
+  saveConfig,
+  subscribeConfig,
+} from '@/entrypoints/utils/config';
 
 const props = withDefaults(defineProps<{
   activeSection?: string
@@ -556,25 +561,21 @@ const appendDeepLXPreset = (endpoint: string | undefined) => {
   selectedDeepLXPreset.value = '';
 };
 
-function applyStoredConfig(value: unknown) {
-  if (typeof value !== 'string' || !value.trim()) return;
+let hydrated = false;
+const unsubscribeConfig = subscribeConfig((nextConfig) => {
+  Object.assign(config.value, nextConfig);
+});
 
-  try {
-    Object.assign(config.value, normalizeConfig(JSON.parse(value)));
-  } catch (error) {
-    console.warn('[FluentRead] 无法读取设置页配置', error);
-  }
-}
-
-void storage.getItem('local:config')
-  .then((value) => applyStoredConfig(value))
-  .catch((error) => console.warn('[FluentRead] 无法读取本地配置', error))
-  .finally(() => updateTheme(config.value.theme || 'auto'));
-
-storage.watch('local:config', (newValue) => applyStoredConfig(newValue));
+void configReady
+  .then(() => {
+    Object.assign(config.value, runtimeConfig);
+    hydrated = true;
+    updateTheme(config.value.theme || 'auto');
+  })
+  .catch((error) => console.warn('[FluentRead] 无法读取本地配置', error));
 
 watch(config, (newValue) => {
-  void storage.setItem('local:config', JSON.stringify(newValue));
+  if (hydrated) void saveConfig(newValue).catch((error) => console.warn('[FluentRead] 保存设置失败', error));
 }, { deep: true });
 
 // 设置页左侧列表只切换正在编辑的服务，不改变网页翻译实际使用的默认服务。
@@ -650,6 +651,7 @@ darkModeMediaQuery.onchange = (e) => {
 // 组件卸载时清理
 onUnmounted(() => {
   darkModeMediaQuery.onchange = null;
+  unsubscribeConfig();
 });
 
 // 计算样式分组
@@ -912,14 +914,9 @@ const isValidAzureEndpoint = (endpoint: string) => {
 
 const handleExport = async () => {
   try {
-    const configStr = await storage.getItem('local:config');
-    if (typeof configStr !== 'string' || !configStr.trim()) {
-      ElMessage({ message: '没有找到配置信息', type: 'warning' });
-      return;
-    }
-
+    await configReady;
     exportData.value = JSON.stringify(
-      sanitizeConfigForExport(JSON.parse(configStr)),
+      sanitizeConfigForExport(runtimeConfig),
       null,
       2,
     );
@@ -948,7 +945,7 @@ const saveImport = async () => {
       });
       return;
     }
-    await storage.setItem('local:config', JSON.stringify(normalizeConfig(parsedConfig)));
+    await saveConfig(normalizeConfig(parsedConfig));
     ElMessage({
       message: '配置导入成功!',
       type: 'success',

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -267,9 +267,14 @@
 <script lang="ts" setup>
 import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from 'vue';
 import browser from 'webextension-polyfill';
-import { storage } from '@wxt-dev/storage';
+import {
+  config as runtimeConfig,
+  configReady,
+  saveConfig,
+  subscribeConfig,
+} from '@/entrypoints/utils/config';
 import { Setting } from '@element-plus/icons-vue';
-import { Config, normalizeConfig } from '@/entrypoints/utils/model';
+import { Config } from '@/entrypoints/utils/model';
 import { options } from '@/entrypoints/utils/option';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
@@ -344,18 +349,19 @@ function applyTheme(theme: string) {
 }
 
 async function hydrate() {
-  const value = await storage.getItem('local:config');
-  if (typeof value === 'string' && value) Object.assign(config.value, normalizeConfig(JSON.parse(value)));
+  await configReady;
+  Object.assign(config.value, runtimeConfig);
   lastSerialized = JSON.stringify(config.value);
   hydrated.value = true;
   applyTheme(config.value.theme || 'auto');
 }
 void hydrate();
 
-storage.watch('local:config', (value: any) => {
-  if (typeof value !== 'string' || !value || value === lastSerialized) return;
-  lastSerialized = value;
-  Object.assign(config.value, normalizeConfig(JSON.parse(value)));
+const unsubscribeConfig = subscribeConfig((value) => {
+  const serialized = JSON.stringify(value);
+  if (serialized === lastSerialized) return;
+  lastSerialized = serialized;
+  Object.assign(config.value, value);
 });
 
 watch(config, async value => {
@@ -363,7 +369,7 @@ watch(config, async value => {
   const serialized = JSON.stringify(value);
   if (serialized === lastSerialized) return;
   lastSerialized = serialized;
-  await storage.setItem('local:config', serialized);
+  await saveConfig(value).catch((error) => console.warn('[FluentRead] 保存 popup 设置失败', error));
 }, { deep: true });
 watch(() => config.value.theme, theme => applyTheme(theme || 'auto'));
 darkMode.onchange = () => { if (config.value.theme === 'auto') applyTheme('auto'); };
@@ -389,6 +395,7 @@ onMounted(() => {
   document.addEventListener('keydown', handleServicePickerKeydown);
 });
 onUnmounted(() => {
+  unsubscribeConfig();
   document.removeEventListener('pointerdown', closeServicePicker);
   document.removeEventListener('keydown', handleServicePickerKeydown);
   darkMode.onchange = null;

--- a/entrypoints/service/zhipu.ts
+++ b/entrypoints/service/zhipu.ts
@@ -2,7 +2,7 @@ import {method, urls} from "../utils/constant";
 import {services} from "../utils/option";
 import {commonMsgTemplate} from "../utils/template";
 import CryptoJS from 'crypto-js';
-import {config} from "@/entrypoints/utils/config";
+import {config, saveConfig} from "@/entrypoints/utils/config";
 
 
 // 文档参考：https://open.bigmodel.cn/dev/api#nosdk
@@ -16,7 +16,7 @@ async function zhipu(message: any) {
         if (!secret) throw new Error('无法生成令牌');
         // 保存 secret 和 expiration
         config.extra[services.zhipu] = {secret, expiration: Date.now() + 3600000 * 24};
-        await storage.setItem('local:config', JSON.stringify(config));
+        await saveConfig();
     }
 
     // 构建请求头

--- a/entrypoints/utils/config.ts
+++ b/entrypoints/utils/config.ts
@@ -1,59 +1,160 @@
-import { Config, normalizeConfig } from "@/entrypoints/utils/model";
+import { storage } from '@wxt-dev/storage';
+import { Config, normalizeConfig } from '@/entrypoints/utils/model';
 
-// 声明 config 类型, new Config() 会设置好所有默认值
-export let config: Config = new Config();
-export const configReady = loadConfig();
+export const CONFIG_STORAGE_KEY = 'local:config' as const;
 
-// 检查从存储中解析出的对象是否是有效的Config对象
-function isConfigObjectValid(obj: any): obj is Config {
-    if (typeof obj !== 'object' || obj === null) {
-        return false;
-    }
-    // 检查一些关键属性是否存在，以判断配置是否有效
-    return 'on' in obj && 'service' in obj && 'from' in obj && 'to' in obj;
+type ConfigListener = (nextConfig: Config) => void;
+
+const listeners = new Set<ConfigListener>();
+let storageRevision = 0;
+let initialized = false;
+let lastPersistedSerialized = '';
+let writeRevision = 0;
+let writeQueue: Promise<void> = Promise.resolve();
+
+// 所有运行时模块共享同一个可变配置对象；存储层负责把跨上下文变更同步进来。
+export const config = new Config();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-// 异步加载配置并应用
-async function loadConfig() {
+export function parseStoredConfig(value: unknown): Record<string, unknown> | null {
+    let parsed = value;
+
+    if (typeof parsed === 'string') {
+        if (!parsed.trim()) return null;
+        try {
+            parsed = JSON.parse(parsed);
+        } catch {
+            return null;
+        }
+    }
+
+    if (!isRecord(parsed)) return null;
+    if (!['on', 'service', 'from', 'to'].every((key) => key in parsed)) return null;
+    return parsed;
+}
+
+export function serializeConfig(value: unknown): string {
+    return JSON.stringify(value);
+}
+
+function notifyListeners(nextConfig: Config): void {
+    const snapshot = normalizeConfig(nextConfig);
+    listeners.forEach((listener) => listener(snapshot));
+}
+
+function applyConfig(nextConfig: Config): void {
+    Object.assign(config, nextConfig);
+    notifyListeners(config);
+}
+
+function queueStorageWrite(nextConfig: Config, serialized: string, revision: number): Promise<void> {
+    writeQueue = writeQueue
+        .catch(() => undefined)
+        .then(async () => {
+            // 只写最后一次快照，避免连续输入或多个页面初始化时排队回写旧配置。
+            if (revision !== writeRevision || lastPersistedSerialized !== serialized) return;
+            try {
+                await storage.setItem<Config>(CONFIG_STORAGE_KEY, nextConfig);
+            } catch (error) {
+                if (lastPersistedSerialized === serialized) lastPersistedSerialized = '';
+                throw error;
+            }
+        });
+    return writeQueue;
+}
+
+async function persistNormalizedConfig(nextConfig: Config, serialized = serializeConfig(nextConfig)): Promise<void> {
+    if (serialized === lastPersistedSerialized) return;
+
+    lastPersistedSerialized = serialized;
+    const revision = ++writeRevision;
+    await queueStorageWrite(nextConfig, serialized, revision);
+}
+
+function handleStoredConfigChange(value: unknown): void {
+    storageRevision += 1;
+    const parsed = parseStoredConfig(value);
+    if (!parsed) return;
+
+    const normalized = normalizeConfig(parsed);
+    const serialized = serializeConfig(normalized);
+    if (serialized === lastPersistedSerialized) return;
+
+    // 外部上下文已经产生了新快照，使尚未写入的旧快照失效。
+    writeRevision += 1;
+    lastPersistedSerialized = serialized;
+    applyConfig(normalized);
+}
+
+// 在首次读取前注册监听，避免设置页打开期间丢失其他上下文的更新。
+storage.watch(CONFIG_STORAGE_KEY, handleStoredConfigChange);
+
+async function initializeConfig(): Promise<void> {
     try {
-        const value = await storage.getItem('local:config');
-        if (typeof value === 'string' && value.trim().length > 0) {
-            const parsedConfig = JSON.parse(value);
-            if (isConfigObjectValid(parsedConfig)) {
-                const normalizedConfig = normalizeConfig(parsedConfig);
-                Object.assign(config, normalizedConfig);
-                if (JSON.stringify(parsedConfig) !== JSON.stringify(normalizedConfig)) {
-                    await storage.setItem('local:config', JSON.stringify(normalizedConfig));
-                }
-                return; // 加载成功，直接返回
-            }
+        let storedValue: unknown = null;
+
+        // 读取过程中若收到 storage.onChanged，重新读取一次，避免旧读结果覆盖新配置。
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+            const revisionAtRead = storageRevision;
+            storedValue = await storage.getItem<unknown>(CONFIG_STORAGE_KEY);
+            if (revisionAtRead === storageRevision) break;
         }
-        // 如果存储中没有配置、配置为空或无效，则将当前带有默认值的 config 对象存入存储
-        await storage.setItem('local:config', JSON.stringify(config));
+
+        const parsed = parseStoredConfig(storedValue);
+        const normalized = parsed ? normalizeConfig(parsed) : new Config();
+        const serialized = serializeConfig(normalized);
+
+        initialized = true;
+        applyConfig(normalized);
+
+        // 兼容旧版 JSON 字符串、缺失字段和模型迁移；迁移只在初始化时写回一次。
+        const storedSerialized = isRecord(storedValue) ? serializeConfig(storedValue) : '';
+        if (!parsed || typeof storedValue === 'string' || storedSerialized !== serialized) {
+            lastPersistedSerialized = '';
+            await persistNormalizedConfig(normalized, serialized);
+        } else {
+            lastPersistedSerialized = serialized;
+        }
     } catch (error) {
-        console.error('Error loading or validating config:', error);
-        // 出错时也尝试保存一次默认配置
+        // 存储 API 暂时不可用时仍提供默认配置，避免 Firefox 设置页因初始化 rejection 反复重载。
+        console.error('[FluentRead] 配置读取失败，使用默认配置', error);
+        const fallback = new Config();
+        const serialized = serializeConfig(fallback);
+        initialized = true;
+        lastPersistedSerialized = '';
+        applyConfig(fallback);
         try {
-            await storage.setItem('local:config', JSON.stringify(new Config()));
+            await persistNormalizedConfig(fallback, serialized);
         } catch (saveError) {
-            console.error('Failed to save default config after an error:', saveError);
+            console.error('[FluentRead] 默认配置保存失败', saveError);
         }
     }
 }
 
-// 监控配置变化并更新 config
-storage.watch('local:config', (newValue: any, oldValue: any) => {
-    if (typeof newValue === 'string' && newValue.trim().length > 0) {
-        try {
-            const parsedConfig = JSON.parse(newValue);
-            if (isConfigObjectValid(parsedConfig)) {
-                // 如果新的配置有效，更新 config
-                Object.assign(config, normalizeConfig(parsedConfig));
-            } else {
-                console.warn('An invalid configuration was detected in storage.watch. Ignoring.');
-            }
-        } catch (error) {
-            console.error('Error parsing new config in storage.watch:', error);
-        }
-    }
-});
+export const configReady = initializeConfig();
+
+export function subscribeConfig(listener: ConfigListener): () => void {
+    listeners.add(listener);
+    if (initialized) listener(normalizeConfig(config));
+    return () => listeners.delete(listener);
+}
+
+export function getConfigSnapshot(): Config {
+    return normalizeConfig(config);
+}
+
+/**
+ * 配置唯一写入口。调用方可以传入编辑中的快照，也可以省略参数保存运行时配置。
+ * 写入前会归一化、去重，并串行淘汰旧快照，避免设置页和 popup 互相回灌。
+ */
+export async function saveConfig(value: unknown = config): Promise<void> {
+    await configReady;
+
+    const normalized = normalizeConfig(value);
+    const serialized = serializeConfig(normalized);
+    if (serializeConfig(config) !== serialized) applyConfig(normalized);
+    await persistNormalizedConfig(normalized, serialized);
+}

--- a/entrypoints/utils/floatingBall.ts
+++ b/entrypoints/utils/floatingBall.ts
@@ -1,7 +1,6 @@
 import FloatingBall from '@/components/FloatingBall.vue';
-import { config } from '@/entrypoints/utils/config';
+import { config, saveConfig } from '@/entrypoints/utils/config';
 import browser from 'webextension-polyfill';
-import { storage } from '@wxt-dev/storage';
 import { autoTranslateEnglishPage, restoreOriginalContent } from '@/entrypoints/main/trans';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
@@ -54,7 +53,7 @@ export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' 
         config.floatingBallPosition = newPosition;
 
         // 保存配置到存储
-        saveConfig();
+        void saveConfig().catch((error) => console.error('Failed to save config:', error));
       },
       // 添加翻译状态变化事件监听
       onTranslationToggle: (isTranslating: boolean) => {
@@ -204,16 +203,6 @@ function addFloatingBallAnimation(type: 'translate' | 'restore') {
 }
 
 /**
- * 保存配置到存储
- */
-function saveConfig() {
-  // 使用插件提供的存储 API 保存配置
-  storage.setItem('local:config', JSON.stringify(config)).catch((error) => {
-    console.error('Failed to save config:', error);
-  });
-}
-
-/**
  * 卸载悬浮球
  */
 export function unmountFloatingBall() {
@@ -242,7 +231,7 @@ export function toggleFloatingBall() {
   }
   
   // 保存配置到存储
-  saveConfig();
+  void saveConfig().catch((error) => console.error('Failed to save config:', error));
 }
 
 /**
@@ -259,5 +248,5 @@ export function toggleFloatingBallPosition() {
   }
   
   // 保存配置到存储
-  saveConfig();
+  void saveConfig().catch((error) => console.error('Failed to save config:', error));
 }

--- a/entrypoints/utils/newApi.ts
+++ b/entrypoints/utils/newApi.ts
@@ -1,6 +1,5 @@
-import { config } from "@/entrypoints/utils/config";
+import { config, saveConfig } from "@/entrypoints/utils/config";
 import {customModelString, services} from "@/entrypoints/utils/option";
-import { storage } from '@wxt-dev/storage';
 
 let containerEl: HTMLElement | null = null;
 
@@ -47,7 +46,7 @@ export function mountNewApiComponent() {
 
 
     try {
-      await storage.setItem('local:config', JSON.stringify(config));
+      await saveConfig();
     } catch (error) {
       console.error('Error saving config:', error);
     }

--- a/entrypoints/utils/selectionTranslator.ts
+++ b/entrypoints/utils/selectionTranslator.ts
@@ -1,6 +1,5 @@
 import SelectionTranslator from '@/components/SelectionTranslator.vue';
-import { config } from '@/entrypoints/utils/config';
-import { storage } from '@wxt-dev/storage';
+import { config, saveConfig } from '@/entrypoints/utils/config';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
 import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
@@ -74,15 +73,7 @@ export function toggleSelectionTranslator() {
   }
   
   // 保存配置到存储
-  saveConfig();
-}
-
-/**
- * 保存配置到存储
- */
-function saveConfig() {
-  // 使用插件提供的存储API保存配置
-  storage.setItem('local:config', JSON.stringify(config)).catch((error) => {
+  void saveConfig().catch((error) => {
     console.error('Failed to save config:', error);
   });
 }

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -5,9 +5,8 @@
 
 import { enqueueTranslation, clearTranslationQueue } from './translateQueue';
 import browser from 'webextension-polyfill';
-import { config } from './config';
+import { config, saveConfig } from './config';
 import { detectlang } from './common';
-import { storage } from '@wxt-dev/storage';
 import { resolveConfiguredModel, servicesType } from './option';
 import { getPageTranslationContext } from './pageContext';
 
@@ -46,7 +45,7 @@ export async function translateText(origin: string, context: string = document.t
   // 增加翻译计数
   config.count++;
   // 保存配置以确保计数持久化
-  storage.setItem('local:config', JSON.stringify(config));
+  void saveConfig().catch((error) => console.error('[FluentRead] 保存翻译计数失败:', error));
 
   // 使用队列处理翻译请求
   return enqueueTranslation(async () => {
@@ -108,7 +107,7 @@ export async function translateTextBatch(
   const pageContext = await resolvePageContext(options.pageContext);
 
   config.count++;
-  storage.setItem('local:config', JSON.stringify(config));
+  void saveConfig().catch((error) => console.error('[FluentRead] 保存翻译计数失败:', error));
 
   return enqueueTranslation(async () => {
     const translationTask = async (retryCount: number = 0): Promise<string[]> => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeConfig } from '@/entrypoints/utils/model';
+
+const storageMock = vi.hoisted(() => ({
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    watch: vi.fn(),
+}));
+
+vi.mock('@wxt-dev/storage', () => ({ storage: storageMock }));
+
+const storedConfig = {
+    on: true,
+    service: 'openai',
+    from: 'auto',
+    to: 'zh-Hans',
+};
+
+async function loadConfigModule(value: unknown = null) {
+    vi.resetModules();
+    storageMock.getItem.mockReset().mockResolvedValue(value);
+    storageMock.setItem.mockReset().mockResolvedValue(undefined);
+    storageMock.watch.mockReset().mockReturnValue(() => undefined);
+    return import('@/entrypoints/utils/config');
+}
+
+describe('统一配置存储', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('兼容旧 JSON 字符串，并只迁移成一次对象存储', async () => {
+        const configStore = await loadConfigModule(JSON.stringify(storedConfig));
+
+        await configStore.configReady;
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        expect(storageMock.setItem).toHaveBeenCalledWith(
+            'local:config',
+            expect.objectContaining(storedConfig),
+        );
+        expect(typeof storageMock.setItem.mock.calls[0][1]).toBe('object');
+    });
+
+    it('读取已经规范化的对象时不产生初始化回写', async () => {
+        const canonicalConfig = normalizeConfig(storedConfig);
+        const configStore = await loadConfigModule(canonicalConfig);
+
+        await configStore.configReady;
+
+        expect(storageMock.setItem).not.toHaveBeenCalled();
+        expect(configStore.config).toMatchObject(storedConfig);
+    });
+
+    it('存储内容损坏时回退到默认配置，并保持初始化 Promise 可用', async () => {
+        const configStore = await loadConfigModule('{not-json');
+
+        await expect(configStore.configReady).resolves.toBeUndefined();
+
+        expect(configStore.config.on).toBe(true);
+        expect(storageMock.setItem).toHaveBeenCalledWith(
+            'local:config',
+            expect.objectContaining({ on: true }),
+        );
+    });
+
+    it('保存相同快照时去重，并让连续保存只保留最新快照', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+        await configStore.configReady;
+        storageMock.setItem.mockClear();
+
+        const firstSave = configStore.saveConfig({ ...configStore.config, on: false });
+        const latestSave = configStore.saveConfig({ ...configStore.config, on: true, to: 'en' });
+        await Promise.all([firstSave, latestSave]);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        expect(storageMock.setItem).toHaveBeenLastCalledWith(
+            'local:config',
+            expect.objectContaining({ on: true, to: 'en' }),
+        );
+
+        storageMock.setItem.mockClear();
+        await configStore.saveConfig({ ...configStore.config, on: true, to: 'en' });
+        expect(storageMock.setItem).not.toHaveBeenCalled();
+    });
+
+    it('收到外部对象更新时立即同步运行时状态，并通知订阅者', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+        await configStore.configReady;
+        const listener = vi.fn();
+        const unsubscribe = configStore.subscribeConfig(listener);
+        const watchCallback = storageMock.watch.mock.calls[0][1];
+
+        watchCallback({ ...storedConfig, on: false }, storedConfig);
+
+        expect(configStore.config.on).toBe(false);
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({ on: false }));
+        unsubscribe();
+    });
+
+    it('外部更新不会被本地 watcher 再次写回，取消订阅后也不再通知', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+        await configStore.configReady;
+        const listener = vi.fn();
+        const unsubscribe = configStore.subscribeConfig(listener);
+        const watchCallback = storageMock.watch.mock.calls[0][1];
+        listener.mockClear();
+        storageMock.setItem.mockClear();
+
+        watchCallback({ ...storedConfig, on: false }, storedConfig);
+        unsubscribe();
+        watchCallback({ ...storedConfig, on: true }, { ...storedConfig, on: false });
+
+        expect(storageMock.setItem).not.toHaveBeenCalled();
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## 变更概述

重构 FluentRead 配置设置、存储和跨上下文同步，解决 Firefox 设置页打开时可能反复闪烁、配置回灌和实时同步不稳定的问题。

### 主要改动

- 统一 `configReady`、`subscribeConfig`、`saveConfig` 配置入口
- 将 `local:config` 规范为结构化对象存储，并兼容旧 JSON 字符串迁移
- 增加初始化竞态保护、配置标准化、损坏数据默认回退
- 增加写入去重、revision 控制和旧快照淘汰
- 设置页、Popup、Footer 改为订阅统一运行时配置
- 翻译计数、悬浮球、划词翻译、NewAPI、智谱 token 等直接写入点统一迁移
- 新增配置迁移、并发保存、外部同步、取消订阅和损坏数据回归测试

### 验证

- `pnpm compile`
- `pnpm test`：13 个测试文件、134 个测试全部通过
- `pnpm build`
- `pnpm build:firefox`
- `pnpm dev:firefox`：WXT 0.20.18 开发服务器和 Firefox MV2 dev 产物启动成功

该 PR 基于最新 `main` 创建。

## Summary by Sourcery

通过在共享运行时存储中集中管理配置状态，为扩展提供结构化存储、规范化处理以及可靠的跨上下文同步。

新功能：
- 为所有扩展上下文提供统一的配置运行时（当前配置、就绪 Promise、订阅 API，以及单一的保存入口）。

改进：
- 将 `local:config` 标准化为结构化对象存储，并支持从旧版 JSON 字符串迁移以及对部分或过期配置进行规范化处理。
- 添加去重且带版本控制的配置持久化机制，避免过期写入以及设置页面和弹窗之间的配置反馈循环。
- 在存储不可用或数据损坏时优雅回退到默认配置，同时保持初始化流程的稳定性。
- 更新设置页、弹窗和页脚，使其从共享运行时配置中读取并订阅，而不再维护各自独立的存储监听器。
- 将翻译次数、悬浮球控制、选中翻译器、NewAPI 选项以及 Zhipu 令牌统一通过集中化的 `saveConfig` 工作流进行持久化，以确保一致性。

测试：
- 添加单元测试，覆盖旧配置格式的迁移、损坏数据的回退、去重且有序的保存、外部更新同步以及订阅行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize configuration state management into a shared runtime store with structured storage, normalization, and robust cross-context synchronization for the extension.

New Features:
- Expose a unified configuration runtime (current config, readiness promise, subscription API, and single save entrypoint) for all extension contexts.

Enhancements:
- Standardize `local:config` as structured object storage with migration from legacy JSON strings and normalization of partial or outdated configs.
- Add deduplicated, revision-controlled config persistence to avoid outdated writes and configuration feedback loops between settings and popup.
- Ensure graceful fallback to default configuration when storage is unavailable or data is corrupted, while keeping initialization flows stable.
- Update settings page, popup, and footer to read from and subscribe to the shared runtime config instead of maintaining separate storage listeners.
- Route translation count, floating ball controls, selection translator, NewAPI options, and Zhipu tokens through the centralized `saveConfig` workflow for consistent persistence.

Tests:
- Add unit tests covering config migration from legacy formats, corruption fallback, deduplicated and ordered saves, external update synchronization, and subscription behavior.

</details>