### PR TITLE
Add YouTube video subtitle translation beta

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -48,6 +48,33 @@
       </el-col>
     </el-row>
 
+    <!-- 文本与视频使用独立的翻译服务 -->
+    <el-row class="margin-bottom margin-left-2em settings-preference-row">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="网页、划词和悬停翻译使用的默认服务。视频字幕服务可以单独选择。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">文本翻译服务<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.service" aria-label="文本翻译服务" placeholder="请选择文本翻译服务">
+          <el-option class="select-left" v-for="item in options.services" :key="item.value" :label="item.label" :value="item.value" :disabled="item.disabled" />
+        </el-select>
+      </el-col>
+    </el-row>
+
+    <el-row class="margin-bottom margin-left-2em settings-preference-row">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="YouTube 原生字幕下方显示的译文使用此服务，与文本翻译服务互不影响。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">视频翻译服务<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.videoService" aria-label="视频翻译服务" placeholder="请选择视频翻译服务">
+          <el-option class="select-left" v-for="item in videoServiceOptions" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
     <!--    译文样式选择器-->
     <el-row v-show="config.display === 1" class="margin-bottom margin-left-2em settings-preference-row">
       <el-col :span="12" class="lightblue rounded-corner">
@@ -111,6 +138,32 @@
         </template>
       </ServiceCatalog>
 
+    </section>
+
+    <!-- 视频字幕 Beta -->
+    <section v-show="props.activeSection === 'settings-video'" id="settings-video" class="settings-section">
+      <div class="video-settings-hero">
+        <div><span class="eyebrow">Beta 功能</span><h2>YouTube 视频字幕</h2><p>边看边译 YouTube 原生字幕；不上传音频，不改变播放器时间轴。</p></div>
+        <el-switch v-model="config.videoTranslationEnabled" class="settings-switch" aria-label="视频字幕翻译" />
+      </div>
+
+      <el-row class="settings-control-row">
+        <el-col :span="12" class="settings-control-label lightblue rounded-corner">
+          <el-tooltip class="box-item" effect="dark" content="视频字幕独立使用机器翻译服务，默认 DeepLX；网页翻译仍使用上方的文本翻译服务。" placement="top-start" :show-after="500">
+            <span class="popup-text popup-vertical-left">视频翻译服务<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+          </el-tooltip>
+        </el-col>
+        <el-col :span="12" class="settings-control-field">
+          <el-select v-model="config.videoService" aria-label="视频字幕翻译服务" :disabled="!config.videoTranslationEnabled" placeholder="请选择服务">
+            <el-option class="select-left" v-for="item in videoServiceOptions" :key="item.value" :label="item.label" :value="item.value" />
+          </el-select>
+        </el-col>
+      </el-row>
+
+      <div class="video-settings-note">
+        <strong>使用方式</strong>
+        <p>打开 YouTube 视频的原生字幕后，FluentRead 会在字幕下方显示译文。字幕变化时自动更新；切换视频或关闭此功能会清理译文。</p>
+      </div>
     </section>
 
 
@@ -596,6 +649,9 @@ const aiContextModel = computed(() => resolveConfiguredModel(
   config.value.customModel[config.value.service],
 ));
 const canUseAIContext = computed(() => servicesType.isUseAIContext(config.value.service, aiContextModel.value));
