### PR TITLE
remove LLM temperature parameters

### DIFF
--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -56,7 +56,6 @@ export function commonMsgTemplate(origin: string, context?: string, prompt?: str
 
     const payload: any = {
         'model': model,
-        "temperature": 1.0,
         'messages': [
             {'role': 'system', 'content': system},
             {'role': 'user', 'content': user},
@@ -103,10 +102,6 @@ export function deepseekResponsesMsgTemplate(origin: string, context?: string, p
         input: user,
     };
 
-    if (getDeepSeekThinkingMode() === 'disabled') {
-        payload.temperature = 0.7;
-    }
-
     return JSON.stringify(payload);
 }
 
@@ -123,10 +118,6 @@ export function deepseekMsgTemplate(origin: string, context?: string, prompt?: s
         ],
         thinking: {type: thinking},
     };
-
-    if (thinking === 'disabled') {
-        payload.temperature = 0.7;
-    }
 
     return JSON.stringify(mergeCustomBody(payload, currentCustomBody()));
 }

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -24,6 +24,7 @@ import {
     buildPageSummaryPrompt,
     buildPageSummarySystemPrompt,
     deepseekMsgTemplate,
+    deepseekResponsesMsgTemplate,
     geminiMsgTemplate,
     tongyiMsgTemplate,
 } from '@/entrypoints/utils/template';
