### PR TITLE
fix: restore input box translation triggers

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -8,6 +8,14 @@ import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoi
 import { cancelAllTranslations, translateText } from "@/entrypoints/utils/translateApi";
 import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
 import { mountImageTranslator, unmountImageTranslator } from "@/entrypoints/utils/imageTranslation";
+import {
+    getDeepActiveElement,
+    getInputBoxText,
+    isInputElement,
+    matchesInputBoxTrigger,
+    removeTriggerSymbols,
+    type InputBoxTrigger,
+} from "@/entrypoints/utils/inputBox";
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import { createShadowRootUi, type ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
 
@@ -33,6 +41,7 @@ export default defineContentScript({
         contentScriptContext = ctx;
         installPageStyles(ctx);
         await configReady // 等待配置加载完成
+        setupInputBoxTranslation();
         if (config.on === false) return; // 如果配置关闭，则不执行任何操作
         // 添加手动翻译事件监听器
         setupManualTranslationTriggers();
@@ -657,26 +666,36 @@ function autoTranslationEvent() {
  */
 function setupInputBoxTranslation() {
     let keyPressCount = 0;
-    let keyPressTimer: NodeJS.Timeout | null = null;
-    let lastTriggerKey = '';
+    let keyPressTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastInputElement: HTMLElement | null = null;
     const TRIPLE_KEY_TIMEOUT = 1000; // 1秒内连续按三下才生效
-    
-    // 监听键盘事件
-    document.addEventListener('keydown', async (event) => {
+
+    const resetKeyPresses = () => {
+        keyPressCount = 0;
+        lastInputElement = null;
+        if (keyPressTimer) {
+            clearTimeout(keyPressTimer);
+            keyPressTimer = null;
+        }
+    };
+
+    const handleKeyDown = async (event: KeyboardEvent) => {
         // 检查功能是否启用
-        if (config.inputBoxTranslationTrigger === 'disabled') {
+        if (config.on === false || config.inputBoxTranslationTrigger === 'disabled') {
+            resetKeyPresses();
             return;
         }
-        
-        // 检查当前焦点元素是否为输入框
-        const activeElement = document.activeElement as HTMLElement;
+
+        // 从 Shadow DOM 中找到真正的焦点元素，而不是只看宿主节点。
+        const activeElement = getDeepActiveElement();
         if (!isInputElement(activeElement)) {
+            resetKeyPresses();
             return;
         }
-        
+
         // 处理不同的触发方式
         const triggerType = config.inputBoxTranslationTrigger;
-        
+
         if (triggerType === 'ctrl_enter') {
             // Ctrl+Enter 触发
             if (event.ctrlKey && event.key === 'Enter') {
@@ -686,125 +705,44 @@ function setupInputBoxTranslation() {
             }
         } else if (triggerType === 'triple_space' || triggerType === 'triple_equal' || triggerType === 'triple_dash') {
             // 连按三次触发
-            let targetKey = '';
-            switch (triggerType) {
-                case 'triple_space':
-                    targetKey = ' ';
-                    break;
-                case 'triple_equal':
-                    targetKey = '=';
-                    break;
-                case 'triple_dash':
-                    targetKey = '-';
-                    break;
-            }
-            
-            // 只响应目标按键
-            if (event.key !== targetKey) {
+            if (event.repeat || !matchesInputBoxTrigger(event, triggerType as InputBoxTrigger)) {
                 // 如果按的不是目标键，重置计数器
-                keyPressCount = 0;
-                lastTriggerKey = '';
-                if (keyPressTimer) {
-                    clearTimeout(keyPressTimer);
-                    keyPressTimer = null;
-                }
+                resetKeyPresses();
                 return;
             }
-            
-            // 检查是否是同一个按键的连续按下
-            if (lastTriggerKey !== targetKey) {
+
+            // 切换输入框后必须重新开始计数，避免把两个输入框的按键拼成一次触发。
+            if (lastInputElement !== activeElement) {
                 keyPressCount = 1;
-                lastTriggerKey = targetKey;
+                lastInputElement = activeElement;
             } else {
                 keyPressCount++;
             }
-            
+
             // 如果是第三次按下目标键
             if (keyPressCount === 3) {
                 event.preventDefault(); // 阻止默认输入
+                resetKeyPresses();
                 await handleInputBoxTranslation(activeElement);
-                keyPressCount = 0; // 重置计数器
-                lastTriggerKey = '';
+                return;
             }
-            
+
             // 设置超时，如果在指定时间内没有连续按满三次，就重置计数器
             if (keyPressTimer) {
                 clearTimeout(keyPressTimer);
             }
             keyPressTimer = setTimeout(() => {
-                keyPressCount = 0;
-                lastTriggerKey = '';
+                resetKeyPresses();
             }, TRIPLE_KEY_TIMEOUT);
         }
+    };
+
+    // 使用捕获阶段，兼容会在冒泡阶段停止传播键盘事件的富文本编辑器。
+    document.addEventListener('keydown', handleKeyDown, true);
+    contentScriptContext?.onInvalidated(() => {
+        document.removeEventListener('keydown', handleKeyDown, true);
+        resetKeyPresses();
     });
-}
-
-/**
- * 检查元素是否为输入元素
- */
-function isInputElement(element: HTMLElement): boolean {
-    if (!element) return false;
-    
-    const tagName = element.tagName.toLowerCase();
-    const isInput = tagName === 'input';
-    const isTextarea = tagName === 'textarea';
-    const isContentEditable = element.contentEditable === 'true';
-    
-    // 对于input元素，还需要检查type属性
-    if (isInput) {
-        const inputType = (element as HTMLInputElement).type.toLowerCase();
-        const textInputTypes = ['text', 'search', 'url', 'email', 'password'];
-        return textInputTypes.includes(inputType);
-    }
-    
-    return isTextarea || isContentEditable;
-}
-
-/**
- * 获取输入框中的文本
- */
-function getInputBoxText(element: HTMLElement): string {
-    const tagName = element.tagName.toLowerCase();
-    
-    if (tagName === 'input' || tagName === 'textarea') {
-        return (element as HTMLInputElement | HTMLTextAreaElement).value.trim();
-    } else if (element.contentEditable === 'true') {
-        return element.innerText.trim();
-    }
-    
-    return '';
-}
-
-/**
- * 根据触发方式去除末尾的触发符号
- */
-function removeTriggerSymbols(text: string, triggerType: string): string {
-    if (!text || triggerType === 'disabled' || triggerType === 'ctrl_enter') {
-        return text;
-    }
-    
-    let triggerSymbol = '';
-    switch (triggerType) {
-        case 'triple_space':
-            triggerSymbol = ' ';
-            break;
-        case 'triple_equal':
-            triggerSymbol = '=';
-            break;
-        case 'triple_dash':
-            triggerSymbol = '-';
-            break;
-        default:
-            return text;
-    }
-    
-    // 去除末尾所有的触发符号
-    let cleanedText = text;
-    while (cleanedText.endsWith(triggerSymbol)) {
-        cleanedText = cleanedText.slice(0, -1);
-    }
-    
-    return cleanedText.trim();
 }
 
 /**
@@ -820,7 +758,7 @@ function setInputBoxText(element: HTMLElement, text: string): void {
         // 触发input事件，以便网页能感知到值的变化
         inputElement.dispatchEvent(new Event('input', { bubbles: true }));
         inputElement.dispatchEvent(new Event('change', { bubbles: true }));
-    } else if (element.contentEditable === 'true') {
+    } else if (isInputElement(element)) {
         element.innerText = text;
         
         // 触发input事件
@@ -1071,6 +1009,3 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
         setTimeout(() => removeExistingTooltip(), 3000);
     }
 }
-
-// 初始化输入框翻译功能
-setupInputBoxTranslation();

--- a/entrypoints/utils/inputBox.ts
+++ b/entrypoints/utils/inputBox.ts
@@ -1,0 +1,74 @@
+const TEXT_INPUT_TYPES = new Set(['text', 'search', 'url', 'email', 'password', 'tel']);
+
+export type InputBoxTrigger = 'triple_space' | 'triple_equal' | 'triple_dash';
+
+/** 找到 Shadow DOM 内真正获得焦点的元素。 */
+export function getDeepActiveElement(): Element | null {
+    let activeElement: Element | null = document.activeElement;
+
+    while (activeElement?.shadowRoot?.activeElement) {
+        activeElement = activeElement.shadowRoot.activeElement;
+    }
+
+    return activeElement;
+}
+
+/** 判断元素是否是可翻译的文本输入目标。 */
+export function isInputElement(element: Element | null): element is HTMLElement {
+    if (!element) return false;
+    if ('disabled' in element && Boolean((element as HTMLInputElement).disabled)) return false;
+    if ('readOnly' in element && Boolean((element as HTMLInputElement | HTMLTextAreaElement).readOnly)) return false;
+
+    const tagName = element.tagName.toLowerCase();
+    if (tagName === 'input') {
+        return TEXT_INPUT_TYPES.has((element as HTMLInputElement).type.toLowerCase());
+    }
+    if (tagName === 'textarea') return true;
+
+    return (element as HTMLElement).isContentEditable || ['true', 'plaintext-only'].includes(element.getAttribute('contenteditable') || '');
+}
+
+/** 获取输入目标中的纯文本。 */
+export function getInputBoxText(element: HTMLElement): string {
+    const tagName = element.tagName.toLowerCase();
+
+    if (tagName === 'input' || tagName === 'textarea') {
+        return (element as HTMLInputElement | HTMLTextAreaElement).value.trim();
+    }
+
+    return (element.innerText || element.textContent || '').trim();
+}
+
+/** 判断一次键盘事件是否匹配当前的三连击触发方式。 */
+export function matchesInputBoxTrigger(event: KeyboardEvent, trigger: InputBoxTrigger): boolean {
+    switch (trigger) {
+        case 'triple_space':
+            return event.key === ' ' || event.code === 'Space';
+        case 'triple_equal':
+            return event.key === '=' || (event.code === 'Equal' && !event.shiftKey);
+        case 'triple_dash':
+            return event.key === '-' || (event.code === 'Minus' && !event.shiftKey);
+        default:
+            return false;
+    }
+}
+
+/** 根据触发方式去除末尾的触发符号。 */
+export function removeTriggerSymbols(text: string, trigger: string): string {
+    const triggerSymbol = trigger === 'triple_space'
+        ? ' '
+        : trigger === 'triple_equal'
+            ? '='
+            : trigger === 'triple_dash'
+                ? '-'
+                : '';
+
+    if (!triggerSymbol) return text;
+
+    let cleanedText = text;
+    while (cleanedText.endsWith(triggerSymbol)) {
+        cleanedText = cleanedText.slice(0, -1);
+    }
+
+    return cleanedText.trim();
+}

--- a/tests/inputBox.test.ts
+++ b/tests/inputBox.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getInputBoxText,
+    isInputElement,
+    matchesInputBoxTrigger,
+    removeTriggerSymbols,
+} from '@/entrypoints/utils/inputBox';
+
+function keyEvent(key: string, code: string, shiftKey = false): KeyboardEvent {
+    return { key, code, shiftKey } as KeyboardEvent;
+}
+
+function fakeElement(tagName: string, attributes: Record<string, string> = {}): HTMLElement {
+    return {
+        tagName,
+        getAttribute(name: string) {
+            return attributes[name] ?? null;
+        },
+        isContentEditable: false,
+        value: '',
+        textContent: '',
+        innerText: '',
+        type: 'text',
+    } as unknown as HTMLElement;
+}
+
+describe('输入框快捷键', () => {
+    it('兼容浏览器的 Space、Equal 和 Minus 按键值', () => {
+        expect(matchesInputBoxTrigger(keyEvent(' ', 'Space'), 'triple_space')).toBe(true);
+        expect(matchesInputBoxTrigger(keyEvent('=', 'Equal'), 'triple_equal')).toBe(true);
+        expect(matchesInputBoxTrigger(keyEvent('-', 'Minus'), 'triple_dash')).toBe(true);
+        expect(matchesInputBoxTrigger(keyEvent('+', 'Equal', true), 'triple_equal')).toBe(false);
+    });
+
+    it('识别 plaintext-only 可编辑区域并跳过只读输入框', () => {
+        expect(isInputElement(fakeElement('DIV', { contenteditable: 'plaintext-only' }))).toBe(true);
+        expect(isInputElement({ ...fakeElement('TEXTAREA'), readOnly: true } as unknown as HTMLElement)).toBe(false);
+    });
+
+    it('清理触发符号后保留真实输入内容', () => {
+        expect(removeTriggerSymbols('Hello   ', 'triple_space')).toBe('Hello');
+        expect(removeTriggerSymbols('Hello===', 'triple_equal')).toBe('Hello');
+        expect(getInputBoxText({ ...fakeElement('DIV'), innerText: ' Hello world ' } as unknown as HTMLElement)).toBe('Hello world');
+    });
+});


### PR DESCRIPTION
## Summary
- 修复三次空格、等号和短横线输入框翻译触发。
- 支持 Shadow DOM、contenteditable="plaintext-only" 和阻止冒泡的富文本编辑器。
- 添加输入框触发逻辑回归测试。

## Validation
- pnpm test（161 tests）
- pnpm compile
- pnpm build
- git diff --check
- 隔离 Edge 输入框测试：三次空格/等号、plaintext-only、事件阻止冒泡
- 标准 Control 段落测试：[1,0,1]，相邻段落：[0,0,0]

## Summary by Sourcery

恢复并强化输入框翻译触发机制，包括更广泛的输入元素支持和更可靠的按键检测。

Bug Fixes:
- 修复三空格、三等号和三连字符输入框翻译触发器触发不稳定的问题。
- 确保输入框翻译遵守全局开关配置，并能在 Shadow DOM 和阻止冒泡的富文本编辑器中正常工作。

Enhancements:
- 将输入框相关工具提取到独立模块，用于检测可编辑目标、读取文本、匹配触发器以及清理触发符号。
- 扩展输入元素检测范围，涵盖仅支持纯文本的 `contenteditable` 字段，并跳过禁用或只读的输入。
- 改进 keydown 处理逻辑，通过跟踪当前活动输入元素，避免跨输入框的三键累积，并在内容脚本失效时清理监听器。

Tests:
- 添加单元测试，覆盖输入触发按键匹配、纯文本可编辑字段检测、只读字段跳过，以及触发符号移除和文本提取等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore and harden input box translation triggers, including broader input element support and robust key detection.

Bug Fixes:
- Fix triple-space, triple-equal, and triple-dash input box translation triggers that were not reliably firing.
- Ensure input box translation respects global on/off configuration and works across Shadow DOM and bubbling-stopped rich text editors.

Enhancements:
- Extract input box utilities into a dedicated module for detecting editable targets, reading text, trigger matching, and cleaning trigger symbols.
- Extend input element detection to cover plaintext-only contenteditable fields and skip disabled or read-only inputs.
- Improve keydown handling by tracking the active input element, avoiding cross-input triple-key accumulation, and cleaning up listeners on content script invalidation.

Tests:
- Add unit tests covering input trigger key matching, plaintext-only editable detection, read-only skipping, and trigger symbol removal and text extraction.

</details>