+const videoServiceOptions = computed(() => options.services.filter((item: any) =>
+  !item.disabled && servicesType.machine.has(item.value),
+));
 const filteredServices = computed(() =>
   options.services.filter((item: any) =>
     !([item.google].includes(item.value) && config.value.display !== 1),
@@ -977,6 +1033,23 @@ const saveImport = async () => {
   border-radius: 18px;
   background: linear-gradient(135deg, #fff8fa, #fff);
 }
+
+.video-settings-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 0 12px 20px;
+  padding: 20px;
+  border: 1px solid #cceee9;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #f1fbf9, #fff);
+}
+.video-settings-hero h2 { margin: 5px 0 6px; color: #172033; font-size: 21px; }
+.video-settings-hero p { margin: 0; color: #737c8f; font-size: 11px; }
+.video-settings-note { margin: 18px 12px; padding: 16px 18px; border: 1px dashed #cfe7e5; border-radius: 14px; color: #6d788b; background: #f8fcfc; font-size: 11px; line-height: 1.6; }
+.video-settings-note strong { color: #087f80; }
+.video-settings-note p { margin: 6px 0 0; }
 
 .settings-status-copy {
   display: flex;

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -34,6 +34,11 @@
 
 <img src="/sample-git-3.gif" alt="智能缓存" style="width: 60%; max-width: 20%;border: 1px solid #eee;border-radius: 4px;box-shadow: 0 1px 2px rgba(0,0,0,0.05);" />
 
+### YouTube 视频字幕翻译（Beta）
+视频字幕翻译默认开启。在 YouTube 打开原生字幕后，FluentRead 会在播放器字幕下方显示译文，并随着字幕变化自动更新；它只处理 YouTube 已提供的字幕文本，不上传音频，也不改变播放器时间轴。
+
+视频翻译服务与网页文本翻译服务独立配置：可以在“通用设置”或弹窗的“视频字幕 Beta”卡片中单独选择机器翻译服务，例如网页使用微软翻译、视频使用 DeepLX。完整设置中的“视频字幕 Beta”页面可以关闭该功能；当前版本仅处理 YouTube 的 `/watch` 和 `/shorts` 页面。
+
 ## 操作方式
 
 <img src="/hotkey.png" alt="快捷键操作" style="width: 35%; max-width: 100%;border: 1px solid #eee;border-radius: 4px;box-shadow: 0 1px 2px rgba(0,0,0,0.05);" />

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -36,6 +36,8 @@ interface TranslationRequestMessageBase {
     context?: string;
     pageContext?: string;
     useCache?: boolean;
+    /** 视频字幕使用的独立机器翻译服务；普通网页请求不设置。 */
+    serviceOverride?: string;
 }
 
 type TranslationSingleRequestMessage = TranslationRequestMessageBase & { origin: string };
@@ -50,8 +52,8 @@ function getSelectedModel(service: string): string {
     return resolveConfiguredModel(config.model[service], config.customModel[service]);
 }
 
-function isAIContextEnabled(): boolean {
-    return config.enableAIContext && servicesType.isUseAIContext(config.service, getSelectedModel(config.service));
+function isAIContextEnabled(service = config.service): boolean {
+    return config.enableAIContext && servicesType.isUseAIContext(service, getSelectedModel(service));
 }
 
 function getProviderEndpoint(service: string): string {
@@ -67,8 +69,9 @@ function buildCacheKey(
     context: string,
     pageContext: string,
     mode: CacheRequestMode,
+    serviceOverride?: string,
 ): string {
-    const service = config.service;
+    const service = serviceOverride || config.service;
 
     return buildTranslationCacheKey({
         requestMode: mode,
@@ -90,7 +93,7 @@ function buildCacheKey(
         // DeepL sends the title context to the provider. AI adapters send the
         // bounded webpage context through their prompt templates.
         context: service === 'deepL' ? context : undefined,
-        pageContext: isAIContextEnabled() && service === config.service ? pageContext : undefined,
+        pageContext: isAIContextEnabled(service) ? pageContext : undefined,
     });
 }
 
@@ -102,10 +105,10 @@ function isCacheableResult(origin: string, result: unknown): result is string {
     return typeof result === 'string' && result.length > 0 && result !== origin;
 }
 
-function getTranslationService() {
-    const service = _service[config.service];
+function getTranslationService(serviceName = config.service) {
+    const service = _service[serviceName];
     if (!service) {
-        throw new Error(`未找到翻译服务适配器: ${config.service}`);
+        throw new Error(`未找到翻译服务适配器: ${serviceName}`);
     }
     return service;
 }
@@ -210,11 +213,12 @@ async function translateSingleWithCache(
     pageContext: string,
     useCache: boolean,
 ): Promise<string> {
+    const service = message.serviceOverride || config.service;
     if (!useCache) {
-        return getTranslationService()({...message, context, pageContext});
+        return getTranslationService(service)({...message, context, pageContext});
     }
 
-    const key = buildCacheKey(message.origin, context, pageContext, 'single');
+    const key = buildCacheKey(message.origin, context, pageContext, 'single', service);
     const existing = pendingTranslations.get(key);
     if (existing) return existing;
 
@@ -222,7 +226,7 @@ async function translateSingleWithCache(
         const cached = await translationCache.get(key);
         if (cached !== null) return cached;
 
-        const result = await getTranslationService()({...message, context, pageContext});
+        const result = await getTranslationService(service)({...message, context, pageContext});
         if (isCacheableResult(message.origin, result)) {
             await translationCache.set(key, result);
         }
@@ -247,19 +251,20 @@ async function translateBatchWithCache(
     pageContext: string,
     useCache: boolean,
 ): Promise<string[]> {
+    const service = message.serviceOverride || config.service;
     if (!useCache) {
-        const result = await getTranslationService()({...message, context, pageContext});
+        const result = await getTranslationService(service)({...message, context, pageContext});
         if (!Array.isArray(result)) throw new Error('批量翻译返回格式异常');
         return result as string[];
     }
 
-    const batchKey = buildCacheKey(message.origin, context, pageContext, 'batch');
+    const batchKey = buildCacheKey(message.origin, context, pageContext, 'batch', service);
     const existing = pendingBatches.get(batchKey);
     if (existing) return existing;
 
     const request = (async () => {
         const cached = await Promise.all(
-            message.origin.map((origin) => translationCache.get(buildCacheKey(origin, context, pageContext, 'batch'))),
+            message.origin.map((origin) => translationCache.get(buildCacheKey(origin, context, pageContext, 'batch', service))),
         );
         const missingIndexes = cached
             .map((value, index) => value === null ? index : -1)
@@ -276,12 +281,12 @@ async function translateBatchWithCache(
         const uniqueMissingOrigins = Array.from(
             new Map(
                 missingEntries.map(({origin}) => [
-                    buildCacheKey(origin, context, pageContext, 'batch'),
+                    buildCacheKey(origin, context, pageContext, 'batch', service),
                     origin,
                 ]),
             ).values(),
         );
-        const translated = await getTranslationService()({
+        const translated = await getTranslationService(service)({
             ...message,
             context,
             pageContext,
@@ -294,15 +299,15 @@ async function translateBatchWithCache(
         const result = [...cached] as Array<string | null>;
         const translatedByKey = new Map(
             uniqueMissingOrigins.map((origin, index) => [
-                buildCacheKey(origin, context, pageContext, 'batch'),
+                buildCacheKey(origin, context, pageContext, 'batch', service),
                 translated[index],
             ]),
         );
         await Promise.all(missingEntries.map(async ({index, origin}) => {
-            const value = translatedByKey.get(buildCacheKey(origin, context, pageContext, 'batch'));
+            const value = translatedByKey.get(buildCacheKey(origin, context, pageContext, 'batch', service));
             result[index] = value as string;
             if (isCacheableResult(origin, value)) {
-                await translationCache.set(buildCacheKey(origin, context, pageContext, 'batch'), value);
+                await translationCache.set(buildCacheKey(origin, context, pageContext, 'batch', service), value);
             }
         }));
 
@@ -323,6 +328,10 @@ async function translateBatchWithCache(
 
 async function translateWithCache(message: TranslationRequestMessage): Promise<string | string[]> {
     await configReady;
+    const serviceOverride = message.serviceOverride;
+    if (serviceOverride && !servicesType.machine.has(serviceOverride)) {
+        throw new Error('视频字幕仅支持机器翻译服务，请在设置中选择微软、DeepLX、DeepL 或其他机器翻译服务');
+    }
     const context = typeof message.context === 'string' ? message.context : '';
     const rawPageContext = typeof message.pageContext === 'string' ? message.pageContext : '';
     const pageContext = await addPageSummary(rawPageContext);

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -9,9 +9,11 @@ import { cancelAllTranslations, translateText } from "@/entrypoints/utils/transl
 import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import { createShadowRootUi, type ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
+import { mountVideoSubtitleTranslation } from './main/videoSubtitle';
 
 let contentScriptContext: ContentScriptContext | null = null;
 let inputTooltipUi: ShadowRootContentScriptUi<HTMLElement> | null = null;
+let unmountVideoSubtitleTranslation: (() => void) | null = null;
 
 function installPageStyles(ctx: ContentScriptContext) {
     const existing = document.getElementById('fluent-read-page-styles');
@@ -33,6 +35,8 @@ export default defineContentScript({
         installPageStyles(ctx);
         await configReady // 等待配置加载完成
         if (config.on === false) return; // 如果配置关闭，则不执行任何操作
+        // 视频字幕 Beta 只在 YouTube 播放页监听原生字幕，不采集音频或视频内容。
+        unmountVideoSubtitleTranslation = mountVideoSubtitleTranslation();
         // 添加手动翻译事件监听器
         setupManualTranslationTriggers();
         // 添加悬浮球快捷键事件监听器
@@ -150,6 +154,8 @@ export default defineContentScript({
             unmountFloatingBall();
             // 移除划词翻译组件
             unmountSelectionTranslator();
+            unmountVideoSubtitleTranslation?.();
+            unmountVideoSubtitleTranslation = null;
             removeExistingTooltip();
         });
     }

--- a/entrypoints/main/dom.ts
+++ b/entrypoints/main/dom.ts
@@ -144,6 +144,7 @@ function isHiddenElement(node: Element): boolean {
 function isNoTranslateElement(node: Element): boolean {
     return Boolean(
         node.classList.contains('notranslate') ||
+        node.matches('#ytp-caption-window-container, .ytp-caption-window-container, .fluent-read-video-subtitle') ||
         node.getAttribute('translate') === 'no' ||
         node.getAttribute('data-notranslate') === 'true',
     );

--- a/entrypoints/main/videoSubtitle.ts
+++ b/entrypoints/main/videoSubtitle.ts
@@ -1,0 +1,176 @@
+import { config, subscribeConfig } from '@/entrypoints/utils/config';
+import { translateVideoText } from '@/entrypoints/utils/translateApi';
+
+export const VIDEO_CAPTION_CONTAINER_SELECTOR = '#ytp-caption-window-container, .ytp-caption-window-container';
+export const VIDEO_CAPTION_SEGMENT_SELECTOR = '.ytp-caption-segment, .captions-text';
+export const VIDEO_TRANSLATION_OVERLAY_ID = 'fluent-read-video-subtitle';
+
+const YOUTUBE_HOST_PATTERN = /(^|\.)youtube\.com$/i;
+const YOUTUBE_MOBILE_HOST_PATTERN = /(^|\.)youtube-nocookie\.com$/i;
+
+export function isYouTubeVideoPage(locationLike: Pick<Location, 'hostname' | 'pathname'> = window.location): boolean {
+  const isYouTubeHost = YOUTUBE_HOST_PATTERN.test(locationLike.hostname) || YOUTUBE_MOBILE_HOST_PATTERN.test(locationLike.hostname);
+  return isYouTubeHost && (locationLike.pathname === '/watch' || locationLike.pathname === '/shorts');
+}
+
+/** 读取当前播放器可见的原生字幕，不读取插件自己的译文节点。 */
+export function readVisibleCaptionText(container: Element | null): string {
+  if (!container) return '';
+
+  const segments = Array.from(container.querySelectorAll(VIDEO_CAPTION_SEGMENT_SELECTOR))
+    .map((segment) => segment.textContent?.replace(/[\s\u3000]+/g, ' ').trim() || '')
+    .filter(Boolean);
+
+  return segments.join(' ').replace(/[\s\u3000]+/g, ' ').trim();
+}
+
+function findCaptionContainer(): HTMLElement | null {
+  return document.querySelector(VIDEO_CAPTION_CONTAINER_SELECTOR);
+}
+
+function getOrCreateTranslationOverlay(container: HTMLElement): HTMLElement {
+  const existing = container.querySelector<HTMLElement>(`#${VIDEO_TRANSLATION_OVERLAY_ID}`);
+  if (existing) return existing;
+
+  const overlay = document.createElement('div');
+  overlay.id = VIDEO_TRANSLATION_OVERLAY_ID;
+  overlay.className = 'fluent-read-video-subtitle notranslate';
+  overlay.setAttribute('data-fluent-read-ui', 'video-subtitle');
+  overlay.setAttribute('aria-live', 'polite');
+  overlay.setAttribute('aria-label', 'FluentRead 视频字幕译文');
+  container.appendChild(overlay);
+  return overlay;
+}
+
+function removeTranslationOverlay(): void {
+  document.querySelectorAll(`#${VIDEO_TRANSLATION_OVERLAY_ID}`).forEach((node) => node.remove());
+}
+
+function installVideoSubtitleStyle(): HTMLStyleElement {
+  const existing = document.getElementById('fluent-read-video-subtitle-style');
+  if (existing instanceof HTMLStyleElement) return existing;
+
+  const style = document.createElement('style');
+  style.id = 'fluent-read-video-subtitle-style';
+  style.textContent = `
+    #${VIDEO_TRANSLATION_OVERLAY_ID} {
+      display: block !important;
+      position: relative !important;
+      z-index: 2 !important;
+      box-sizing: border-box !important;
+      max-width: min(92vw, 960px) !important;
+      margin: 0.24em auto 0 !important;
+      padding: 0.08em 0.24em !important;
+      color: #ffe45c !important;
+      font: 600 0.82em/1.35 Arial, sans-serif !important;
+      text-align: center !important;
+      text-shadow: 2px 2px 0 #000, -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 0 2px 4px rgba(0, 0, 0, .75) !important;
+      white-space: pre-wrap !important;
+      pointer-events: none !important;
+      user-select: none !important;
+    }
+    #${VIDEO_TRANSLATION_OVERLAY_ID}:empty { display: none !important; }
+  `;
+  (document.head || document.documentElement).appendChild(style);
+  return style;
+}
+
+/**
+ * 挂载 YouTube 原生字幕监听器。返回清理函数，供页面卸载和 Beta 开关使用。
+ * 字幕变化使用 generation 防止慢请求覆盖后续字幕，且只保留一个译文节点。
+ */
+export function mountVideoSubtitleTranslation(): () => void {
+  if (!isYouTubeVideoPage()) return () => undefined;
+
+  const style = installVideoSubtitleStyle();
+  let destroyed = false;
+  let generation = 0;
+  let lastSource = '';
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let captionObserver: MutationObserver | undefined;
+  let pageObserver: MutationObserver | undefined;
+  let observedContainer: HTMLElement | null = null;
+
+  const clearRenderedTranslation = () => {
+    const overlay = document.getElementById(VIDEO_TRANSLATION_OVERLAY_ID);
+    if (overlay) overlay.textContent = '';
+  };
+
+  const updateCaption = () => {
+    if (destroyed || !config.on || !config.videoTranslationEnabled) return;
+
+    const container = findCaptionContainer();
+    if (!container) {
+      observedContainer = null;
+      clearRenderedTranslation();
+      return;
+    }
+
+    container.classList.add('notranslate');
+    const source = readVisibleCaptionText(container);
+    const overlay = getOrCreateTranslationOverlay(container);
+
+    if (source === lastSource) return;
+    lastSource = source;
+    const currentGeneration = ++generation;
+    overlay.textContent = '';
+    if (!source) return;
+
+    void translateVideoText(source).then((translated) => {
+      if (destroyed || currentGeneration !== generation || source !== lastSource) return;
+      const result = typeof translated === 'string' ? translated.trim() : '';
+      if (result && result !== source) overlay.textContent = result;
+    }).catch((error) => {
+      if (!destroyed && currentGeneration === generation) {
+        console.warn('[FluentRead] 视频字幕翻译失败', error);
+      }
+    });
+  };
+
+  const scheduleUpdate = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(updateCaption, 80);
+  };
+
+  const observeCaptionContainer = () => {
+    const container = findCaptionContainer();
+    if (!container || container === observedContainer) return;
+
+    captionObserver?.disconnect();
+    observedContainer = container;
+    container.classList.add('notranslate');
+    captionObserver = new MutationObserver(scheduleUpdate);
+    captionObserver.observe(container, { childList: true, subtree: true, characterData: true });
+    scheduleUpdate();
+  };
+
+  pageObserver = new MutationObserver(() => {
+    observeCaptionContainer();
+    scheduleUpdate();
+  });
+  pageObserver.observe(document.documentElement, { childList: true, subtree: true });
+  observeCaptionContainer();
+
+  const unsubscribeConfig = subscribeConfig((nextConfig) => {
+    if (!nextConfig.on || !nextConfig.videoTranslationEnabled) {
+      generation += 1;
+      lastSource = '';
+      clearRenderedTranslation();
+      return;
+    }
+    observeCaptionContainer();
+    scheduleUpdate();
+  });
+
+  return () => {
+    destroyed = true;
+    generation += 1;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    captionObserver?.disconnect();
+    pageObserver?.disconnect();
+    unsubscribeConfig();
+    removeTranslationOverlay();
+    document.querySelectorAll(VIDEO_CAPTION_CONTAINER_SELECTOR).forEach((node) => node.classList.remove('notranslate'));
+    style.remove();
+  };
+}

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -44,6 +44,12 @@ export const navigationGroups: NavigationGroup[] = [
         kicker: '操作方式', title: '交互与快捷键', detail: '为高频动作选择容易记忆且不冲突的触发方式。',
         searchDescription: '鼠标悬停、划词翻译、全文翻译与自定义按键',
       },
+      {
+        id: 'settings-video', icon: 'CC', label: '视频字幕 Beta', description: 'YouTube 边看边译', group: '阅读工具',
+        heading: '边看边译视频字幕', summary: '在 YouTube 原生字幕下方显示译文，并独立选择视频翻译服务。',
+        kicker: '视频翻译 Beta', title: 'YouTube 视频字幕', detail: '只处理播放器已经提供的字幕文本，不上传音频或视频内容。',
+        searchDescription: 'YouTube、视频字幕、视频翻译服务、DeepLX、微软翻译',
+      },
     ],
   },
   {

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -142,6 +142,11 @@
           <span><strong>译文显示</strong><small>{{ displaySummary }}</small></span>
           <b>›</b>
         </button>
+        <button class="feature-card video-feature-card" data-feature="video-subtitle" type="button" :disabled="!config.on" @click="openDrawer('video')">
+          <span class="feature-icon teal">CC</span>
+          <span><strong>视频字幕 <em>Beta</em></strong><small>{{ videoSummary }}</small></span>
+          <i :class="{ active: config.videoTranslationEnabled }" />
+        </button>
       </div>
     </section>
 
@@ -239,6 +244,21 @@
         </button>
       </div>
 
+      <div v-else-if="activeDrawer === 'video'" class="drawer-content">
+        <div class="video-beta-banner"><span class="feature-icon teal">CC</span><span><strong>YouTube 字幕翻译</strong><small>Beta · 只处理播放器已经提供的字幕文本</small></span></div>
+        <div class="setting-row">
+          <span><strong>启用视频字幕翻译</strong><small>在 YouTube 原生字幕下方显示中文译文</small></span>
+          <button class="switch compact" type="button" role="switch" :aria-checked="config.videoTranslationEnabled" aria-label="启用或关闭视频字幕翻译" @click="setVideoTranslationEnabled(!config.videoTranslationEnabled)"><i /></button>
+        </div>
+        <label class="select-row">
+          <span><strong>视频翻译服务</strong><small>与网页翻译服务独立保存</small></span>
+          <select v-model="config.videoService" :disabled="!config.videoTranslationEnabled">
+            <option v-for="item in videoServiceOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+          </select>
+        </label>
+        <small class="drawer-hint">目前支持 YouTube；需要先打开 YouTube 的原生字幕。DeepLX 默认地址可在完整设置中配置。</small>
+      </div>
+
       <div v-else class="drawer-content">
         <div class="choice-block">
           <label>翻译模式</label>
@@ -275,11 +295,11 @@ import {
 } from '@/entrypoints/utils/config';
 import { Setting } from '@element-plus/icons-vue';
 import { Config } from '@/entrypoints/utils/model';
-import { options } from '@/entrypoints/utils/option';
+import { options, servicesType } from '@/entrypoints/utils/option';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
-type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance';
-type SettingsSection = 'settings-general' | 'settings-shortcuts';
+type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance' | 'video';
+type SettingsSection = 'settings-general' | 'settings-shortcuts' | 'settings-video';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 const version = process.env.VUE_APP_VERSION;
 const config = ref(new Config());
@@ -304,9 +324,11 @@ const drawerSettingsSection: Record<DrawerName, SettingsSection> = {
   selection: 'settings-shortcuts',
   floating: 'settings-shortcuts',
   appearance: 'settings-general',
+  video: 'settings-video',
 };
 
 const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
+const videoServiceOptions = computed(() => options.services.filter((item: any) => !item.disabled && servicesType.machine.has(item.value)));
 const popularServiceValues = ['freeTranslation', 'microsoft', 'google', 'deepL', 'deeplx', 'deepseek', 'openai', 'gemini', 'claude'];
 const popularServiceOptions = computed(() => popularServiceValues
   .map(value => serviceOptions.value.find((item: any) => item.value === value))
@@ -314,18 +336,21 @@ const popularServiceOptions = computed(() => popularServiceValues
 const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !popularServiceValues.includes(item.value)));
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
+const videoServiceLabel = computed(() => videoServiceOptions.value.find((item: any) => item.value === config.value.videoService)?.label || config.value.videoService);
 const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');
 const hoverKey = computed(() => config.value.hotkey === 'custom' ? (config.value.customHotkey || '自定义') : config.value.hotkey);
 const hoverSummary = computed(() => config.value.hotkey === 'none' ? '已关闭' : `${hoverKey.value} + 悬停`);
 const selectionSummary = computed(() => ({ disabled: '已关闭', bilingual: '双语显示', 'translation-only': '仅显示译文' }[config.value.selectionTranslatorMode] || '双语显示'));
 const floatingSummary = computed(() => `${config.value.floatingBallPosition === 'left' ? '页面左侧' : '页面右侧'} · ${config.value.floatingBallHotkey}`);
 const displaySummary = computed(() => config.value.display === 1 ? `双语 · ${styleLabel.value}` : '仅显示译文');
-const drawerTitle = computed(() => ({ hover: '悬停翻译设置', selection: '划词翻译设置', floating: '全文悬浮球设置', appearance: '译文显示设置' }[activeDrawer.value]));
+const videoSummary = computed(() => config.value.videoTranslationEnabled ? `${videoServiceLabel.value} · YouTube` : '已关闭');
+const drawerTitle = computed(() => ({ hover: '悬停翻译设置', selection: '划词翻译设置', floating: '全文悬浮球设置', appearance: '译文显示设置', video: '视频字幕设置' }[activeDrawer.value]));
 const drawerDescription = computed(() => ({
   hover: '把鼠标停在文本上，用轻量快捷键获取即时译文。',
   selection: '选中文字后，按你的偏好显示原文与译文。',
   floating: '把全文翻译入口固定在最顺手的位置。',
   appearance: '调整双语布局、译文样式与界面主题。',
+  video: '在 YouTube 播放器中显示实时字幕译文。',
 }[activeDrawer.value]));
 const hoverChoices = [
   { value: 'Control', label: 'Ctrl' },
@@ -481,6 +506,9 @@ function setSelectionTrigger(trigger: string) {
 function setFloatingEnabled(enabled: boolean) {
   config.value.disableFloatingBall = !enabled;
   void broadcast({ type: 'toggleFloatingBall', isEnabled: enabled });
+}
+function setVideoTranslationEnabled(enabled: boolean) {
+  config.value.videoTranslationEnabled = enabled;
 }
 function handleFloatingHotkeyChange() {
   if (config.value.floatingBallHotkey === 'custom' && !config.value.customFloatingBallHotkey) showCustomHotkeyDialog.value = true;

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -166,25 +166,31 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 footer button {
   padding: 0; border: 0; color: var(--brand-strong); background: none; font-size: 10px; font-weight: 700; cursor: pointer;
 }
-.feature-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
+.feature-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
 .feature-card {
-  display: grid; grid-template-columns: 36px 1fr auto; align-items: center; gap: 9px; min-height: 64px; padding: 9px 11px;
+  display: grid; grid-template-columns: 32px 1fr auto; align-items: center; gap: 8px; min-height: 57px; padding: 7px 10px;
   border: 1px solid var(--line); border-radius: 16px; background: var(--surface); text-align: left; cursor: pointer;
   transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 .feature-card:hover:not(:disabled) { border-color: rgba(239, 71, 118, .32); transform: translateY(-1px); box-shadow: 0 8px 20px rgba(25, 32, 50, .07); }
-.feature-icon { display: grid; place-items: center; width: 36px; height: 36px; border-radius: 11px; font-size: 13px; font-weight: 750; }
+.feature-icon { display: grid; place-items: center; width: 32px; height: 32px; border-radius: 10px; font-size: 12px; font-weight: 750; }
 .feature-icon.rose { color: #e73a6c; background: #fff0f4; font-size: 22px; }
 .feature-icon.violet { color: #6f55d9; background: #f1edff; font-family: Georgia, serif; font-size: 19px; }
 .feature-icon.blue { color: #2678c9; background: #eaf4ff; font-size: 18px; }
 .feature-icon.amber { color: #a75f16; background: #fff4df; }
+.feature-icon.teal { color: #087f80; background: #e3f8f5; font-size: 12px; letter-spacing: -.04em; }
 :root.dark .feature-icon.rose { background: rgba(231, 58, 108, .14); }
 :root.dark .feature-icon.violet { background: rgba(111, 85, 217, .17); }
 :root.dark .feature-icon.blue { background: rgba(38, 120, 201, .17); }
 :root.dark .feature-icon.amber { background: rgba(177, 104, 29, .17); }
+:root.dark .feature-icon.teal { background: rgba(8, 127, 128, .17); }
 .feature-card > span:nth-child(2) { display: flex; flex-direction: column; min-width: 0; }
 .feature-card strong { font-size: 11.5px; line-height: 1.4; }
 .feature-card small { margin-top: 2px; overflow: hidden; color: var(--muted); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.feature-card em { display: inline-block; margin-left: 3px; padding: 1px 4px; border: 1px solid #f5a4bd; border-radius: 999px; color: #d83263; font-size: 8px; font-style: normal; font-weight: 800; vertical-align: 1px; }
+.video-beta-banner { display: flex; align-items: center; gap: 10px; padding: 12px; border: 1px solid #cceee9; border-radius: 14px; background: #f1fbf9; }
+.video-beta-banner > span:last-child { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
+.video-beta-banner small { color: var(--muted); font-size: 9px; }
 .feature-card > i { width: 6px; height: 6px; }
 .feature-card > b { color: var(--muted); font-size: 18px; font-weight: 400; }
 .feature-card:disabled, .translate-button:disabled, select:disabled { cursor: not-allowed; opacity: .48; }

--- a/entrypoints/service/deepl.ts
+++ b/entrypoints/service/deepl.ts
@@ -3,17 +3,18 @@ import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
 
 async function deepl(message: any) {
+    const service = message.serviceOverride || config.service;
     // deepl 不支持 zh-Hans，需要转换为 zh
     let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
 
     // 判断是否使用代理
-    let url: string = config.proxy[config.service] ? config.proxy[config.service] : urls[services.deepL]
+    let url: string = config.proxy[service] ? config.proxy[service] : urls[services.deepL]
 
     const resp = await fetch(url, {
         method: method.POST,
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': 'DeepL-Auth-Key ' + config.token[services.deepL]
+            'Authorization': 'DeepL-Auth-Key ' + config.token[service]
         },
         body: JSON.stringify({
             text: [message.origin],
@@ -34,4 +35,3 @@ async function deepl(message: any) {
 }
 
 export default deepl;
-

--- a/entrypoints/service/tencent.ts
+++ b/entrypoints/service/tencent.ts
@@ -123,7 +123,8 @@ async function tencent(message: any) {
         const authorization = await createTencentSignature(requestBody, timestamp, secretId, secretKey);
         
         // 判断是否使用代理
-        const url = config.proxy[config.service] || 'https://tmt.tencentcloudapi.com/';
+        const service = message.serviceOverride || config.service;
+        const url = config.proxy[service] || 'https://tmt.tencentcloudapi.com/';
         
         const response = await fetch(url, {
             method: method.POST,

--- a/entrypoints/service/xiaoniu.ts
+++ b/entrypoints/service/xiaoniu.ts
@@ -3,16 +3,17 @@ import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
 
 async function xiaoniu(message: any) {
+    const service = message.serviceOverride || config.service;
     // 根据需要调整目标语言
     let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
 
     // 判断是否使用代理
-    let url: string = config.proxy[config.service] ? config.proxy[config.service] : urls[services.xiaoniu]
+    let url: string = config.proxy[service] ? config.proxy[service] : urls[services.xiaoniu]
 
     const resp = await fetch(url, {
         method: method.POST,
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: `from=auto&to=${targetLang}&apikey=${config.token[services.xiaoniu]}&src_text=${encodeURIComponent(message.origin)}`
+        body: `from=auto&to=${targetLang}&apikey=${config.token[service]}&src_text=${encodeURIComponent(message.origin)}`
     });
 
     if (resp.ok) {

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -1,4 +1,4 @@
-import { currentModelIds, defaultOption, services } from "./option";
+import { currentModelIds, defaultOption, services, servicesType } from "./option";
 import { normalizeCustomBodyMapping } from "./custom-body";
 
 export type DeepSeekApiType = 'auto' | 'responses' | 'chat';
@@ -22,6 +22,8 @@ export class Config {
     style: number;
     display: number = 1;
     service: string;
+    videoTranslationEnabled: boolean; // 是否启用视频字幕翻译 Beta
+    videoService: string; // 视频字幕独立翻译服务
     token: IMapping;
     ak: string;
     sk: string;
@@ -71,6 +73,8 @@ export class Config {
         this.display = defaultOption.display;
         this.hotkey = defaultOption.hotkey;
         this.service = defaultOption.service;
+        this.videoTranslationEnabled = true; // Beta 功能默认开启
+        this.videoService = services.deeplx; // 视频字幕默认使用 DeepLX
         this.token = {};
         this.ak = '';
         this.sk = '';
@@ -190,6 +194,13 @@ export function normalizeConfig(value: unknown): Config {
     normalized.model = isRecord(source.model) ? {...source.model} : {};
     normalized.customModel = isRecord(source.customModel) ? {...source.customModel} : {};
     normalized.customBody = normalizeCustomBodyMapping(source.customBody);
+
+    if (typeof normalized.videoTranslationEnabled !== 'boolean') {
+        normalized.videoTranslationEnabled = true;
+    }
+    if (!servicesType.machine.has(normalized.videoService)) {
+        normalized.videoService = services.deeplx;
+    }
 
     migrateModelIdentifiers(normalized.model);
 

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -138,6 +138,30 @@ export async function translateTextBatch(
 }
 
 /**
+ * 翻译视频字幕。视频字幕使用独立的服务配置，但仍通过 background
+ * 统一请求、缓存和错误边界；只发送 YouTube 已提供的纯文本字幕内容。
+ */
+export async function translateVideoText(origin: string): Promise<string> {
+  const cleanedOrigin = origin?.replace(/[\s\u3000]/g, '') || '';
+  if (!cleanedOrigin) return origin || '';
+
+  config.count++;
+  void saveConfig().catch((error) => console.error('[FluentRead] 保存视频翻译计数失败:', error));
+
+  return enqueueTranslation(async () => {
+    return Promise.race([
+      browser.runtime.sendMessage({
+        context: `YouTube 视频字幕：${document.title}`,
+        origin,
+        useCache: config.useCache,
+        serviceOverride: config.videoService,
+      }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('视频字幕翻译请求超时')), 20000)),
+    ]) as Promise<string>;
+  });
+}
+
+/**
  * 当用户离开页面或主动取消翻译时，清空翻译队列
  */
 export function cancelAllTranslations() {

--- a/scripts/run-video-subtitle-test.cjs
+++ b/scripts/run-video-subtitle-test.cjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createRequire } = require('node:module');
+
+function loadPlaywright(root) {
+  try { return require('playwright'); } catch {
+    const runtimeRequire = createRequire(path.join(path.resolve(root), '__fluentread_video_test__.cjs'));
+    return runtimeRequire('playwright');
+  }
+}
+
+function arg(name, fallback) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+async function main() {
+  const extensionDir = path.resolve(arg('extension-dir', '.output/chrome-mv3-dev'));
+  const playwrightRoot = arg('playwright-root', process.env.PLAYWRIGHT_ROOT);
+  const url = arg('url', 'https://www.youtube.com/watch?v=drSMZgnmJjk');
+  const artifactsDir = path.resolve(arg('artifacts-dir', path.join(os.tmpdir(), 'fluentread-video-subtitle-evidence')));
+  const browserPath = arg('browser-path', '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fluentread-edge-video-profile-'));
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  if (!fs.existsSync(path.join(extensionDir, 'manifest.json'))) throw new Error(`找不到扩展构建：${extensionDir}`);
+
+  const { chromium } = loadPlaywright(playwrightRoot);
+  const context = await chromium.launchPersistentContext(profileDir, {
+    executablePath: browserPath,
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionDir}`,
+      `--load-extension=${extensionDir}`,
+      '--start-minimized', '--window-position=-10000,-10000',
+      '--no-first-run', '--no-default-browser-check',
+    ],
+    viewport: { width: 1280, height: 900 },
+  });
+
+  try {
+    const workers = context.serviceWorkers();
+    const worker = workers[0] || await context.waitForEvent('serviceworker', { timeout: 30000 });
+    const extensionId = worker.url().match(/^chrome-extension:\/\/([^/]+)/)?.[1];
+    if (!extensionId) throw new Error('无法取得扩展 ID');
+
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`, { waitUntil: 'domcontentloaded' });
+    await popup.waitForSelector('[data-feature="video-subtitle"]', { timeout: 15000 });
+    await worker.evaluate(async () => {
+      const stored = await chrome.storage.local.get('config');
+      const config = stored.config || {};
+      await chrome.storage.local.set({ config: {
+        ...config,
+        on: true,
+        display: 1,
+        from: 'auto',
+        to: 'zh-Hans',
+        service: 'deeplx',
+        videoTranslationEnabled: true,
+        videoService: 'microsoft',
+        useCache: false,
+      }});
+    });
+    const popupState = await popup.evaluate(async () => {
+      const stored = await chrome.storage.local.get('config');
+      return {
+        featurePresent: Boolean(document.querySelector('[data-feature="video-subtitle"]')),
+        featureCount: document.querySelectorAll('.feature-card').length,
+        config: stored.config,
+      };
+    });
+    await popup.locator('[data-feature="video-subtitle"]').click();
+    await popup.getByText('YouTube 字幕翻译').waitFor({ state: 'visible', timeout: 10000 });
+    const videoDrawerState = await popup.evaluate(() => ({
+      drawerVisible: Boolean([...document.querySelectorAll('.drawer-content')].find((node) => node.textContent?.includes('视频翻译服务'))),
+      providerCount: document.querySelectorAll('.drawer-content select option').length,
+    }));
+    await popup.screenshot({ path: path.join(artifactsDir, 'popup-video-beta-drawer.png'), fullPage: true });
+    await popup.screenshot({ path: path.join(artifactsDir, 'popup-video-beta.png'), fullPage: true });
+    await popup.close();
+
+    const options = await context.newPage();
+    await options.goto(`chrome-extension://${extensionId}/options.html#settings-video`, { waitUntil: 'domcontentloaded' });
+    await options.getByRole('heading', { name: '边看边译视频字幕' }).waitFor({ timeout: 15000 });
+    const optionsState = await options.evaluate(() => ({
+      activeNav: document.querySelector('.sidebar button.active')?.textContent?.replace(/\s+/g, ' ').trim(),
+      videoSection: Boolean(document.querySelector('#settings-video')),
+      providerControl: Boolean(document.querySelector('[aria-label="视频字幕翻译服务"]')),
+    }));
+    await options.screenshot({ path: path.join(artifactsDir, 'options-video-subtitle.png'), fullPage: true });
+    await options.close();
+
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(6000);
+
+    const subtitleButton = page.locator('button.ytp-subtitles-button').first();
+    if (await subtitleButton.count()) {
+      if (await subtitleButton.getAttribute('aria-pressed') !== 'true') await subtitleButton.click();
+      await page.waitForTimeout(2500);
+    }
+
+    const playButton = page.locator('button.ytp-play-button').first();
+    if (await playButton.count() && (await playButton.getAttribute('aria-label') || '').toLowerCase().includes('play')) {
+      await playButton.click().catch(() => undefined);
+      await page.waitForTimeout(5000);
+    }
+    const nativeSubtitle = await page.locator('.ytp-caption-segment').first().count();
+    const injected = await page.evaluate(() => {
+      let container = document.querySelector('#ytp-caption-window-container');
+      if (!container) {
+        container = document.createElement('div');
+        container.id = 'ytp-caption-window-container';
+        document.body.appendChild(container);
+      }
+      container.replaceChildren();
+      const segment = document.createElement('span');
+      segment.className = 'ytp-caption-segment';
+      segment.textContent = 'This is a FluentRead video subtitle test.';
+      container.appendChild(segment);
+      return Boolean(container);
+    });
+    await page.waitForFunction(() => {
+      const overlay = document.querySelector('#fluent-read-video-subtitle');
+      return Boolean(overlay?.textContent?.match(/[\u3400-\u9fff]/));
+    }, { timeout: 45000 });
+    const first = await page.locator('#fluent-read-video-subtitle').textContent();
+
+    await page.evaluate(() => {
+      const segment = document.querySelector('#ytp-caption-window-container .ytp-caption-segment');
+      if (segment) segment.textContent = 'The second subtitle updates correctly.';
+    });
+    await page.waitForFunction((oldText) => {
+      const overlay = document.querySelector('#fluent-read-video-subtitle');
+      return Boolean(overlay?.textContent?.trim() && overlay.textContent !== oldText);
+    }, first, { timeout: 45000 });
+    const second = await page.locator('#fluent-read-video-subtitle').textContent();
+    const overlayCount = await page.locator('#fluent-read-video-subtitle').count();
+
+    await worker.evaluate(async () => {
+      const stored = await chrome.storage.local.get('config');
+      await chrome.storage.local.set({ config: { ...stored.config, videoTranslationEnabled: false }});
+    });
+    await page.waitForFunction(() => !document.querySelector('#fluent-read-video-subtitle')?.textContent?.trim(), null, { timeout: 10000 });
+    await page.screenshot({ path: path.join(artifactsDir, 'youtube-video-subtitle-final.png'), fullPage: false });
+
+    console.log(JSON.stringify({
+      ok: true,
+      url: page.url(),
+      popupState: {
+        featurePresent: popupState.featurePresent,
+        featureCount: popupState.featureCount,
+        textService: popupState.config.service,
+        videoService: popupState.config.videoService,
+        videoTranslationEnabled: popupState.config.videoTranslationEnabled,
+      },
+      videoDrawerState,
+      optionsState,
+      nativeSubtitle,
+      injected,
+      firstTranslation: first,
+      secondTranslation: second,
+      overlayCount,
+      disabledClearedOverlay: true,
+      artifactsDir,
+    }, null, 2));
+  } finally {
+    await context.close();
+    fs.rmSync(profileDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error);
+  process.exitCode = 1;
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -52,6 +52,23 @@ describe('统一配置存储', () => {
         expect(configStore.config).toMatchObject(storedConfig);
     });
 
+    it('为旧配置补齐默认开启的视频字幕 Beta 与独立 DeepLX 服务', async () => {
+        const configStore = await loadConfigModule(storedConfig);
+
+        await configStore.configReady;
+
+        expect(configStore.config.videoTranslationEnabled).toBe(true);
+        expect(configStore.config.videoService).toBe('deeplx');
+    });
+
+    it('非法的视频服务回退到机器翻译默认服务', async () => {
+        const configStore = await loadConfigModule({ ...storedConfig, videoService: 'openai' });
+
+        await configStore.configReady;
+
+        expect(configStore.config.videoService).toBe('deeplx');
+    });
+
     it('存储内容损坏时回退到默认配置，并保持初始化 Promise 可用', async () => {
         const configStore = await loadConfigModule('{not-json');
 

--- a/tests/videoSubtitle.test.ts
+++ b/tests/videoSubtitle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@wxt-dev/storage', () => ({
+    storage: {
+        getItem: vi.fn().mockResolvedValue(null),
+        setItem: vi.fn().mockResolvedValue(undefined),
+        watch: vi.fn().mockReturnValue(() => undefined),
+    },
+}));
+vi.mock('webextension-polyfill', () => ({
+    default: { runtime: { sendMessage: vi.fn() } },
+}));
+import {
+    isYouTubeVideoPage,
+    readVisibleCaptionText,
+    VIDEO_CAPTION_SEGMENT_SELECTOR,
+} from '@/entrypoints/main/videoSubtitle';
+
+describe('YouTube 视频字幕识别', () => {
+    it('只把 YouTube 视频页识别为视频字幕目标', () => {
+        expect(isYouTubeVideoPage({ hostname: 'www.youtube.com', pathname: '/watch' })).toBe(true);
+        expect(isYouTubeVideoPage({ hostname: 'youtube-nocookie.com', pathname: '/watch' })).toBe(true);
+        expect(isYouTubeVideoPage({ hostname: 'www.youtube.com', pathname: '/results' })).toBe(false);
+        expect(isYouTubeVideoPage({ hostname: 'example.com', pathname: '/watch' })).toBe(false);
+    });
+
+    it('按播放器中的字幕片段合并文本，并忽略空片段', () => {
+        const segments = [
+            { textContent: '  This is ' },
+            { textContent: 'a test.\n' },
+            { textContent: '' },
+        ];
+        const container = {
+            querySelectorAll: (selector: string) => {
+                expect(selector).toBe(VIDEO_CAPTION_SEGMENT_SELECTOR);
+                return segments;
+            },
+        } as unknown as Element;
+
+        expect(readVisibleCaptionText(container)).toBe('This is a test.');
+        expect(readVisibleCaptionText(null)).toBe('');
+    });
+});


### PR DESCRIPTION
## What changed
- Add a default-on YouTube video subtitle translation Beta feature with one translation overlay under native captions.
- Add independent video translation provider settings in the popup and full options page; video requests support machine translation overrides without changing the text provider.
- Add caption lifecycle handling, stale-response protection, cleanup, config migration defaults, docs, unit tests, and a repeatable isolated Edge browser test.

## Validation
- `pnpm compile`
- `pnpm test -- --run` — 14 files / 139 tests passed
- `pnpm build`
- Production extension in isolated Edge on TED-Ed YouTube URL: popup/options checks passed; deterministic native-caption-shaped fixture translated and updated; one overlay remained; disabling cleared it.

## Note
The temporary Edge session did not expose a native YouTube caption segment (`nativeSubtitle: 0`) because of the site/playback session, so the browser check records that limitation explicitly rather than treating the fixture as native playback evidence. No merge has been performed; awaiting approval.

## Summary by Sourcery

引入一个默认开启的 YouTube 字幕翻译 Beta 功能，该功能在原生 YouTube 字幕下方叠加翻译后的字幕，并使用可独立配置的机器翻译服务。

New Features:
- 在弹窗和选项界面中，为视频字幕翻译服务添加独立配置，与主文本翻译提供商分离。
- 新增 YouTube 视频字幕设置区域和弹窗抽屉，用于控制功能开关并选择视频翻译服务提供商。
- 实现对 YouTube 原生字幕的跟踪，并使用单一翻译叠加层随着字幕变化进行更新，在功能禁用或页面导航时进行清理。

Enhancements:
- 扩展后台翻译管线，以支持对机器翻译提供商进行按请求的服务覆盖，同时保持缓存和 AI 上下文行为不变。
- 更新 DOM 处理逻辑，将 YouTube 字幕元素和 FluentRead 视频字幕元素从通用页面翻译逻辑中排除。
- 优化弹窗布局和样式，以容纳新的视频字幕功能卡片和 Beta 横幅。

Build:
- 添加一个 Node 脚本，用于针对已构建的扩展运行隔离的 Edge Playwright 测试，以生成构建产物并验证 YouTube 字幕翻译行为。

Documentation:
- 在面向用户的功能指南中记录 YouTube 视频字幕翻译 Beta 功能、其行为以及配置方式。

Tests:
- 添加针对 YouTube 视频页面检测、字幕文本提取，以及视频字幕默认值与回退行为配置规范化的单元测试。
- 添加可重复的基于 Playwright 的 Edge 浏览器脚本，以验证 YouTube 字幕翻译叠加层及其设置集成的端到端行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a default-on YouTube subtitle translation Beta that overlays translated captions under native YouTube subtitles and uses an independently configurable machine translation service.

New Features:
- Add independent configuration for video subtitle translation service separate from the main text translation provider in both popup and options UI.
- Add a YouTube video subtitle settings section and popup drawer to control enabling the feature and selecting the video translation provider.
- Implement YouTube native caption tracking and a single translation overlay that updates with caption changes and cleans up when disabled or on navigation.

Enhancements:
- Extend background translation pipeline to support per-request service overrides for machine translation providers while preserving caching and AI context behavior.
- Update DOM handling to exclude YouTube caption and FluentRead video subtitle elements from generic page translation logic.
- Refine popup layout and styling to accommodate the new video subtitle feature card and Beta banner.

Build:
- Add a Node script to run an isolated Edge Playwright test against a built extension to generate artifacts and verify YouTube subtitle translation behavior.

Documentation:
- Document the YouTube video subtitle translation Beta feature, its behavior, and configuration in the user-facing feature guide.

Tests:
- Add unit tests for YouTube video page detection, caption text extraction, and configuration normalization for video subtitle defaults and fallback behavior.
- Add a repeatable Playwright-based Edge browser script to validate end-to-end behavior of the YouTube subtitle translation overlay and settings integration.

</details>