### PR TITLE
fix: make floating ball logo inert

### DIFF
--- a/components/FloatingBall.vue
+++ b/components/FloatingBall.vue
@@ -34,23 +34,20 @@
       <span v-if="isTranslating" class="check-mark" aria-hidden="true" />
     </button>
 
-    <button
+    <div
       class="floating-ball-main floating-ball-item"
-      type="button"
-      :aria-label="mainButtonLabel"
-      :aria-pressed="isTranslating"
-      :title="mainButtonTitle"
-      @focus="expandBall"
-      @blur="collapseBall"
+      role="img"
+      aria-label="FluentRead"
+      title="按住拖动调整位置"
       @pointerdown="startDrag"
       @pointerup="finishPointerInteraction"
       @pointercancel="cancelPointerInteraction"
     >
       <svg class="floating-ball-mascot" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <image v-if="logoUrl" :href="logoUrl" x="0" y="0" width="32" height="32" preserveAspectRatio="none" image-rendering="pixelated" />
+        <image v-if="logoUrl" :href="logoUrl" x="0" y="0" width="32" height="32" preserveAspectRatio="none" image-rendering="auto" />
       </svg>
       <span v-if="isTranslating" class="check-mark" aria-hidden="true" />
-    </button>
+    </div>
 
     <button
       v-if="showMenu"
@@ -129,8 +126,6 @@ let animationTimer: ReturnType<typeof setTimeout> | undefined;
 let tooltipTimer: ReturnType<typeof setTimeout> | undefined;
 
 const currentDisplayPosition = computed(() => internalPosition.value || props.position);
-const mainButtonLabel = computed(() => isTranslating.value ? '恢复网页原文' : '翻译整个网页');
-const mainButtonTitle = computed(() => `${mainButtonLabel.value}；按住拖动调整位置`);
 
 function expandBall() {
   if (!isDragging.value) isExpanded.value = true;
@@ -227,8 +222,6 @@ function finishPointerInteraction(event: PointerEvent) {
     nextTick(updatePositionStyle);
     return;
   }
-
-  toggleTranslation();
 }
 
 function cancelPointerInteraction(event: PointerEvent) {
@@ -401,10 +394,10 @@ watch(() => props.position, (newPosition) => {
 
 .floating-ball-mascot {
   display: block;
-  width: 42px;
-  height: 42px;
+  width: 36px;
+  height: 36px;
   pointer-events: none;
-  image-rendering: pixelated;
+  image-rendering: auto;
 }
 
 .translation-icon {

--- a/entrypoints/utils/floatingBall.ts
+++ b/entrypoints/utils/floatingBall.ts
@@ -42,7 +42,7 @@ export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' 
     props: {
       position: ballPosition,
       showMenu: true,
-      logoUrl: browser.runtime.getURL('/icon/32.png'),
+      logoUrl: browser.runtime.getURL('/icon/128.png'),
       onSettingsClick: () => {
         browser.runtime.sendMessage({ type: 'openOptionsPage' });
       },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
         ],
         web_accessible_resources: [
             {
-                resources: ['icon/32.png'],
+                resources: ['icon/32.png', 'icon/128.png'],
                 matches: ['<all_urls>'],
             },
         ],


### PR DESCRIPTION
## 变更
- 使用 128px 图标资源，显示尺寸调整为 36px，并取消像素化渲染。
- 中间 FluentRead 图标改为纯展示元素；点击不再触发全文翻译，仍保留按住拖动调整位置。
- 将 `icon/128.png` 加入网页可访问资源声明。

## 验证
- `pnpm compile`
- `pnpm test`（174 tests passed）
- `pnpm build`
- 隔离 Edge 真实浏览器验证：图标实际显示，点击后译文数量保持 0，URL 不变，顶部翻译按钮仍存在。

Closes the requested floating-ball sidebar behavior fix.

## Summary by Sourcery

让悬浮球 Logo 成为一个不可交互的视觉吉祥物，同时更新其图标资源和展示属性。

New Features:
- 将 128px 的 Logo 资源暴露为可通过 Web 访问的资源，以供悬浮球使用。

Bug Fixes:
- 阻止点击悬浮球主 Logo 触发整页翻译，使其仅保持可拖拽功能。

Enhancements:
- 调整悬浮球 Logo 的渲染方式，使用更高分辨率的图标，同时缩小展示尺寸，并避免图像像素化渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the floating ball logo a non-interactive visual mascot while updating its icon asset and display properties.

New Features:
- Expose the 128px logo asset as a web-accessible resource for use by the floating ball.

Bug Fixes:
- Prevent clicks on the floating ball main logo from triggering full-page translation, keeping it only draggable.

Enhancements:
- Adjust floating ball logo rendering to use a higher-resolution icon with smaller display size and non-pixelated image rendering.

</details>