### PR TITLE
重构 FluentRead 网页配置提示

### DIFF
--- a/entrypoints/style.css
+++ b/entrypoints/style.css
@@ -47,6 +47,152 @@
     cursor: pointer;
 }
 
+/* FluentRead 页面提示：避免把配置问题渲染成宿主网页的巨大红色报错。 */
+.fluent-read-message.el-message {
+    box-sizing: border-box;
+    display: flex !important;
+    align-items: center !important;
+    width: min(480px, calc(100vw - 32px));
+    min-height: 58px;
+    padding: 10px 12px 10px 10px;
+    border: 1px solid #e8dff0;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, .98);
+    box-shadow: 0 12px 30px rgba(39, 29, 55, .14), 0 0 0 4px rgba(239, 71, 118, .07);
+    color: #273247;
+}
+
+.fluent-read-message,
+.fluent-read-message * {
+    box-sizing: border-box;
+}
+
+.fluent-read-message .el-message__icon {
+    display: grid;
+    flex: 0 0 auto;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    margin-right: 10px;
+    border-radius: 10px;
+    color: #fff;
+    background: linear-gradient(145deg, #f35482, #dc315f);
+}
+
+.fluent-read-notice-mark {
+    display: block;
+    width: 30px !important;
+    height: 30px !important;
+    border-radius: 9px;
+    object-fit: cover;
+}
+
+.fluent-read-message .el-message__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0;
+    color: inherit;
+    line-height: 1.4;
+}
+
+.fluent-read-notice-copy {
+    display: flex;
+    flex: 1 1 0%;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+    width: 0;
+}
+
+.fluent-read-notice-heading {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    font-size: 11px;
+}
+
+.fluent-read-notice-brand {
+    color: #dc315f;
+    font-weight: 800;
+}
+
+.fluent-read-notice-divider {
+    color: #b0a7b8;
+}
+
+.fluent-read-notice-title {
+    color: #737c8f;
+    font-weight: 700;
+}
+
+.fluent-read-notice-body {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.fluent-read-notice-detail {
+    overflow-wrap: anywhere;
+    color: #273247;
+    font-size: 13px;
+    font-weight: 550;
+}
+
+.fluent-read-notice-action {
+    flex: 0 0 auto;
+    padding: 3px 8px;
+    border: 1px solid rgba(180, 107, 0, .28);
+    border-radius: 7px;
+    color: #a86500;
+    background: rgba(255, 255, 255, .72);
+    font: inherit;
+    font-size: 11px;
+    font-weight: 800;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.fluent-read-notice-action:hover,
+.fluent-read-notice-action:focus-visible {
+    border-color: rgba(180, 107, 0, .46);
+    background: #fff;
+    outline: none;
+}
+
+.fluent-read-message .el-message__closeBtn {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    justify-content: center;
+    align-self: center;
+    width: 20px;
+    height: 20px;
+    margin-left: 8px;
+    color: #9da4b2;
+}
+
+.fluent-read-message .el-message__closeBtn svg {
+    width: 14px !important;
+    height: 14px !important;
+}
+
+.fluent-read-message-credential.el-message {
+    border-color: #f0d49f;
+    background: linear-gradient(135deg, #fffdf8, #fff9ef);
+    box-shadow: 0 12px 30px rgba(122, 86, 20, .13), 0 0 0 4px rgba(243, 209, 158, .16);
+}
+
+.fluent-read-message-credential .fluent-read-notice-title,
+.fluent-read-message-credential .fluent-read-notice-detail {
+    color: #795b27;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .fluent-read-message.el-message { transition: none; }
+}
+
 /* 图片翻译覆盖层：翻译完成后用同尺寸位图层覆盖原图，避免原文字从译文下面透出。 */
 .fluent-read-image-translation-overlay {
     position: fixed;

--- a/entrypoints/utils/tip.ts
+++ b/entrypoints/utils/tip.ts
@@ -1,15 +1,74 @@
 import {ElMessage} from "element-plus";
+import {h} from "vue";
 import {throttle} from "@/entrypoints/utils/common";
 
-// deprecated
-const prefix = "";
+function isCredentialMessage(message: string): boolean {
+    return /API Key|访问令牌/.test(message);
+}
+
+function getNoticeTitle(message: string, type: 'error' | 'success', credential: boolean): string {
+    if (credential) return '配置提醒';
+    return type === 'success' ? '操作完成' : '翻译提醒';
+}
+
+function getNoticeDetail(message: string, credential: boolean): string {
+    if (!credential) return message;
+
+    const service = message.match(/^(.+?) 需要 API Key/)?.[1];
+    return service
+        ? `还差一步：为 ${service} 填写 API Key，就可以开始翻译了。`
+        : '还差一步：填写 API Key，就可以继续翻译了。';
+}
+
+function createNoticeContent(message: string, type: 'error' | 'success', credential: boolean) {
+    const detail = getNoticeDetail(message, credential);
+    return h('span', {class: 'fluent-read-notice-copy'}, [
+        h('span', {class: 'fluent-read-notice-heading'}, [
+            h('strong', {class: 'fluent-read-notice-brand'}, '流畅阅读'),
+            h('span', {class: 'fluent-read-notice-divider', 'aria-hidden': 'true'}, '·'),
+            h('span', {class: 'fluent-read-notice-title'}, getNoticeTitle(message, type, credential)),
+        ]),
+        h('span', {class: 'fluent-read-notice-body'}, [
+            h('span', {class: 'fluent-read-notice-detail'}, detail),
+            credential
+                ? h('button', {
+                    class: 'fluent-read-notice-action',
+                    type: 'button',
+                    onClick: () => {
+                        void browser.runtime.sendMessage({type: 'openOptionsPage'});
+                    },
+                }, '去设置')
+                : null,
+        ]),
+    ]);
+}
+
+function sendMessage(message: string, type: 'error' | 'success'): void {
+    const credential = isCredentialMessage(message);
+    const tone = credential ? 'warning' : type;
+
+    ElMessage({
+        message: createNoticeContent(message, type, credential),
+        type: tone,
+        icon: () => h('img', {
+            class: 'fluent-read-notice-mark',
+            src: browser.runtime.getURL('/icon/48.png'),
+            alt: '流畅阅读',
+        }),
+        customClass: `fluent-read-message${credential ? ' fluent-read-message-credential' : ''}`,
+        showClose: true,
+        duration: credential ? 6500 : 3500,
+        offset: 18,
+        plain: true,
+    });
+}
 
 function _sendErrorMessage(message: string) {
-    ElMessage({message: prefix + message, type: 'error'});
+    sendMessage(message, 'error');
 }
 
 function _sendSuccessMessage(message: string) {
-    ElMessage({message: prefix + message, type: 'success'});
+    sendMessage(message, 'success');
 }
 
 // 使用防抖函数包装，1s 内只能发送一次消息

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
         ],
         web_accessible_resources: [
             {
-                resources: ['icon/32.png', 'icon/128.png'],
+                resources: ['icon/32.png', 'icon/48.png', 'icon/128.png'],
                 matches: ['<all_urls>'],
             },
         ],


### PR DESCRIPTION
## 变更

- 将网页内的 API Key 提示重构为 FluentRead 品牌化顶部 toast。
- 使用现有 FluentRead 图标，显示“流畅阅读 · 配置提醒”。
- 将提示文案改为更友好的“还差一步”表达，并提供“去设置”按钮。
- 增加宿主网页样式隔离，避免网页全局 SVG/CSS 拉伸通知控件。

## 验证

- `pnpm compile`
- `pnpm test`（17 个测试文件，180 项通过）
- `pnpm build`
- 隔离临时 Edge 真实网页验证：品牌图标加载、toast 布局、无控制台错误，以及“去设置”打开 options 页面。

## Summary by Sourcery

重新设计页面内通知系统，改用带有 FluentRead 品牌风格的 toast，并配备定制内容和样式，从而改进 API 密钥配置指引，并减少与宿主页面的视觉冲突。

New Features:
- 引入品牌化的 FluentRead toast 通知用于页面内消息，包括带有直接跳转到选项页快捷方式的 API 密钥配置提醒。

Enhancements:
- 优化通知文案与视觉样式，以更友好、干扰更小的方式展示配置和翻译状态。
- 为 FluentRead 通知应用隔离样式，以避免被宿主页面的 SVG/CSS 规则干扰。

Build:
- 将 48px 扩展图标暴露为 Web 可访问资源，以便在页面内通知中使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revamp the in-page notification system to use a FluentRead-branded toast with tailored content and styling, improving API key configuration guidance and reducing visual conflicts with host pages.

New Features:
- Introduce a branded FluentRead toast notification for in-page messages, including API key configuration reminders with a direct shortcut to the options page.

Enhancements:
- Refine notification copy and visual styling to present configuration and translation status in a friendlier, less intrusive way.
- Apply isolated styles for FluentRead notifications to avoid interference from host page SVG/CSS rules.

Build:
- Expose the 48px extension icon as a web-accessible resource for use in in-page notifications.

</details>