### PR TITLE
fix: reduce selection translation startup work

### DIFF
--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -46,7 +46,7 @@ import browser from 'webextension-polyfill';
 import { config } from '@/entrypoints/utils/config';
 import { translateText } from '@/entrypoints/utils/translateApi';
 import { detectlang } from '@/entrypoints/utils/common';
-import { calculateSelectionPopupPosition, chooseSelectionRect, normalizeSelectionText, normalizeSpeechLanguage, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
+import { calculateSelectionPopupPosition, chooseSelectionRect, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
 
 type SelectionTrigger = 'direct' | 'icon' | 'dot';
 type AudioKind = 'source' | 'translation';
@@ -115,8 +115,13 @@ function scheduleSelectionRead(): void {
   selectionFrame = window.requestAnimationFrame(() => { selectionFrame = null; if (!isSelecting) applySelection(readSelectionSnapshot()); });
 }
 
+function isSelectionInTargetLanguage(text: string): boolean {
+  return isSameLanguage(detectlang(text), config.to);
+}
+
 function applySelection(next: SelectionSnapshot | null): void {
   if (!next) { if (!isSelecting) hideAll(); return; }
+  if (isSelectionInTargetLanguage(next.text)) { hideAll(); return; }
   const changedText = selectedText.value !== next.text;
   snapshot.value = next;
   selectedText.value = next.text;
@@ -152,7 +157,7 @@ function schedulePositionUpdate(): void {
 }
 
 function openTooltip(): void {
-  if (!snapshot.value) return;
+  if (!snapshot.value || isSelectionInTargetLanguage(snapshot.value.text)) { hideAll(); return; }
   showIndicator.value = true;
   showTooltip.value = true;
   void requestTranslation(snapshot.value.text);
@@ -321,9 +326,10 @@ onMounted(() => {
   document.addEventListener('keydown', handleKeydown, true);
   window.addEventListener('scroll', schedulePositionUpdate, true);
   window.addEventListener('resize', schedulePositionUpdate);
-  watch(() => [config.theme, config.selectionTranslatorTrigger] as const, () => {
+  watch(() => [config.theme, config.selectionTranslatorTrigger, config.to] as const, () => {
     updateTheme();
     if (snapshot.value) {
+      if (isSelectionInTargetLanguage(snapshot.value.text)) { hideAll(); return; }
       showIndicator.value = triggerMode.value !== 'direct';
       showTooltip.value = triggerMode.value === 'direct';
       if (showTooltip.value) void requestTranslation(snapshot.value.text);

--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -102,8 +102,7 @@ function readSelectionSnapshot(): SelectionSnapshot | null {
 
   const range = selection.getRangeAt(0).cloneRange();
   const rects = Array.from(range.getClientRects()).map(toSelectionRect).filter(rect => rect.width > 0 || rect.height > 0);
-  const fallbackRect = toSelectionRect(range.getBoundingClientRect());
-  const visualRects = rects.length > 0 ? rects : [fallbackRect];
+  const visualRects = rects.length > 0 ? rects : [toSelectionRect(range.getBoundingClientRect())];
   const isForward = selection.anchorNode === range.startContainer && selection.anchorOffset === range.startOffset;
   const anchor = chooseSelectionRect(visualRects, isForward);
   if (!anchor || (anchor.width === 0 && anchor.height === 0)) return null;
@@ -111,6 +110,7 @@ function readSelectionSnapshot(): SelectionSnapshot | null {
 }
 
 function scheduleSelectionRead(): void {
+  if (isSelecting) return;
   if (selectionFrame !== null) return;
   selectionFrame = window.requestAnimationFrame(() => { selectionFrame = null; if (!isSelecting) applySelection(readSelectionSnapshot()); });
 }
@@ -119,24 +119,38 @@ function isSelectionInTargetLanguage(text: string): boolean {
   return isSameLanguage(detectlang(text), config.to);
 }
 
+function isSameSelection(left: SelectionSnapshot | null, right: SelectionSnapshot): boolean {
+  if (!left || left.text !== right.text) return false;
+  return left.range.startContainer === right.range.startContainer
+    && left.range.startOffset === right.range.startOffset
+    && left.range.endContainer === right.range.endContainer
+    && left.range.endOffset === right.range.endOffset;
+}
+
 function applySelection(next: SelectionSnapshot | null): void {
   if (!next) { if (!isSelecting) hideAll(); return; }
+  if (isSameSelection(snapshot.value, next)) return;
   if (isSelectionInTargetLanguage(next.text)) { hideAll(); return; }
+  const hadActiveSelection = snapshot.value !== null;
   const changedText = selectedText.value !== next.text;
   snapshot.value = next;
   selectedText.value = next.text;
   showIndicator.value = triggerMode.value !== 'direct';
   showTooltip.value = triggerMode.value === 'direct';
   if (changedText) { translationResult.value = ''; error.value = ''; }
-  updatePosition();
-  if (showTooltip.value) void requestTranslation(next.text);
+  updatePosition(false);
+  if (showTooltip.value && (!hadActiveSelection || changedText)) void requestTranslation(next.text);
 }
 
-function updatePosition(): void {
+function updatePosition(refreshSelection = true): void {
   const current = snapshot.value;
   if (!current) return;
-  const rects = Array.from(current.range.getClientRects()).map(toSelectionRect).filter(rect => rect.width > 0 || rect.height > 0);
-  const anchor = chooseSelectionRect(rects.length > 0 ? rects : [current.anchor], current.isForward);
+  const rects = refreshSelection
+    ? Array.from(current.range.getClientRects()).map(toSelectionRect).filter(rect => rect.width > 0 || rect.height > 0)
+    : [];
+  const anchor = refreshSelection
+    ? chooseSelectionRect(rects.length > 0 ? rects : [current.anchor], current.isForward)
+    : current.anchor;
   if (!anchor) return;
   current.anchor = anchor;
   indicatorStyle.value = { left: `${anchor.right}px`, top: `${anchor.bottom}px` };

--- a/entrypoints/utils/selectionTranslatorCore.ts
+++ b/entrypoints/utils/selectionTranslatorCore.ts
@@ -23,6 +23,42 @@ export interface PopupPosition {
     placement: 'top' | 'bottom';
 }
 
+const languageAliases: Record<string, string> = {
+    cmn: 'zh',
+    zho: 'zh',
+    chi: 'zh',
+    eng: 'en',
+    jpn: 'ja',
+    kor: 'ko',
+    fra: 'fr',
+    fre: 'fr',
+    deu: 'de',
+    ger: 'de',
+    spa: 'es',
+    rus: 'ru',
+    ita: 'it',
+    por: 'pt',
+    ara: 'ar',
+    hin: 'hi',
+    tha: 'th',
+    vie: 'vi',
+    nld: 'nl',
+    dut: 'nl',
+    pol: 'pl',
+    tur: 'tr',
+};
+
+/** Compare detected and configured languages without depending on region/script details. */
+export function isSameLanguage(detectedLanguage: string | undefined, targetLanguage: string | undefined): boolean {
+    const detected = String(detectedLanguage ?? '').trim().replace(/_/g, '-').toLowerCase();
+    const target = String(targetLanguage ?? '').trim().replace(/_/g, '-').toLowerCase();
+    if (!detected || !target || ['auto', 'detect', 'unknown', 'und'].includes(detected) || ['auto', 'detect', 'unknown', 'und'].includes(target)) return false;
+
+    const detectedBase = languageAliases[detected] || detected.split('-')[0];
+    const targetBase = languageAliases[target] || target.split('-')[0];
+    return Boolean(detectedBase && targetBase && detectedBase === targetBase);
+}
+
 const DEFAULT_PADDING = 12;
 const DEFAULT_GAP = 10;
 

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     calculateSelectionPopupPosition,
     chooseSelectionRect,
+    isSameLanguage,
     normalizeSelectionText,
     normalizeSpeechLanguage,
 } from '@/entrypoints/utils/selectionTranslatorCore';
@@ -36,6 +37,14 @@ describe('selection translator core geometry', () => {
 });
 
 describe('selection translator text and speech language normalization', () => {
+    it('matches detected languages with configured language families', () => {
+        expect(isSameLanguage('zh-Hans', 'zh-Hant')).toBe(true);
+        expect(isSameLanguage('eng', 'en')).toBe(true);
+        expect(isSameLanguage('ja', 'en')).toBe(false);
+        expect(isSameLanguage('und', 'en')).toBe(false);
+        expect(isSameLanguage('en', 'auto')).toBe(false);
+    });
+
     it('normalizes browser whitespace without changing words', () => {
         expect(normalizeSelectionText('  hello\u00a0  world\n   again  ')).toBe('hello world\nagain');
     });


### PR DESCRIPTION
## What changed

- Avoid scheduling selection reads while the pointer is still dragging.
- Ignore duplicate `selectionchange` events for the same text and Range.
- Avoid repeated translation requests for an unchanged active selection.
- Reuse the selection anchor already measured during the first selection instead of forcing another synchronous layout read.
- Avoid calculating the Range fallback rectangle when client rects are already available.

## Why

PR #258 fixed target-language selection popups, but the selection component could still process the same selection more than once after pointer release. That repeated language detection, layout work, reactive updates, and translation scheduling can cause a visible hitch at the start of selection.

This PR includes PR #258 and is intended as its replacement; PR #258 is not being closed automatically.

## Validation

- `pnpm test` — 135 tests passed.
- `pnpm compile` — passed.
- `pnpm build` — passed.
- `git diff --check` — passed.
- Isolated Microsoft Edge with a temporary screen-off profile: target-language selection had `tooltip=0, indicator=0`; English selection had one popup and one Microsoft translation request. Long-task evidence was collected at `/private/tmp/fluentread-selection-performance-evidence-final/`.

## Summary by Sourcery

减少冗余的选区翻译工作，避免在文本选区变为激活状态时出现卡顿。

New Features:
- 添加语言家族比较功能，以跳过对已为目标语言的选区进行翻译。

Bug Fixes:
- 防止对同一选区快照进行重复处理，避免对未变化的选区发送重复的翻译请求。
- 在用户正在拖动选区时，停止安排选区读取和弹窗更新。
- 确保当工具提示打开以及主题/触发器发生变化时，如果选中文本与目标语言匹配，则隐藏 UI。

Enhancements:
- 复用之前测量过的选区锚点，在更新弹窗位置时避免不必要的布局读取。
- 简化选区矩形的兜底处理逻辑，仅在需要时计算边界矩形。

Tests:
- 为选区翻译核心中的语言家族匹配功能添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce redundant selection translation work to avoid hitches when text selection becomes active.

New Features:
- Add language family comparison to skip translation for selections already in the target language.

Bug Fixes:
- Prevent reprocessing the same selection snapshot and avoid duplicate translation requests for unchanged selections.
- Stop scheduling selection reads and popup updates while the user is actively dragging a selection.
- Ensure tooltip opening and theme/trigger changes hide UI when the selection text matches the target language.

Enhancements:
- Reuse previously measured selection anchor and avoid unnecessary layout reads when updating popup position.
- Simplify selection rectangle fallback handling by only computing bounding rects when needed.

Tests:
- Add unit tests for language family matching in selection translation core.

</details>