### PR TITLE
fix: refine donation wording

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -32,15 +32,11 @@
         <section class="donation-card">
           <button class="donation-close" type="button" aria-label="关闭赞赏页" @click="closeDonation">×</button>
           <div class="donation-icon" aria-hidden="true"><Coffee /></div>
-          <span class="eyebrow">支持流畅阅读</span>
-          <h2 id="donation-title">如果它帮到了你</h2>
-          <p class="donation-description">欢迎请作者喝杯咖啡，让这段开源阅读之旅继续下去。</p>
+          <span class="eyebrow">开源免费软件</span>
+          <h2 id="donation-title">想支持作者吗？</h2>
+          <p class="donation-qr-label">微信扫码赞赏</p>
           <div class="donation-qr-frame">
             <img src="/misc/approve.jpg" alt="流畅阅读赞赏码" />
-          </div>
-          <div class="donation-note">
-            <strong>微信扫一扫</strong>
-            <span>感谢你的支持与鼓励 ❤️</span>
           </div>
         </section>
       </div>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -32,9 +32,9 @@
         <section class="donation-card">
           <button class="donation-close" type="button" aria-label="关闭赞赏页" @click="closeDonation">×</button>
           <div class="donation-icon" aria-hidden="true"><Coffee /></div>
-          <span class="eyebrow">开源免费软件</span>
-          <h2 id="donation-title">想支持作者吗？</h2>
-          <p class="donation-qr-label">微信扫码赞赏</p>
+          <span class="eyebrow">软件开源免费</span>
+          <h2 id="donation-title">如果你喜欢这款软件，</h2>
+          <p class="donation-description">可以扫描微信赞赏码支持作者，感谢鼓励。</p>
           <div class="donation-qr-frame">
             <img src="/misc/approve.jpg" alt="流畅阅读赞赏码" />
           </div>

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -273,15 +273,12 @@ footer > button { justify-self: end; }
 .donation-icon svg { width: 21px; height: 21px; }
 .donation-card .eyebrow { margin-bottom: 5px; }
 .donation-card h2 { margin-bottom: 6px; font-size: 19px; }
-.donation-description { max-width: 240px; margin: 0 auto 14px; color: var(--muted); font-size: 11px; line-height: 1.55; }
+.donation-qr-label { margin: 0 auto 9px; color: var(--ink); font-size: 13px; font-weight: 750; line-height: 1.4; white-space: nowrap; }
 .donation-qr-frame {
   width: 194px; height: 194px; margin: 0 auto 13px; padding: 6px; border: 1px solid var(--line); border-radius: 17px;
   background: #fff; box-shadow: 0 10px 24px rgba(31, 40, 61, .1);
 }
 .donation-qr-frame img { display: block; width: 100%; height: 100%; border-radius: 11px; object-fit: cover; }
-.donation-note { display: flex; flex-direction: column; gap: 4px; }
-.donation-note strong { color: var(--ink); font-size: 11px; }
-.donation-note span { color: var(--muted); font-size: 9.5px; }
 .donation-fade-enter-active, .donation-fade-leave-active { transition: opacity 160ms ease; }
 .donation-fade-enter-active .donation-card, .donation-fade-leave-active .donation-card { transition: transform 180ms ease, opacity 160ms ease; }
 .donation-fade-enter-from, .donation-fade-leave-to { opacity: 0; }

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -273,7 +273,7 @@ footer > button { justify-self: end; }
 .donation-icon svg { width: 21px; height: 21px; }
 .donation-card .eyebrow { margin-bottom: 5px; }
 .donation-card h2 { margin-bottom: 6px; font-size: 19px; }
-.donation-qr-label { margin: 0 auto 9px; color: var(--ink); font-size: 13px; font-weight: 750; line-height: 1.4; white-space: nowrap; }
+.donation-description { max-width: 280px; margin: 0 auto 14px; color: var(--muted); font-size: 13px; line-height: 1.55; white-space: nowrap; }
 .donation-qr-frame {
   width: 194px; height: 194px; margin: 0 auto 13px; padding: 6px; border: 1px solid var(--line); border-radius: 17px;
   background: #fff; box-shadow: 0 10px 24px rgba(31, 40, 61, .1);


### PR DESCRIPTION
## 变更内容

- 将顶部文案调整为“软件开源免费”。
- 将说明调整为“如果你喜欢这款软件，可以扫描微信赞赏码支持作者，感谢鼓励。”。
- 移除重复的“微信扫码赞赏”标题，减少弹窗信息层级。

## 关联 PR

这是基于 #278 的后续文案调整；请先合并 #278，再合并本 PR。

## 验证

- WXT 生产构建通过。
- 真实隔离 Edge 验证文案、字号、无溢出、二维码加载及亮色/暗色主题。
- 现有完整 UI 脚本仍会在项目原有的“快捷功能卡数量不是 4”断言处停止；当前基线实际为 5 张卡片，与本次改动无关。

## Summary by Sourcery

优化捐赠弹窗的文案和布局，突出软件的开源与免费特性，同时简化支持说明文本。

Enhancements:
- 更新捐赠弹窗的标题和描述文案，侧重表达对用户的感谢及对微信支持的说明。
- 调整捐赠说明的样式，使文字区域更宽、字体更大，同时避免换行溢出。
- 移除次级捐赠说明部分，减少视觉层级，精简弹窗内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the donation popup copy and layout to emphasize the software being open-source and free while simplifying the supporting text.

Enhancements:
- Update donation popup headline and description wording to focus on user appreciation and WeChat support.
- Adjust donation description styling for wider text and larger font while preventing wrapping overflow.
- Remove the secondary donation note section to reduce visual hierarchy and streamline the popup content.

</details>