### PR TITLE
fix: translate controls inside structural containers

### DIFF
--- a/entrypoints/main/dom.ts
+++ b/entrypoints/main/dom.ts
@@ -190,6 +190,8 @@ function hasStructuralIgnoreAncestor(node: Element): boolean {
 export function isTranslationContentBlock(node: Element): boolean {
     if (!node || isDocumentSurface(node) || isExtensionElement(node)) return false;
     if (isStructuralIgnoreElement(node) || skipSet.has(node.tagName.toLowerCase())) return false;
+    // 结构容器中的普通文案仍然不属于正文候选；控件会在扫描器的独立分支中处理。
+    if (hasStructuralIgnoreAncestor(node)) return false;
     if (isHiddenElement(node) || isNoTranslateElement(node) || isControlElement(node)) return false;
     if (!isBlockLayout(node) || !hasReadableText(node)) return false;
     if (hasReadableBlockChild(node)) return false;
@@ -215,7 +217,7 @@ function walkTranslationBlocks(
         const tag = node.tagName.toLowerCase();
         // html/body 是全文扫描的容器，不能因为它们属于 skipSet 就提前截断正文子树。
         // 其他 skip 元素仍然连同后代一起跳过，避免把脚本、代码块等内部文字送去翻译。
-        if ((skipSet.has(tag) && !isDocumentSurface(node)) || isStructuralIgnoreElement(node)) return;
+        if (skipSet.has(tag) && !isDocumentSurface(node)) return;
 
         // 控件必须先进入统一 control 分支。站点兼容规则不能把 button/role=button
         // 提前截断，否则双语模式会错误地保留英文按钮，也无法复用按钮恢复逻辑。
@@ -224,17 +226,24 @@ function walkTranslationBlocks(
             return;
         }
 
+        // header/footer/nav/aside 仍然是正文扫描的结构边界，但不能阻止继续遍历，
+        // 因为按钮和 role=button 控件可能嵌套在这些容器中。普通文案由
+        // isTranslationContentBlock 的结构祖先判断继续过滤，避免把导航标题送去翻译。
+        const insideStructuralContainer = isStructuralIgnoreElement(node) || hasStructuralIgnoreAncestor(node);
+
         // 站点兼容规则负责正文容器和站点特有的噪声过滤；例如 X 的推文正文
         // 位于 article 内的 div[dir="auto"]，而用户名/操作图标可以整棵跳过。
-        const compatNode = getCompatNode(node);
-        if (compatNode === 'skip') return;
-        if (compatNode instanceof Element && compatNode === node && hasReadableText(node)) {
-            result.push(node);
-            return;
-        }
-        if (isTranslationContentBlock(node)) {
-            result.push(node);
-            return;
+        if (!insideStructuralContainer) {
+            const compatNode = getCompatNode(node);
+            if (compatNode === 'skip') return;
+            if (compatNode instanceof Element && compatNode === node && hasReadableText(node)) {
+                result.push(node);
+                return;
+            }
+            if (isTranslationContentBlock(node)) {
+                result.push(node);
+                return;
+            }
         }
 
         for (const child of Array.from(node.children)) visit(child);
@@ -310,19 +319,23 @@ function resolveTranslatableElement(start: Element): Element | false {
         }
 
         const tag = current.tagName.toLowerCase();
-        if (skipSet.has(tag) || isStructuralIgnoreElement(current) ||
-            hasStructuralIgnoreAncestor(current) || isHiddenElement(current)) {
+        if (skipSet.has(tag) || isStructuralIgnoreElement(current) || isHiddenElement(current)) {
             return false;
         }
         if (isNoTranslateElement(current) || (current as HTMLElement).isContentEditable) return false;
 
+        // 先识别控件，再判断结构祖先。这样悬浮到结构容器内按钮的文字子节点时，
+        // 仍可向上找到按钮并复用按钮的替换/恢复逻辑。
         if (isTranslationControl(current)) return current;
 
-        const compatNode = getCompatNode(current);
-        if (compatNode === 'skip') return false;
-        if (compatNode && hasReadableText(compatNode)) return compatNode;
+        const insideStructuralContainer = hasStructuralIgnoreAncestor(current);
+        if (!insideStructuralContainer) {
+            const compatNode = getCompatNode(current);
+            if (compatNode === 'skip') return false;
+            if (compatNode && hasReadableText(compatNode)) return compatNode;
 
-        if (isTranslationContentBlock(current)) return current;
+            if (isTranslationContentBlock(current)) return current;
+        }
         current = current.parentElement;
     }
 


### PR DESCRIPTION
## 问题

全文/悬浮翻译扫描遇到 `header`、`footer`、`nav`、`aside` 时会提前停止，导致这些结构容器内的 `button` 和 `role="button"` 控件无法进入统一控件翻译分支。

## 修复

- 结构容器继续遍历后代节点。
- 结构容器内只放行可见控件，普通结构文案仍保持过滤，避免导航噪声。
- 悬浮命中控件内部文字时可以向上归一到控件，复用直接替换/恢复逻辑。
- 双语模式下控件仍直接替换文字，不插入双语 wrapper。

## 验证

- `pnpm test`：135 tests passed
- `pnpm compile`
- `pnpm build --browser edge`
- 隔离、屏幕外 Microsoft Edge：`example.com` Control 翻译→恢复→再次翻译为 `[1,0,1]`，相邻段落始终为 `0`
- X 优先页面 `https://x.com/elonmusk/status/2088484972965298489`：侧栏 `Continue with Apple` 三态切换通过，按钮内双语 wrapper 为 `0`
- X 全文 `Alt+T`：5 条推文正文识别，延迟加载回复滚入视口后可补译，恢复和再次全文翻译通过

## Summary by Sourcery

调整翻译扫描方式，以在正确处理嵌套在结构性容器内的控件时，仍然过滤掉非控件的结构性文本。

Bug Fixes:
- 确保位于 `header`/`footer`/`nav`/`aside` 内的按钮和 `role=button` 控件被纳入统一的控件翻译处理逻辑，用于整页翻译和悬停翻译。
- 防止结构性容器中的普通文本被视为正文内容候选，从而避免导航和布局类噪音进入翻译结果。
- 允许对控件内部文本进行悬停翻译时，解析到其父控件元素，以复用现有的替换/还原行为，而不是被结构性边界阻断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust translation scanning to correctly handle controls nested inside structural containers while keeping non-control structural text filtered out.

Bug Fixes:
- Ensure buttons and role=button controls inside header/footer/nav/aside are included in unified control translation handling for full-page and hover translation.
- Prevent ordinary text inside structural containers from being treated as body content candidates, avoiding navigation and layout noise in translations.
- Allow hover translation over control inner text to resolve to the parent control element so existing replace/restore behavior is reused instead of being blocked by structural boundaries.

</details>