### PR TITLE
fix: reduce floating ball icon size

### DIFF
--- a/components/FloatingBall.vue
+++ b/components/FloatingBall.vue
@@ -400,8 +400,8 @@ watch(() => props.position, (newPosition) => {
 
 .floating-ball-logo {
   display: block;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   object-fit: cover;
   pointer-events: none;
@@ -409,22 +409,22 @@ watch(() => props.position, (newPosition) => {
 
 .floating-ball-logo-fallback {
   display: inline-flex;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
   background: linear-gradient(145deg, #f2487d, #ff7397);
   color: #fff;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 800;
   letter-spacing: -1px;
   pointer-events: none;
 }
 
 .translation-icon {
-  width: 19px;
-  height: 19px;
+  width: 17px;
+  height: 17px;
 }
 
 .floating-ball-tool {
@@ -492,8 +492,8 @@ watch(() => props.position, (newPosition) => {
 }
 
 .floating-ball-settings svg {
-  width: 18px;
-  height: 18px;
+  width: 17px;
+  height: 17px;
 }
 
 .shortcut-tooltip {

--- a/components/FloatingBall.vue
+++ b/components/FloatingBall.vue
@@ -13,10 +13,30 @@
     :style="positionStyle"
     @mouseenter="expandBall"
     @mouseleave="collapseBall"
+    @focusin="expandBall"
+    @focusout="collapseBall"
   >
     <button
-      ref="mainButton"
-      class="floating-ball-main"
+      v-if="showMenu"
+      class="floating-ball-tool floating-ball-translate floating-ball-item"
+      type="button"
+      :aria-label="isTranslating ? '恢复网页原文' : '翻译整个网页'"
+      :aria-pressed="isTranslating"
+      :title="isTranslating ? '恢复网页原文' : '翻译整个网页'"
+      @pointerdown.stop
+      @click.stop="toggleTranslation"
+    >
+      <svg class="translation-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path
+          d="M12.87 15.07 10.33 12.56l.03-.03A16.6 16.6 0 0 0 14.07 6H17V4h-7V2H8v2H1v2h11.17A16.8 16.8 0 0 1 9 11.35 15.7 15.7 0 0 1 6.69 8h-2A18.3 18.3 0 0 0 7.67 12.56L2.58 17.58 4 19l5-5 3.11 3.11z"
+          fill="currentColor"
+        />
+      </svg>
+      <span v-if="isTranslating" class="check-mark" aria-hidden="true" />
+    </button>
+
+    <button
+      class="floating-ball-main floating-ball-item"
       type="button"
       :aria-label="mainButtonLabel"
       :aria-pressed="isTranslating"
@@ -27,33 +47,25 @@
       @pointerup="finishPointerInteraction"
       @pointercancel="cancelPointerInteraction"
     >
-      <span class="floating-ball-icon" aria-hidden="true">
-        <svg class="translation-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M12.87 15.07 10.33 12.56l.03-.03A16.6 16.6 0 0 0 14.07 6H17V4h-7V2H8v2H1v2h11.17A16.8 16.8 0 0 1 9 11.35 15.7 15.7 0 0 1 6.69 8h-2A18.3 18.3 0 0 0 7.67 12.56L2.58 17.58 4 19l5-5 3.11 3.11z"
-            fill="currentColor"
-          />
-        </svg>
-        <span v-if="isTranslating" class="check-mark" />
-      </span>
-      <span class="floating-ball-label">{{ isTranslating ? '恢复原文' : '翻译全文' }}</span>
+      <img v-if="logoUrl" class="floating-ball-logo" :src="logoUrl" alt="" draggable="false" />
+      <span v-else class="floating-ball-logo-fallback" aria-hidden="true">A↔中</span>
+      <span v-if="isTranslating" class="check-mark" aria-hidden="true" />
     </button>
 
-    <div v-show="isExpanded && !isDragging && showMenu" class="floating-ball-menu" role="group" aria-label="悬浮球工具">
-      <button
-        class="floating-ball-action"
-        type="button"
-        aria-label="打开 FluentRead 设置"
-        title="打开设置"
-        @pointerdown.stop
-        @click.stop="handleSettingsClick"
-      >
-        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="m19.43 12.98 1.25.98-1.5 2.6-1.5-.6a7.3 7.3 0 0 1-1.69.98L15.77 18h-3l-.22-1.06a7.3 7.3 0 0 1-1.69-.98l-1.5.6-1.5-2.6 1.25-.98a6.7 6.7 0 0 1 0-1.96l-1.25-.98 1.5-2.6 1.5.6a7.3 7.3 0 0 1 1.69-.98L12.77 6h3l.22 1.06c.6.24 1.16.57 1.69.98l1.5-.6 1.5 2.6-1.25.98a6.7 6.7 0 0 1 0 1.96Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" />
-          <circle cx="14.27" cy="12" r="2.4" stroke="currentColor" stroke-width="1.7" />
-        </svg>
-      </button>
-    </div>
+    <button
+      v-if="showMenu"
+      class="floating-ball-tool floating-ball-settings floating-ball-item"
+      type="button"
+      aria-label="打开 FluentRead 设置"
+      title="打开设置"
+      @pointerdown.stop
+      @click.stop="handleSettingsClick"
+    >
+      <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="m19.43 12.98 1.25.98-1.5 2.6-1.5-.6a7.3 7.3 0 0 1-1.69.98L15.77 18h-3l-.22-1.06a7.3 7.3 0 0 1-1.69-.98l-1.5.6-1.5-2.6 1.25-.98a6.7 6.7 0 0 1 0-1.96l-1.25-.98 1.5-2.6 1.5.6a7.3 7.3 0 0 1 1.69-.98L12.77 6h3l.22 1.06c.6.24 1.16.57 1.69.98l1.5-.6 1.5 2.6-1.25.98a6.7 6.7 0 0 1 0 1.96Z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" />
+        <circle cx="14.27" cy="12" r="2.4" stroke="currentColor" stroke-width="1.7" />
+      </svg>
+    </button>
 
     <div v-if="showShortcutTooltip" class="shortcut-tooltip" role="status">{{ shortcutTip }}</div>
   </div>
@@ -76,6 +88,10 @@ const props = defineProps({
   showMenu: {
     type: Boolean,
     default: true,
+  },
+  logoUrl: {
+    type: String,
+    default: '',
   },
   onSettingsClick: {
     type: Function as PropType<(event: MouseEvent) => void>,
@@ -105,7 +121,6 @@ const draggedY = ref<number | null>(null);
 const internalPosition = ref<'left' | 'right' | null>(null);
 const isTranslating = ref(false);
 const floatingBall = ref<HTMLElement | null>(null);
-const mainButton = ref<HTMLButtonElement | null>(null);
 const showShortcutTooltip = ref(false);
 const shortcutTip = ref('快捷键：Alt+T');
 const dragState = ref<PointerDragState | null>(null);
@@ -122,7 +137,7 @@ function expandBall() {
 }
 
 function collapseBall() {
-  if (!isDragging.value && !mainButton.value?.matches(':focus')) isExpanded.value = false;
+  if (!isDragging.value && !floatingBall.value?.matches(':focus-within')) isExpanded.value = false;
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -132,8 +147,14 @@ function clamp(value: number, min: number, max: number) {
 function updatePositionStyle() {
   if (isDragging.value) return;
 
+  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
+  const halfHeight = containerHeight / 2;
+  const centerY = draggedY.value === null
+    ? '50%'
+    : `${clamp(draggedY.value, halfHeight, Math.max(halfHeight, window.innerHeight - halfHeight))}px`;
+
   positionStyle.value = {
-    top: draggedY.value === null ? '50%' : `${clamp(draggedY.value, 0, Math.max(0, window.innerHeight - BALL_SIZE))}px`,
+    top: centerY,
     left: undefined,
     right: undefined,
     transform: undefined,
@@ -153,8 +174,9 @@ function startDrag(event: PointerEvent) {
     moved: false,
   };
 
+  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
   const startLeft = clamp(event.clientX - BALL_SIZE / 2, 0, Math.max(0, window.innerWidth - BALL_SIZE));
-  const startTop = clamp(event.clientY - BALL_SIZE / 2, 0, Math.max(0, window.innerHeight - BALL_SIZE));
+  const startTop = clamp(event.clientY - containerHeight / 2, 0, Math.max(0, window.innerHeight - containerHeight));
   positionStyle.value = {
     left: `${startLeft}px`,
     top: `${startTop}px`,
@@ -175,8 +197,9 @@ function handlePointerMove(event: PointerEvent) {
     currentDrag.moved = true;
   }
 
+  const containerHeight = floatingBall.value?.getBoundingClientRect().height || BALL_SIZE;
   const nextLeft = clamp(event.clientX - BALL_SIZE / 2, 0, Math.max(0, window.innerWidth - BALL_SIZE));
-  const nextTop = clamp(event.clientY - BALL_SIZE / 2, 0, Math.max(0, window.innerHeight - BALL_SIZE));
+  const nextTop = clamp(event.clientY - containerHeight / 2, 0, Math.max(0, window.innerHeight - containerHeight));
   positionStyle.value = {
     left: `${nextLeft}px`,
     top: `${nextTop}px`,
@@ -195,9 +218,10 @@ function finishPointerInteraction(event: PointerEvent) {
 
   if (currentDrag.moved) {
     const rect = floatingBall.value?.getBoundingClientRect();
-    const finalTop = rect?.top ?? event.clientY - BALL_SIZE / 2;
+    const finalCenterY = rect ? rect.top + rect.height / 2 : event.clientY;
     const nextPosition = event.clientX < window.innerWidth / 2 ? 'left' : 'right';
-    draggedY.value = clamp(finalTop, 0, Math.max(0, window.innerHeight - BALL_SIZE));
+    const halfHeight = (rect?.height || BALL_SIZE) / 2;
+    draggedY.value = clamp(finalCenterY, halfHeight, Math.max(halfHeight, window.innerHeight - halfHeight));
     internalPosition.value = nextPosition;
     props.onPositionChanged(nextPosition);
     nextTick(updatePositionStyle);
@@ -287,110 +311,161 @@ watch(() => props.position, (newPosition) => {
 <style scoped>
 .fr-floating-ball {
   position: fixed;
-  z-index: 9999;
+  z-index: 2147483647;
   display: flex;
-  width: 42px;
-  height: 42px;
-  align-items: center;
-  transition: width 0.22s ease, transform 0.22s ease;
+  width: 48px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  color: #596273;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  transition: transform 0.46s cubic-bezier(0.22, 1, 0.36, 1);
   user-select: none;
   touch-action: none;
+  will-change: transform;
 }
 
 .fr-floating-ball[data-position="left"] {
   left: 0;
-  justify-content: flex-start;
-  transform: translateX(-50%);
+  align-items: flex-start;
+  transform: translateY(-50%);
 }
 
 .fr-floating-ball[data-position="right"] {
   right: 0;
-  justify-content: flex-end;
-  transform: translateX(50%);
+  transform: translateY(-50%);
 }
 
 .fr-floating-ball-expanded {
-  width: 166px;
+  transform: translateY(-50%) !important;
+}
+
+.floating-ball-item {
+  position: relative;
+  flex: 0 0 auto;
+  transform: translateX(48px);
+  transition: transform 0.46s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.24s ease, box-shadow 0.24s ease, border-color 0.24s ease, background 0.24s ease;
+  will-change: transform;
+}
+
+.fr-floating-ball[data-position="left"] .floating-ball-item {
+  transform: translateX(-48px);
+}
+
+.fr-floating-ball.floating-ball-expanded .floating-ball-item {
+  opacity: 1;
   transform: translateX(0) !important;
+}
+
+.floating-ball-translate {
+  transition-delay: 0.06s;
 }
 
 .floating-ball-main {
   position: relative;
   z-index: 1;
   display: flex;
-  width: 42px;
-  height: 42px;
-  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 0 10px;
-  overflow: hidden;
-  border: 1px solid #e1e5eb;
-  border-radius: 22px;
-  background: #fff;
-  color: #364152;
-  box-shadow: 0 5px 18px rgba(15, 23, 42, 0.2);
+  padding: 0;
+  border: 1px solid rgba(217, 222, 231, 0.96);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
   cursor: pointer;
-  transition: width 0.22s ease, border-color 0.22s ease, background 0.22s ease, box-shadow 0.22s ease;
+  opacity: 0.84;
+  overflow: visible;
+}
+
+.fr-floating-ball:not(.floating-ball-expanded)[data-position="right"] .floating-ball-main {
+  transform: translateX(50%);
+}
+
+.fr-floating-ball:not(.floating-ball-expanded)[data-position="left"] .floating-ball-main {
+  transform: translateX(-50%);
 }
 
 .fr-floating-ball-expanded .floating-ball-main {
-  width: 124px;
-  border-color: #b9c9f8;
-  box-shadow: 0 7px 22px rgba(37, 99, 235, 0.22);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.22);
 }
 
 .floating-ball-main:hover,
 .floating-ball-main:focus-visible {
   outline: none;
-  border-color: #6d8ce8;
-  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.28);
+  border-color: #f06a92;
+  box-shadow: 0 10px 30px rgba(240, 106, 146, 0.28);
 }
 
-.floating-ball-icon {
+.floating-ball-logo {
+  display: block;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.floating-ball-logo-fallback {
   display: inline-flex;
-  width: 24px;
-  height: 24px;
-  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: #ed6d8f;
+  background: linear-gradient(145deg, #f2487d, #ff7397);
   color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: -1px;
+  pointer-events: none;
 }
 
 .translation-icon {
-  width: 17px;
-  height: 17px;
+  width: 19px;
+  height: 19px;
 }
 
-.floating-ball-label {
-  max-width: 0;
-  overflow: hidden;
-  color: #344054;
-  font-size: 13px;
-  font-weight: 650;
+.floating-ball-tool {
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid rgba(217, 222, 231, 0.96);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.94);
+  color: #626b79;
+  cursor: pointer;
   opacity: 0;
-  white-space: nowrap;
-  transition: max-width 0.22s ease, opacity 0.16s ease;
 }
 
-.fr-floating-ball-expanded .floating-ball-label {
-  max-width: 76px;
+.fr-floating-ball.floating-ball-expanded .floating-ball-tool {
   opacity: 1;
 }
 
-.is-translating .floating-ball-icon {
-  background: #3b82f6;
+.floating-ball-settings {
+  transition-delay: 0.1s;
+}
+
+.floating-ball-tool:hover,
+.floating-ball-tool:focus-visible {
+  outline: none;
+  border-color: #f06a92;
+  background: #fff7fa;
+  color: #ec4d7d;
+  box-shadow: 0 8px 22px rgba(240, 106, 146, 0.2);
 }
 
 .is-translating .floating-ball-main {
-  border-color: #86b5f7;
+  border-color: #f06a92;
+  box-shadow: 0 10px 28px rgba(240, 106, 146, 0.24);
 }
 
 .animating .floating-ball-main {
-  animation: floating-ball-pulse 0.5s ease;
+  animation: floating-ball-pulse 0.62s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .check-mark {
@@ -416,49 +491,15 @@ watch(() => props.position, (newPosition) => {
   transform: rotate(45deg);
 }
 
-.floating-ball-menu {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  margin: 0 6px;
-  border: 1px solid #e1e5eb;
-  border-radius: 17px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 5px 18px rgba(15, 23, 42, 0.16);
-  animation: floating-ball-menu-in 0.18s ease both;
-}
-
-.floating-ball-action {
-  display: inline-flex;
-  width: 28px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border: 0;
-  border-radius: 50%;
-  background: transparent;
-  color: #667085;
-  cursor: pointer;
-}
-
-.floating-ball-action:hover,
-.floating-ball-action:focus-visible {
-  outline: none;
-  background: #eef2ff;
-  color: #3155c7;
-}
-
-.floating-ball-action svg {
+.floating-ball-settings svg {
   width: 18px;
   height: 18px;
 }
 
 .shortcut-tooltip {
   position: absolute;
-  top: calc(100% + 8px);
-  left: 50%;
+  top: 50%;
+  right: calc(100% + 10px);
   z-index: 2;
   padding: 5px 8px;
   border-radius: 6px;
@@ -467,7 +508,7 @@ watch(() => props.position, (newPosition) => {
   font-size: 12px;
   white-space: nowrap;
   pointer-events: none;
-  transform: translateX(-50%);
+  transform: translateY(-50%);
   animation: floating-ball-tooltip-in 0.18s ease both;
 }
 
@@ -476,25 +517,22 @@ watch(() => props.position, (newPosition) => {
 }
 
 .dragging .floating-ball-main {
-  width: 42px;
+  transform: none !important;
+  opacity: 1;
   cursor: grabbing;
-  border-color: #6d8ce8;
-  box-shadow: 0 8px 25px rgba(15, 23, 42, 0.28);
+  border-color: #f06a92;
+  box-shadow: 0 8px 25px rgba(240, 106, 146, 0.28);
 }
 
-.dragging .floating-ball-label,
+.dragging .floating-ball-tool,
 .static-mode .shortcut-tooltip {
+  visibility: hidden;
   display: none;
 }
 
-@keyframes floating-ball-menu-in {
-  from { opacity: 0; transform: translateX(4px) scale(0.92); }
-  to { opacity: 1; transform: translateX(0) scale(1); }
-}
-
 @keyframes floating-ball-tooltip-in {
-  from { opacity: 0; transform: translate(-50%, -3px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
+  from { opacity: 0; transform: translate(4px, -50%); }
+  to { opacity: 1; transform: translate(0, -50%); }
 }
 
 @keyframes floating-ball-pulse {
@@ -505,12 +543,12 @@ watch(() => props.position, (newPosition) => {
 
 @media (prefers-reduced-motion: reduce) {
   .fr-floating-ball,
+  .floating-ball-item,
   .floating-ball-main,
-  .floating-ball-label {
+  .floating-ball-tool {
     transition: none;
   }
 
-  .floating-ball-menu,
   .shortcut-tooltip,
   .animating .floating-ball-main {
     animation: none;

--- a/entrypoints/utils/floatingBall.ts
+++ b/entrypoints/utils/floatingBall.ts
@@ -42,6 +42,7 @@ export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' 
     props: {
       position: ballPosition,
       showMenu: true,
+      logoUrl: browser.runtime.getURL('/icon/128.png'),
       onSettingsClick: () => {
         browser.runtime.sendMessage({ type: 'openOptionsPage' });
       },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -62,6 +62,12 @@ export default defineConfig({
             'http://localhost/*',
             'http://127.0.0.1/*',
         ],
+        web_accessible_resources: [
+            {
+                resources: ['icon/128.png'],
+                matches: ['<all_urls>'],
+            },
+        ],
     },
 
 });


### PR DESCRIPTION
## 改动

- 将悬浮球中间的 FluentRead Logo 从 36px 缩小到 30px，保留主按钮尺寸与贴边半隐藏交互。
- fallback 字标同步缩小，翻译和设置图标略微收敛，改善三个按钮的视觉比例。

## 关系

- 基于 PR #260 的纵向贴边悬浮球设计。
- 本 PR 只做图标尺寸与视觉比例微调。
- PR #260 保持打开，本 PR 不取代、不关闭原 PR。

## 验证

- `pnpm compile`
- `pnpm build`
- `git diff --check`
- 隔离 Edge 真实扩展验证：主 Logo 实测 30×30px；默认半隐藏、悬停展开、全文翻译切换、拖拽贴边、设置入口均通过；控制台错误 0。

## Summary by Sourcery

调整悬浮球入口点以使用更小的品牌 logo，并优化其布局、交互和可访问性，同时通过扩展配置接入 logo 资源。

New Features:
- 通过新的 `logoUrl` prop 和可在网页中访问的扩展图标资源，为悬浮球添加外部 logo 图片支持。
- 在悬浮球中引入独立的翻译按钮和设置按钮，使操作更清晰。

Enhancements:
- 优化悬浮球的位置、拖拽行为和展开动画，使其在视觉上保持居中并拥有更顺滑的体验。
- 改进键盘和焦点处理逻辑，使悬浮球在获得焦点时自动展开，并仅在焦点离开时收起。
- 更新悬浮球样式，包括减小 logo/备用图标尺寸，调整颜色、阴影和提示框位置，以获得更好的视觉平衡。

Build:
- 将扩展的 128px 图标暴露为 `web_accessible_resource`，并将其用作悬浮球的 logo。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the floating ball entrypoint to use a smaller branded logo and refine its layout, interactions, and accessibility while wiring the logo asset through the extension config.

New Features:
- Add support for an external logo image in the floating ball via a new logoUrl prop and web-accessible extension icon resource.
- Introduce separate translate and settings tool buttons in the floating ball for clearer actions.

Enhancements:
- Refine floating ball positioning, drag behavior, and expansion animation to stay visually centered and feel smoother.
- Improve keyboard and focus handling so the floating ball expands on focus and collapses only when focus leaves.
- Update floating ball styling, including reduced logo/fallback sizes and adjusted colors, shadows, and tooltip placement for better visual balance.

Build:
- Expose the extension 128px icon as a web_accessible_resource and use it as the floating ball logo.

</details>