@@ -66,8 +67,8 @@ beforeEach(() => {
 
 describe('mergeCustomBody（纯函数）', () => {
     it('raw 为空字符串时，payload 原样返回', () => {
-        const payload = { model: 'x', temperature: 1 };
-        expect(mergeCustomBody(payload, '')).toEqual({ model: 'x', temperature: 1 });
+        const payload = { model: 'x', max_tokens: 128 };
+        expect(mergeCustomBody(payload, '')).toEqual({ model: 'x', max_tokens: 128 });
     });
 
     it('raw 为纯空白时，payload 原样返回', () => {
@@ -88,9 +89,9 @@ describe('mergeCustomBody（纯函数）', () => {
     });
 
     it('用户字段优先：覆盖同名的默认字段', () => {
-        const payload: any = { temperature: 1.0 };
-        const result = mergeCustomBody(payload, '{"temperature": 0.6}');
-        expect(result.temperature).toBe(0.6);
+        const payload: any = { model: 'default-model' };
+        const result = mergeCustomBody(payload, '{"model": "custom-model"}');
+        expect(result.model).toBe('custom-model');
     });
 
     it('支持嵌套对象（如 thinking 这类控制字段）', () => {
@@ -172,7 +173,6 @@ describe('commonMsgTemplate（集成）', () => {
         const body = JSON.parse(commonMsgTemplate('hello'));
         expect(body).toEqual({
             model: 'gpt-5.6-sol',
-            temperature: 1.0,
             messages: [
                 { role: 'system', content: 'You are a translator.' },
                 { role: 'user', content: 'Translate to zh-Hans: hello' },
@@ -221,13 +221,10 @@ describe('自定义请求体注入 thinking 字段（issue #213）', () => {
         expect(body.thinking).toEqual({ type: 'enabled' });
     });
 
-    it('可同时覆盖 temperature 并注入 thinking', () => {
-        mockConfig.customBody = {
-            openai: '{"thinking": {"type": "disabled"}, "temperature": 0.6}',
-        };
+    it('可注入 thinking', () => {
+        mockConfig.customBody = { openai: '{"thinking": {"type": "disabled"}}' };
         const body = JSON.parse(commonMsgTemplate('hi'));
         expect(body.thinking).toEqual({ type: 'disabled' });
-        expect(body.temperature).toBe(0.6);
     });
 
     it('带格式（缩进/换行）的 JSON 也能正确解析', () => {
@@ -252,6 +249,10 @@ describe('所有 AI 请求模板的自定义请求体支持', () => {
         [services.minimax, commonMsgTemplate],
         [services.cozecom, cozeTemplate],
     ] as const;
+    const temperatureTemplateCases = [
+        ...templateCases,
+        [services.deepseek, deepseekResponsesMsgTemplate],
+    ] as const;
 
     it.each(templateCases)('%s 模板会合并顶层自定义字段', (service, template) => {
         mockConfig.service = service;
@@ -259,6 +260,13 @@ describe('所有 AI 请求模板的自定义请求体支持', () => {
 
         const body = JSON.parse(template('hello'));
         expect(body.request_tag).toBe('custom');
+    });
+
+    it.each(temperatureTemplateCases)('%s 模板默认不发送 temperature', (service, template) => {
+        mockConfig.service = service;
+
+        const body = JSON.parse(template('hello'));
+        expect(body).not.toHaveProperty('temperature');
     });
 
     it('自定义请求体入口覆盖所有 AI 服务，但不覆盖机器翻译', () => {

--- a/userscripts.js
+++ b/userscripts.js
@@ -224,7 +224,6 @@ let LLMFormat = {
     getStdData(origin, option) {
         return JSON.stringify({
             'model': option,
-            "temperature": 0.3,
             'messages': [
                 {'role': 'system', 'content': chatMgs.getSystemMsg()},
                 {'role': 'user', 'content': chatMgs.getUserMsg('hello')},
@@ -237,7 +236,6 @@ let LLMFormat = {
         return JSON.stringify({
             'model': option,
             "stream": false,
-            "temperature": 0.1,
             'messages': [
                 {'role': 'system', 'content': chatMgs.getSystemMsg()},
                 {'role': 'user', 'content': chatMgs.getUserMsg(origin)},
@@ -1292,7 +1290,6 @@ function yiyan(origin) {
                 headers: {"Content-Type": "application/json"},
                 system: chatMgs.getSystemMsg(),
                 data: JSON.stringify({
-                    'temperature': 0.3, // 随机度
                     'disable_search': true, // 禁用搜索
                     'messages': [
                         {"role": "user", "content": chatMgs.getUserMsg("hello")},


### PR DESCRIPTION
## 变更
- 删除通用 OpenAI 兼容模板中的默认 `temperature`。
- 删除 DeepSeek Chat/Responses 模板中的默认温度参数。
- 删除旧版 `userscripts.js` 中的温度参数。
- 更新模板测试，验证 AI 请求模板默认不发送 `temperature`。

## 验证
- `pnpm test`：14 个测试文件、154 个测试通过
- `pnpm compile`：通过
- `pnpm build`：通过
- `git diff --check`：通过

## Summary by Sourcery

从 AI 请求模板和旧版用户脚本中移除默认的 temperature 参数，使得只有在显式配置时才会发送 temperature。

Bug Fixes:
- 确保在关闭思维模式时，DeepSeek 模板不再强制设置 temperature，而是依赖服务端默认值或用户配置。

Enhancements:
- 从通用的 OpenAI 兼容消息模板中移除硬编码的 temperature，使请求在默认情况下保持中性。
- 从 DeepSeek 聊天/响应模板中移除内置的 temperature 处理，改为使用外部配置。
- 清理旧版用户脚本中的 LLM 辅助函数，停止发送固定的 temperature 值。

Tests:
- 更新模板测试，以反映 AI 请求负载中不再存在默认 temperature，并验证所有模板在未通过自定义 body 提供 temperature 时都省略该字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove default temperature parameters from AI request templates and legacy user scripts so that temperature is only sent when explicitly configured.

Bug Fixes:
- Ensure DeepSeek templates no longer force a temperature when thinking mode is disabled, relying instead on service defaults or user configuration.

Enhancements:
- Drop hardcoded temperature from the common OpenAI-compatible message template to make requests neutral by default.
- Remove built-in temperature handling from DeepSeek chat/response templates in favor of external configuration.
- Clean up legacy userscript LLM helpers to stop sending fixed temperature values.

Tests:
- Update template tests to reflect the absence of default temperature in AI request payloads and to verify that all templates omit temperature unless provided via custom body.

</details>