### PR TITLE
feat: show full-page shortcut in popup

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -114,7 +114,8 @@
       >
         <span v-if="translating" class="spinner" />
         <span v-else class="translate-glyph">A↔译</span>
-        {{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}
+        <span class="translate-label">{{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}</span>
+        <kbd class="translate-hotkey" :class="{ disabled: fullPageHotkey === '未设置' }">{{ fullPageHotkey }}</kbd>
       </button>
       <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>
     </section>
@@ -340,8 +341,14 @@ const serviceLabel = computed(() => serviceOptions.value.find((item: any) => ite
 const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');
 const hoverKey = computed(() => config.value.hotkey === 'custom' ? (config.value.customHotkey || '自定义') : config.value.hotkey);
 const hoverSummary = computed(() => config.value.hotkey === 'none' ? '已关闭' : `${hoverKey.value} + 鼠标悬停`);
+const fullPageHotkey = computed(() => {
+  const hotkey = config.value.floatingBallHotkey === 'custom'
+    ? config.value.customFloatingBallHotkey
+    : config.value.floatingBallHotkey;
+  return hotkey && hotkey !== 'none' ? hotkey : '未设置';
+});
 const selectionSummary = computed(() => ({ disabled: '已关闭', bilingual: '双语显示', 'translation-only': '仅显示译文' }[config.value.selectionTranslatorMode] || '双语显示'));
-const floatingSummary = computed(() => `${config.value.floatingBallPosition === 'left' ? '页面左侧' : '页面右侧'} · ${config.value.floatingBallHotkey}`);
+const floatingSummary = computed(() => `${config.value.floatingBallPosition === 'left' ? '页面左侧' : '页面右侧'} · ${fullPageHotkey.value}`);
 const displaySummary = computed(() => config.value.display === 1 ? `双语 · ${styleLabel.value}` : '仅显示译文');
 const imageTranslationSummary = computed(() => config.value.disableImageTranslator ? '已关闭' : '悬停图片');
 const drawerTitle = computed(() => ({ hover: '鼠标悬停翻译设置', selection: '划词翻译设置', floating: '全文悬浮球设置', appearance: '译文显示设置', image: '图片翻译设置' }[activeDrawer.value]));

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -156,6 +156,14 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-button.translated { background: linear-gradient(135deg, #35b98a, #15966e); box-shadow: 0 10px 22px rgba(21, 150, 110, .24); }
 .translate-button.translated:hover:not(:disabled) { box-shadow: 0 13px 26px rgba(21, 150, 110, .3); }
 .translate-glyph { font-size: 11px; font-weight: 850; }
+.translate-label { white-space: nowrap; }
+.translate-hotkey {
+  display: inline-flex; align-items: center; min-height: 22px; padding: 0 7px; border: 1px solid rgba(255, 255, 255, .42);
+  border-radius: 7px; color: #fff; background: rgba(255, 255, 255, .16); font-family: inherit; font-size: 10px; font-weight: 700;
+  line-height: 1; white-space: nowrap;
+}
+.translate-hotkey.disabled { opacity: .72; }
+.translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .notice { margin: 10px 0 -2px; color: #16855e; font-size: 10px; text-align: center; }


### PR DESCRIPTION
## 改动

在 popup 的“翻译当前网页”按钮中展示当前全文翻译快捷键，并复用配置中的 `floatingBallHotkey` 与自定义快捷键值。快捷键禁用时显示“未设置”；全文悬浮球快捷功能卡也使用相同的解析后显示值。

## 验证

- `pnpm compile`
- `pnpm build`
- 真实隔离 Edge popup 验证：默认 `Alt+T`、切换 `Alt+A`、禁用后 `未设置`
- `git diff --check`

完整 UI 套件仍有一个现有基线断言要求快捷功能卡数量为 4，而当前 popup 已包含 5 张卡；针对本次功能的 popup 断言已通过。

## Summary by Sourcery

在弹窗中显示已配置的整页翻译快捷键，并统一浮动球快捷方式的展示方式。

New Features:
- 在弹窗中将整页翻译快捷键显示在“翻译当前网页”按钮标签旁边。

Enhancements:
- 从浮动球快捷键设置中推导出规范化的整页快捷键值，包括自定义和禁用状态。
- 更新浮动球设置摘要以复用规范化后的整页快捷键值。
- 为弹窗中的翻译按钮新增快捷键徽标样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display the configured full-page translation hotkey in the popup and unify how the floating-ball shortcut is presented.

New Features:
- Show the full-page translation shortcut next to the “翻译当前网页” button label in the popup.

Enhancements:
- Derive a normalized full-page hotkey value from floating ball hotkey settings, including custom and disabled states.
- Update the floating ball settings summary to reuse the normalized full-page hotkey value.
- Add styling for the new shortcut badge in the popup translate button.

</details>