### PR TITLE
fix: skip selection translation for target language

### DIFF
--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -46,7 +46,7 @@ import browser from 'webextension-polyfill';
 import { config } from '@/entrypoints/utils/config';
 import { translateText } from '@/entrypoints/utils/translateApi';
 import { detectlang } from '@/entrypoints/utils/common';
-import { calculateSelectionPopupPosition, chooseSelectionRect, normalizeSelectionText, normalizeSpeechLanguage, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
+import { calculateSelectionPopupPosition, chooseSelectionRect, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
 
 type SelectionTrigger = 'direct' | 'icon' | 'dot';
 type AudioKind = 'source' | 'translation';
@@ -115,8 +115,13 @@ function scheduleSelectionRead(): void {
   selectionFrame = window.requestAnimationFrame(() => { selectionFrame = null; if (!isSelecting) applySelection(readSelectionSnapshot()); });
 }
 
+function isSelectionInTargetLanguage(text: string): boolean {
+  return isSameLanguage(detectlang(text), config.to);
+}
+
 function applySelection(next: SelectionSnapshot | null): void {
   if (!next) { if (!isSelecting) hideAll(); return; }
+  if (isSelectionInTargetLanguage(next.text)) { hideAll(); return; }
   const changedText = selectedText.value !== next.text;
   snapshot.value = next;
   selectedText.value = next.text;
@@ -152,7 +157,7 @@ function schedulePositionUpdate(): void {
 }
 
 function openTooltip(): void {
-  if (!snapshot.value) return;
+  if (!snapshot.value || isSelectionInTargetLanguage(snapshot.value.text)) { hideAll(); return; }
   showIndicator.value = true;
   showTooltip.value = true;
   void requestTranslation(snapshot.value.text);
@@ -321,9 +326,10 @@ onMounted(() => {
   document.addEventListener('keydown', handleKeydown, true);
   window.addEventListener('scroll', schedulePositionUpdate, true);
   window.addEventListener('resize', schedulePositionUpdate);
-  watch(() => [config.theme, config.selectionTranslatorTrigger] as const, () => {
+  watch(() => [config.theme, config.selectionTranslatorTrigger, config.to] as const, () => {
     updateTheme();
     if (snapshot.value) {
+      if (isSelectionInTargetLanguage(snapshot.value.text)) { hideAll(); return; }
       showIndicator.value = triggerMode.value !== 'direct';
       showTooltip.value = triggerMode.value === 'direct';
       if (showTooltip.value) void requestTranslation(snapshot.value.text);

--- a/entrypoints/utils/selectionTranslatorCore.ts
+++ b/entrypoints/utils/selectionTranslatorCore.ts
@@ -23,6 +23,42 @@ export interface PopupPosition {
     placement: 'top' | 'bottom';
 }
 
+const languageAliases: Record<string, string> = {
+    cmn: 'zh',
+    zho: 'zh',
+    chi: 'zh',
+    eng: 'en',
+    jpn: 'ja',
+    kor: 'ko',
+    fra: 'fr',
+    fre: 'fr',
+    deu: 'de',
+    ger: 'de',
+    spa: 'es',
+    rus: 'ru',
+    ita: 'it',
+    por: 'pt',
+    ara: 'ar',
+    hin: 'hi',
+    tha: 'th',
+    vie: 'vi',
+    nld: 'nl',
+    dut: 'nl',
+    pol: 'pl',
+    tur: 'tr',
+};
+
+/** Compare detected and configured languages without depending on region/script details. */
+export function isSameLanguage(detectedLanguage: string | undefined, targetLanguage: string | undefined): boolean {
+    const detected = String(detectedLanguage ?? '').trim().replace(/_/g, '-').toLowerCase();
+    const target = String(targetLanguage ?? '').trim().replace(/_/g, '-').toLowerCase();
+    if (!detected || !target || ['auto', 'detect', 'unknown', 'und'].includes(detected) || ['auto', 'detect', 'unknown', 'und'].includes(target)) return false;
+
+    const detectedBase = languageAliases[detected] || detected.split('-')[0];
+    const targetBase = languageAliases[target] || target.split('-')[0];
+    return Boolean(detectedBase && targetBase && detectedBase === targetBase);
+}
+
 const DEFAULT_PADDING = 12;
 const DEFAULT_GAP = 10;
 

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     calculateSelectionPopupPosition,
     chooseSelectionRect,
+    isSameLanguage,
     normalizeSelectionText,
     normalizeSpeechLanguage,
 } from '@/entrypoints/utils/selectionTranslatorCore';
@@ -36,6 +37,14 @@ describe('selection translator core geometry', () => {
 });
 
 describe('selection translator text and speech language normalization', () => {
+    it('matches detected languages with configured language families', () => {
+        expect(isSameLanguage('zh-Hans', 'zh-Hant')).toBe(true);
+        expect(isSameLanguage('eng', 'en')).toBe(true);
+        expect(isSameLanguage('ja', 'en')).toBe(false);
+        expect(isSameLanguage('und', 'en')).toBe(false);
+        expect(isSameLanguage('en', 'auto')).toBe(false);
+    });
+
     it('normalizes browser whitespace without changing words', () => {
         expect(normalizeSelectionText('  hello\u00a0  world\n   again  ')).toBe('hello world\nagain');
     });


### PR DESCRIPTION
## What changed

- Detect the selected text language before showing the selection-translation affordance or popup.
- Treat script/region variants in the same language family as the configured target language, including `zh-Hans` and `zh-Hant`.
- Re-check when the target language changes and guard the explicit popup action as well.
- Add unit coverage for language-family matching.

## Why

The translation API already returned target-language text unchanged, but the selection translator displayed its UI before making that request. Selecting text that was already in the target language therefore still opened the selection translator.

## Validation

- `pnpm test` — 135 tests passed.
- `pnpm compile` — passed.
- `pnpm build` — passed.
- `git diff --check` — passed.
- Isolated Microsoft Edge test with a temporary profile and screen-off window: target-language selection produced `tooltip=0, indicator=0`; English selection produced one popup. Evidence: `/private/tmp/fluentread-selection-evidence/target-language-no-popup.png` and `/private/tmp/fluentread-selection-evidence/non-target-language-popup.png`.

## Summary by Sourcery

当选中的文本已经与配置的目标语言属于同一语系时，跳过显示选区翻译 UI。

New Features:
- 添加语言家族匹配工具，用于比较检测到的语言和目标语言，使其不受文字脚本或区域变体的影响。

Bug Fixes:
- 当选中文本已是目标语言时，阻止选区翻译的 tooltip 和弹出窗口出现。

Enhancements:
- 规范化并建立常见语言代码的别名，以支持对同一语言选区的可靠检测。
- 当目标语言设置发生变化时，重新评估选区翻译的可见性。

Tests:
- 添加单元测试，覆盖选区翻译中语言家族匹配行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip showing the selection translation UI when the selected text is already in the configured target language, based on language-family matching.

New Features:
- Add language-family matching utility to compare detected and target languages independent of script or region variants.

Bug Fixes:
- Prevent selection translation tooltip and popup from appearing when the selected text is already in the target language.

Enhancements:
- Normalize and alias common language codes to support robust detection of same-language selections.
- Re-evaluate selection translation visibility when the target language setting changes.

Tests:
- Add unit tests covering language-family matching behavior for selection translation.

</details>