### PR TITLE
fix: remove duplicate selection translation off option

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -238,7 +238,7 @@
         </div>
         <div class="choice-block">
           <label>显示方式</label>
-          <div class="chips three">
+          <div class="chips two">
             <button v-for="item in selectionModes" :key="item.value" type="button" :class="{ selected: config.selectionTranslatorMode === item.value }" @click="setSelectionMode(item.value)">{{ item.label }}</button>
           </div>
         </div>
@@ -393,7 +393,6 @@ const hoverChoices = [
   { value: 'custom', label: '自定义' },
 ];
 const selectionModes = [
-  { value: 'disabled', label: '关闭' },
   { value: 'bilingual', label: '双语显示' },
   { value: 'translation-only', label: '仅译文' },
 ];


### PR DESCRIPTION
## Summary
- remove the duplicate 关闭 selection-translation option from the popup
- keep the two supported display modes and update the chip layout

## Verification
- pnpm compile
- pnpm test
- git diff --check

## Summary by Sourcery

在弹出窗口中精简选中翻译显示选项，仅保留两种有效模式。

Bug 修复：
- 从弹出窗口配置中移除重复的“off”选中翻译选项。

改进：
- 更新选中模式芯片布局，以反映精简后的受支持显示模式集合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Streamline selection translation display options in the popup to only support the two valid modes.

Bug Fixes:
- Remove duplicate 'off' selection-translation option from the popup configuration.

Enhancements:
- Update selection mode chip layout to reflect the reduced set of supported display modes.

</details>