### PR TITLE
feat: add per-model API key requirement setting

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -623,7 +623,7 @@ import {
 } from '@/entrypoints/utils/custom-body';
 import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
 import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
-import { getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
+import { getApiKeyRequirementKey, getMissingCredentialMessage, isApiKeyRequired } from '@/entrypoints/utils/configValidation';
 import {
   IMAGE_OCR_LANGUAGE_PACKS,
   IMAGE_OCR_LANGUAGE_STATE_KEY,
@@ -811,6 +811,12 @@ const createServiceCompute = (serviceSource: ServiceSource) => ({
   showModel: computed(() => servicesType.isUseModel(serviceSource.value)),
   showCustomBody: computed(() => servicesType.isUseCustomBody(serviceSource.value)),
   showToken: computed(() => servicesType.isUseToken(serviceSource.value)),
+  requireApiKey: computed({
+    get: () => isApiKeyRequired(serviceSource.value, config.value),
+    set: (value: boolean) => {
+      config.value.requireApiKey[getApiKeyRequirementKey(serviceSource.value, config.value)] = value;
+    },
+  }),
   credentialWarning: computed(() => getMissingCredentialMessage(serviceSource.value, config.value)),
   showAkSk: computed(() => servicesType.isUseAkSk(serviceSource.value)),
   showYoudao: computed(() => servicesType.isYoudao(serviceSource.value)),

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -8,6 +8,18 @@
       <div><strong>连接参数</strong></div>
     </div>
 
+    <el-row v-show="compute.showAI && compute.showToken" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="默认要求填写 API Key。关闭后，当前服务的当前模型允许在没有 API Key 时发起请求，适用于本地模型或不需要鉴权的代理。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">需要 API Key<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12" class="credential-switch-field">
+        <el-switch v-model="compute.requireApiKey" aria-label="当前模型是否需要 API Key" active-text="需要" inactive-text="不需要" />
+        <small>当前模型：{{ config.model[service] || '未选择' }}</small>
+      </el-col>
+    </el-row>
+
     <el-row v-show="compute.showToken" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="API访问令牌仅保存在本地，用于访问翻译服务。获取方式请参考对应服务的官方文档；翻译服务为 ollama 时，token 可为任意值" placement="top-start" :show-after="500">
@@ -141,5 +153,18 @@ const isValidAzureEndpoint = toRef(props, 'isValidAzureEndpoint')
 .credential-warning strong {
   flex: 0 0 auto;
   font-weight: 750;
+}
+
+.credential-switch-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.credential-switch-field small {
+  flex-basis: 100%;
+  color: #909399;
+  font-size: 11px;
 }
 </style>

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -9,6 +9,7 @@ import {
     saveConfig,
 } from "@/entrypoints/utils/config";
 import {CONTEXT_MENU_IDS} from "@/entrypoints/utils/constant";
+import {getMissingCredentialMessage} from "@/entrypoints/utils/configValidation";
 import {resolveConfiguredModel, servicesType} from "@/entrypoints/utils/option";
 import {synthesizeEdgeTts} from "@/entrypoints/utils/edgeTts";
 import {
@@ -381,6 +382,8 @@ async function translateBatchWithCache(
 
 async function translateWithCache(message: TranslationRequestMessage): Promise<string | string[]> {
     await configReady;
+    const missingCredentialMessage = getMissingCredentialMessage(config.service, config);
+    if (missingCredentialMessage) throw new Error(missingCredentialMessage);
     const context = typeof message.context === 'string' ? message.context : '';
     const rawPageContext = typeof message.pageContext === 'string' ? message.pageContext : '';
     const pageContext = await addPageSummary(rawPageContext);

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -130,6 +130,11 @@
         </div>
       </div>
 
+      <div v-if="credentialWarning" class="credential-warning" role="alert">
+        <span><strong>配置提醒</strong>{{ credentialWarning }}</span>
+        <button type="button" @click="openOptions('settings-services')">去设置</button>
+      </div>
+
       <button
         class="translate-button"
         :class="{ translated: pageTranslated }"
@@ -326,10 +331,11 @@ import {
 import { Setting } from '@element-plus/icons-vue';
 import { Config } from '@/entrypoints/utils/model';
 import { options } from '@/entrypoints/utils/option';
+import { getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
 type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance' | 'image';
-type SettingsSection = 'settings-general' | 'settings-shortcuts';
+type SettingsSection = 'settings-general' | 'settings-shortcuts' | 'settings-services';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 const version = process.env.VUE_APP_VERSION;
 const config = ref(new Config());
@@ -369,6 +375,7 @@ const popularServiceOptions = computed(() => popularServiceValues
 const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !popularServiceValues.includes(item.value)));
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
+const credentialWarning = computed(() => getMissingCredentialMessage(config.value.service, config.value));
 const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');
 const hoverKey = computed(() => config.value.hotkey === 'custom' ? (config.value.customHotkey || '自定义') : config.value.hotkey);
 const hoverSummary = computed(() => config.value.hotkey === 'none' ? '已关闭' : `${hoverKey.value} + 鼠标悬停`);
@@ -528,6 +535,11 @@ async function openOptions(section?: SettingsSection) {
 }
 
 async function togglePageTranslation() {
+  if (credentialWarning.value) {
+    showNotice(credentialWarning.value, 'error');
+    return;
+  }
+
   translating.value = true;
   const action = pageTranslated.value ? 'restore' : 'fullPage';
   try {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -176,6 +176,15 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
+.credential-warning {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-top: 9px; padding: 9px 10px;
+  border: 1px solid #f3d19e; border-radius: 11px; color: #8a5a00; background: #fdf6ec; font-size: 10px; line-height: 1.45;
+}
+.credential-warning span { min-width: 0; }
+.credential-warning strong { margin-right: 4px; font-weight: 800; }
+.credential-warning button {
+  flex: 0 0 auto; padding: 0; border: 0; color: #b46b00; background: transparent; font: inherit; font-weight: 800; text-decoration: underline; cursor: pointer;
+}
 .notice { margin: 10px 0 -2px; color: #16855e; font-size: 10px; text-align: center; }
 .notice.error { color: #d9345e; }
 

--- a/entrypoints/service/auth.ts
+++ b/entrypoints/service/auth.ts
@@ -1,0 +1,9 @@
+export function appendOptionalBearer(headers: Headers, token?: string): void {
+    const trimmedToken = token?.trim();
+    appendOptionalHeader(headers, 'Authorization', trimmedToken ? `Bearer ${trimmedToken}` : '');
+}
+
+export function appendOptionalHeader(headers: Headers, name: string, value?: string): void {
+    const trimmedValue = value?.trim();
+    if (trimmedValue) headers.set(name, trimmedValue);
+}

--- a/entrypoints/service/azure-openai.ts
+++ b/entrypoints/service/azure-openai.ts
@@ -2,12 +2,13 @@ import {method, urls} from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
+import {isApiKeyRequired} from "@/entrypoints/utils/configValidation";
 
 async function azureOpenai(message: any) {
     try {
         // 验证必要的配置
         const apiKey = config.token[config.service];
-        if (!apiKey || apiKey.trim() === '') {
+        if ((!apiKey || apiKey.trim() === '') && isApiKeyRequired(config.service, config)) {
             throw new Error('Azure OpenAI API Key 未配置，请在设置中输入有效的 API Key');
         }
 
@@ -21,10 +22,8 @@ async function azureOpenai(message: any) {
             throw new Error('Azure OpenAI 端点地址格式不正确，请确保包含正确的域名和路径');
         }
 
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-            'api-key': apiKey
-        });
+        const headers = new Headers({'Content-Type': 'application/json'});
+        if (apiKey?.trim()) headers.set('api-key', apiKey.trim());
                 
         const resp = await fetch(endpoint, {
             method: method.POST,

--- a/entrypoints/service/claude.ts
+++ b/entrypoints/service/claude.ts
@@ -2,12 +2,13 @@ import {services} from "../utils/option";
 import {method, urls} from "../utils/constant";
 import {claudeMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
+import {appendOptionalHeader} from './auth';
 
 async function claude(message: any) {
     // 构建请求头
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('x-api-key', config.token[services.claude]);
+    appendOptionalHeader(headers, 'x-api-key', config.token[services.claude]);
     headers.append('anthropic-version', '2023-06-01');
     headers.append('anthropic-dangerous-direct-browser-access', 'true');
 

--- a/entrypoints/service/common.ts
+++ b/entrypoints/service/common.ts
@@ -3,14 +3,13 @@ import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
 import { services } from "../utils/option";
+import { appendOptionalBearer } from './auth';
 
 async function common(message: any) {
     try {
 
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${config.token[config.service]}`
-        });
+        const headers = new Headers({'Content-Type': 'application/json'});
+        appendOptionalBearer(headers, config.token[config.service]);
 
         if(config.service === services.openrouter){
             headers.append('HTTP-Referer', 'https://fluent.thinkstu.com');

--- a/entrypoints/service/coze.ts
+++ b/entrypoints/service/coze.ts
@@ -2,12 +2,13 @@ import {Config} from "../utils/model";
 import {method, urls} from "../utils/constant";
 import {cozeTemplate} from "@/entrypoints/utils/template";
 import {config} from "@/entrypoints/utils/config";
+import {appendOptionalBearer} from './auth';
 
 async function coze( message: any) {
     // 构建请求头
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('Authorization', `Bearer ${config.token[config.service]}`);
+    appendOptionalBearer(headers, config.token[config.service]);
 
     // 判断是否使用代理
     let url: string = config.proxy[config.service] ? config.proxy[config.service] : urls[config.service];

--- a/entrypoints/service/custom.ts
+++ b/entrypoints/service/custom.ts
@@ -3,12 +3,13 @@ import {method} from "../utils/constant";
 import {services} from "@/entrypoints/utils/option";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
+import {appendOptionalBearer} from './auth';
 
 async function custom(message: any) {
 
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('Authorization', `Bearer ${config.token[services.custom]}`);
+    appendOptionalBearer(headers, config.token[services.custom]);
 
     const resp = await fetch(config.custom, {
         method: method.POST,

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -2,6 +2,7 @@ import { method, urls } from "../utils/constant";
 import { deepseekMsgTemplate, deepseekResponsesMsgTemplate } from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
+import { appendOptionalBearer } from './auth';
 
 // 当前官方 V4 文档以 Chat Completion 为主；Responses API 仅在用户明确选择时启用，
 // 便于兼容已经支持该协议的代理或网关。
@@ -13,10 +14,8 @@ function useResponsesApi() {
 
 async function deepseek(message: any) {
     try {
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${config.token[config.service]}`
-        });
+        const headers = new Headers({'Content-Type': 'application/json'});
+        appendOptionalBearer(headers, config.token[config.service]);
 
         const endpoint = config.proxy[config.service] || urls[config.service];
         const isResponses = useResponsesApi();

--- a/entrypoints/service/grok.ts
+++ b/entrypoints/service/grok.ts
@@ -2,6 +2,7 @@ import {method, urls} from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
+import { appendOptionalBearer } from './auth';
 
 /**
  * Grok 服务实现
@@ -10,10 +11,8 @@ import {contentPostHandler} from "@/entrypoints/utils/check";
  */
 async function grok(message: any) {
     try {
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${config.token[config.service]}`
-        });
+        const headers = new Headers({'Content-Type': 'application/json'});
+        appendOptionalBearer(headers, config.token[config.service]);
 
         const url = config.proxy[config.service] || urls[config.service];
 

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -2,13 +2,12 @@ import { method, urls } from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";
+import { appendOptionalBearer } from './auth';
 
 async function newapi(message: any) {
     try {
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${config.token[config.service]}`
-        });
+        const headers = new Headers({'Content-Type': 'application/json'});
+        appendOptionalBearer(headers, config.token[config.service]);
 
         let url = config.newApiUrl
 

--- a/entrypoints/service/tongyi.ts
+++ b/entrypoints/service/tongyi.ts
@@ -2,13 +2,14 @@ import {currentModelIds, services} from "../utils/option";
 import {method, tongyiTokenPlanUrl, urls} from "../utils/constant";
 import {tongyiMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
+import {appendOptionalBearer} from './auth';
 
 // 文档：https://help.aliyun.com/zh/dashscope/developer-reference/tongyi-thousand-questions-metering-and-billing
 async function tongyi(message: any) {
     // 构建请求头
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('Authorization', `Bearer ${config.token[services.tongyi]}`);
+    appendOptionalBearer(headers, config.token[services.tongyi]);
 
     // 判断是否使用代理
     const selectedModel = config.model[services.tongyi];

--- a/entrypoints/service/zhipu.ts
+++ b/entrypoints/service/zhipu.ts
@@ -3,6 +3,7 @@ import {services} from "../utils/option";
 import {commonMsgTemplate} from "../utils/template";
 import CryptoJS from 'crypto-js';
 import {config, saveConfig} from "@/entrypoints/utils/config";
+import {isApiKeyRequired} from "@/entrypoints/utils/configValidation";
 
 
 // 文档参考：https://open.bigmodel.cn/dev/api#nosdk
@@ -11,7 +12,9 @@ async function zhipu(message: any) {
     let token = config.token[services.zhipu];
     let secret, expiration;
     config.extra[services.zhipu] && ({secret, expiration} = config.extra[services.zhipu]);
-    if (!secret || expiration <= Date.now()) {
+    if (!token?.trim() && !isApiKeyRequired(services.zhipu, config)) {
+        secret = undefined;
+    } else if (!secret || expiration <= Date.now()) {
         secret = generateToken(token);
         if (!secret) throw new Error('无法生成令牌');
         // 保存 secret 和 expiration
@@ -22,7 +25,7 @@ async function zhipu(message: any) {
     // 构建请求头
     let headers = new Headers();
     headers.append('Content-Type', 'application/json');
-    headers.append('Authorization', `Bearer ${secret}`);
+    if (secret) headers.append('Authorization', `Bearer ${secret}`);
 
     // 发起 fetch 请求
     const resp = await fetch(urls[services.zhipu], {

--- a/entrypoints/utils/configValidation.ts
+++ b/entrypoints/utils/configValidation.ts
@@ -1,11 +1,32 @@
-import { services, servicesType } from './option';
+import { customModelString, options, services, servicesType } from './option';
 
 export interface CredentialConfig {
     token?: Record<string, string | undefined>;
+    model?: Record<string, string | undefined>;
+    customModel?: Record<string, string | undefined>;
+    requireApiKey?: Record<string, boolean | undefined>;
     youdaoAppKey?: string;
     youdaoAppSecret?: string;
     tencentSecretId?: string;
     tencentSecretKey?: string;
+}
+
+function getServiceLabel(service: string): string {
+    return options.services.find((item) => item.value === service)?.label || service;
+}
+
+/** 使用服务和实际模型共同定位开关，避免切换模型时误用另一模型的设置。 */
+export function getApiKeyRequirementKey(service: string, config: CredentialConfig): string {
+    const selectedModel = config.model?.[service] || '';
+    const actualModel = selectedModel === customModelString
+        ? config.customModel?.[service] || selectedModel
+        : selectedModel;
+    return `${service}:${actualModel}`;
+}
+
+export function isApiKeyRequired(service: string, config: CredentialConfig): boolean {
+    if (!servicesType.isAI(service)) return true;
+    return config.requireApiKey?.[getApiKeyRequirementKey(service, config)] !== false;
 }
 
 /** 返回设置页和翻译前校验共用的凭据提示；返回 null 表示当前服务不缺凭据。 */
@@ -13,20 +34,22 @@ export function getMissingCredentialMessage(
     service: string,
     config: CredentialConfig,
 ): string | null {
-    if (servicesType.isUseToken(service) && service !== services.deeplx) {
+    const serviceLabel = getServiceLabel(service);
+
+    if (servicesType.isUseToken(service) && service !== services.deeplx && isApiKeyRequired(service, config)) {
         if (!config.token?.[service]?.trim()) {
-            return '该服务需要 API Key（访问令牌），当前尚未配置；翻译前请先填写。';
+            return `${serviceLabel} 需要 API Key（访问令牌），当前尚未配置；请先在设置中填写，再开始翻译。`;
         }
     }
 
     if (service === services.youdao
         && (!config.youdaoAppKey?.trim() || !config.youdaoAppSecret?.trim())) {
-        return '该服务需要 App Key 和 App Secret，当前尚未完整配置；翻译前请先填写。';
+        return `${serviceLabel} 需要 App Key 和 App Secret，当前尚未完整配置；请先在设置中填写，再开始翻译。`;
     }
 
     if (service === services.tencent
         && (!config.tencentSecretId?.trim() || !config.tencentSecretKey?.trim())) {
-        return '该服务需要 SecretId 和 SecretKey，当前尚未完整配置；翻译前请先填写。';
+        return `${serviceLabel} 需要 SecretId 和 SecretKey，当前尚未完整配置；请先在设置中填写，再开始翻译。`;
     }
 
     return null;

--- a/entrypoints/utils/icon.ts
+++ b/entrypoints/utils/icon.ts
@@ -85,8 +85,9 @@ function handleErrorClick(errMsg: string) {
 
 // 根据错误信息返回错误提示
 function getErrorMessage(errMsg: string): string {
-  if (errMsg.includes("auth failed") || errMsg.includes("API key")) {
-    return "Token 似乎有点问题，请前往设置页面重新配置后再试。";
+  const normalizedError = errMsg.toLowerCase();
+  if (normalizedError.includes("auth failed") || normalizedError.includes("api key") || errMsg.includes("访问令牌") || errMsg.includes("尚未配置")) {
+    return "当前翻译服务还没有配置 API Key，请前往设置页面填写后再试。";
   } else if (errMsg.includes("quota") || errMsg.includes("limit")) {
     const service = options.services.find((s: { value: string; label: string }) => s.value === config.service);
     return "你的请求频率过高，被【" + (service?.label || config.service) + "】拒绝了，请稍后再试吧~";

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -23,6 +23,7 @@ export class Config {
     display: number = 1;
     service: string;
     token: IMapping;
+    requireApiKey: Record<string, boolean>; // 按服务和模型保存 API Key 校验开关
     ak: string;
     sk: string;
     appid: string;
@@ -73,6 +74,7 @@ export class Config {
         this.hotkey = defaultOption.hotkey;
         this.service = defaultOption.service;
         this.token = {};
+        this.requireApiKey = {};
         this.ak = '';
         this.sk = '';
         this.appid = '';
@@ -198,6 +200,7 @@ export function normalizeConfig(value: unknown): Config {
     delete (normalized as unknown as Record<string, unknown>).__fluentConfigRevision;
 
     normalized.model = isRecord(source.model) ? {...source.model} : {};
+    normalized.requireApiKey = isBooleanMapping(source.requireApiKey) ? {...source.requireApiKey} : {};
     normalized.customModel = isRecord(source.customModel) ? {...source.customModel} : {};
     normalized.customBody = normalizeCustomBodyMapping(source.customBody);
 
@@ -265,6 +268,13 @@ export function migrateModelIdentifier(service: string, selectedModel: string): 
 
 function isRecord(value: unknown): value is Record<string, string> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBooleanMapping(value: unknown): value is Record<string, boolean> {
+    return typeof value === 'object'
+        && value !== null
+        && !Array.isArray(value)
+        && Object.values(value).every((item) => typeof item === 'boolean');
 }
 
 // 构建所有服务的 system_role

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -9,6 +9,7 @@ import { config, saveConfig } from './config';
 import { detectlang } from './common';
 import { resolveConfiguredModel, servicesType } from './option';
 import { getPageTranslationContext } from './pageContext';
+import { getMissingCredentialMessage } from './configValidation';
 
 // 调试相关
 const isDev = process.env.NODE_ENV === 'development';
@@ -34,6 +35,8 @@ export async function translateText(origin: string, context: string = document.t
   if (!cleanedOrigin || cleanedOrigin.length === 0) {
     return origin || '';
   }
+
+  assertTranslationCredentials();
 
   // 如果目标语言与当前文本语言相同，直接返回原文
   if (detectlang(origin.replace(/[\s\u3000]/g, '')) === config.to) {
@@ -98,6 +101,8 @@ export async function translateTextBatch(
 ): Promise<string[]> {
   if (origins.length === 0) return [];
 
+  assertTranslationCredentials();
+
   const {
     maxRetries = 3,
     retryDelay = 1000,
@@ -161,6 +166,11 @@ export interface TranslateOptions {
   useCache?: boolean;
   /** 发送给 LLM 的网页参考上下文；未提供时按当前页面自动提取。 */
   pageContext?: string;
+}
+
+function assertTranslationCredentials(): void {
+  const message = getMissingCredentialMessage(config.service, config);
+  if (message) throw new Error(message);
 }
 
 async function resolvePageContext(suppliedContext?: string): Promise<string | undefined> {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendOptionalBearer, appendOptionalHeader } from '@/entrypoints/service/auth';
+
+describe('可选 API 鉴权请求头', () => {
+    it('没有令牌时不发送伪造的 Bearer 请求头', () => {
+        const headers = new Headers();
+        appendOptionalBearer(headers, '  ');
+        expect(headers.has('Authorization')).toBe(false);
+    });
+
+    it('有令牌时保留标准鉴权请求头', () => {
+        const headers = new Headers();
+        appendOptionalBearer(headers, ' secret-token ');
+        expect(headers.get('Authorization')).toBe('Bearer secret-token');
+    });
+
+    it('可选的非 Bearer 鉴权头同样跳过空值', () => {
+        const headers = new Headers();
+        appendOptionalHeader(headers, 'x-api-key', '');
+        expect(headers.has('x-api-key')).toBe(false);
+    });
+});

--- a/tests/configValidation.test.ts
+++ b/tests/configValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
+import { getApiKeyRequirementKey, getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
 import { services } from '@/entrypoints/utils/option';
 
 describe('翻译服务凭据校验', () => {
@@ -8,6 +8,32 @@ describe('翻译服务凭据校验', () => {
         expect(getMissingCredentialMessage(services.openai, { token: {} })).toContain('API Key');
         expect(getMissingCredentialMessage(services.openai, { token: { [services.openai]: '  ' } })).toContain('API Key');
         expect(getMissingCredentialMessage(services.openai, { token: { [services.openai]: 'configured' } })).toBeNull();
+    });
+
+    it('明确指出 DeepSeek 缺少 API Key', () => {
+        expect(getMissingCredentialMessage(services.deepseek, { token: {} })).toBe(
+            'DeepSeek 需要 API Key（访问令牌），当前尚未配置；请先在设置中填写，再开始翻译。',
+        );
+        expect(getMissingCredentialMessage(services.deepseek, { token: { [services.deepseek]: 'configured' } })).toBeNull();
+    });
+
+    it('允许按当前模型关闭 API Key 校验', () => {
+        const config = {
+            model: { [services.deepseek]: 'deepseek-v4-flash' },
+            requireApiKey: { [`${services.deepseek}:deepseek-v4-flash`]: false },
+            token: {},
+        };
+        expect(getApiKeyRequirementKey(services.deepseek, config)).toBe('deepseek:deepseek-v4-flash');
+        expect(getMissingCredentialMessage(services.deepseek, config)).toBeNull();
+    });
+
+    it('切换模型后不会复用另一个模型的免 Key设置', () => {
+        const config = {
+            model: { [services.deepseek]: 'deepseek-v4-pro' },
+            requireApiKey: { [`${services.deepseek}:deepseek-v4-flash`]: false },
+            token: {},
+        };
+        expect(getMissingCredentialMessage(services.deepseek, config)).toContain('API Key');
     });
 
     it('保留 DeepLX 可选令牌的行为', () => {


### PR DESCRIPTION
## 变更
- 为每个 AI 服务/模型增加默认开启的 API Key 要求开关
- DeepSeek 等服务缺少 Key 时在 popup、设置页和翻译前显示友好提示
- 关闭开关后跳过凭据校验，并省略空的鉴权请求头

## 验证
- pnpm test（180 tests）
- pnpm compile
- pnpm build
- 隔离 Microsoft Edge：DeepSeek 无 Key 提示、开关默认开启、关闭后提示消失并持久化

基于 origin/main，提交 5573bcf。

## Summary by Sourcery

通过为每个服务和每个模型引入 API 密钥需求控制（默认开启），并将其整合到弹窗、后台和翻译流程中的凭证检查中，实现更精细的控制。

New Features:
- 在服务配置界面中新增「按服务 / 按模型的 API 密钥是否必需」开关，对 AI 服务默认开启。
- 在弹窗和设置中，当缺少必需的密钥时（例如 DeepSeek），显示更友好的凭证警告，并在问题解决前阻止翻译执行。

Enhancements:
- 在配置模型中持久化 API 密钥需求设置，并在加载配置时对其进行规范化处理。
- 改进凭证校验消息，使其包含具体服务名称，并在弹窗、后台和页面翻译 API 中复用这些消息。
- 通过集中处理可选授权请求头，避免发送空或占位符的授权头，并相应更新多个服务客户端。
- 优化错误消息映射，使与缺少 API 密钥相关的问题在 UI 中呈现得更清晰。

Tests:
- 添加测试，覆盖 DeepSeek 缺少密钥时的提示信息，以及在切换模型时针对「按模型 API 密钥需求」行为的验证。
- 添加针对「可选授权请求头」辅助函数的测试，确保空令牌不会生成授权请求头。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce per-service and per-model API key requirement control, defaulting to required and integrated into credential checks across popup, background, and translation flows.

New Features:
- Add a per-service and per-model API key requirement switch in the service configuration UI, default-on for AI services.
- Show user-friendly credential warnings (e.g., for DeepSeek) in the popup and settings when required keys are missing, blocking translation until resolved.

Enhancements:
- Persist API key requirement settings in the config model and normalize them when loading configuration.
- Improve credential validation messages to include the specific service name and reuse them across popup, background, and page translation APIs.
- Avoid sending empty or placeholder authorization headers by centralizing optional auth header handling and updating multiple service clients accordingly.
- Refine error message mapping to surface missing-API-key issues more clearly in the UI.

Tests:
- Add tests covering DeepSeek missing-key messaging and per-model API key requirement behavior when switching models.
- Add tests for optional auth header helpers to ensure empty tokens do not produce authorization headers.

</details>