### PR TITLE
refactor: audit architecture and remove dead code

### DIFF
--- a/components/CustomHotkeyInput.vue
+++ b/components/CustomHotkeyInput.vue
@@ -104,9 +104,9 @@
 
 <script setup lang="ts" name="CustomHotkeyInput">
 import { ref, computed, nextTick, watch } from 'vue';
-import { ElDialog, ElButton, ElText, ElIcon, ElCollapse, ElCollapseItem } from 'element-plus';
+import { ElDialog, ElButton, ElText, ElIcon } from 'element-plus';
 import { Loading, WarningFilled, Warning, CircleCheckFilled } from '@element-plus/icons-vue';
-import { parseHotkey, matchesHotkey, validateHotkeyConflicts, type ParsedHotkey } from '@/entrypoints/utils/hotkey';
+import { parseHotkey, validateHotkeyConflicts, type ParsedHotkey } from '@/entrypoints/utils/hotkey';
 
 // Props
 interface Props {

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -617,11 +617,6 @@ const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/Custom
 import ServiceCatalog from '@/components/ServiceCatalog.vue';
 import ServiceConfiguration from '@/components/ServiceConfiguration.vue';
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
-import {
-  isCustomBodyMapping,
-  isValidCustomBody,
-} from '@/entrypoints/utils/custom-body';
-import {DEEPLX_ENDPOINT_PRESETS, parseDeepLXEndpoints} from '@/entrypoints/utils/deeplx';
 import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
 import { getApiKeyRequirementKey, getMissingCredentialMessage, isApiKeyRequired } from '@/entrypoints/utils/configValidation';
 import {
@@ -668,7 +663,6 @@ function updateTheme(theme: string) {
 
 // 配置信息
 const config = ref(new Config());
-const selectedDeepLXPreset = ref('');
 const persistConfig = (value: unknown) => requestConfigSave(value, browser.runtime.sendMessage.bind(browser.runtime));
 let lastSerialized = '';
 const imageOcrLanguagePacks = IMAGE_OCR_LANGUAGE_PACKS;
@@ -710,18 +704,6 @@ async function downloadImageOcrLanguages(languages: ImageOcrLanguageCode[]) {
     imageOcrDownloadingCodes.value = imageOcrDownloadingCodes.value.filter(code => !pending.includes(code));
   }
 }
-
-const appendDeepLXPreset = (endpoint: string | undefined) => {
-  if (!endpoint) {
-    return;
-  }
-
-  const endpoints = parseDeepLXEndpoints(config.value.deeplx);
-  if (!endpoints.includes(endpoint)) {
-    config.value.deeplx = [...endpoints, endpoint].join('\n');
-  }
-  selectedDeepLXPreset.value = '';
-};
 
 let hydrated = false;
 let applyingExternalConfig = false;
@@ -849,7 +831,7 @@ watch(() => config.value.theme, (newTheme) => {
 });
 
 // 使用 onchange 监听系统主题变化
-darkModeMediaQuery.onchange = (e) => {
+darkModeMediaQuery.onchange = () => {
   if (config.value.theme === 'auto') {
     updateTheme('auto');
   }
@@ -955,23 +937,6 @@ const handlePluginStateChange = (val: boolean) => {
       }).catch(() => {
         // 忽略发送失败的错误（可能是页面未加载内容脚本）
       });
-    });
-  });
-};
-
-// 处理悬浮球开关变化
-const toggleFloatingBall = (val: boolean) => {
-  // 向所有激活的标签页发送消息
-  browser.tabs.query({}).then(tabs => {
-    tabs.forEach(tab => {
-      if (tab.id) {
-        browser.tabs.sendMessage(tab.id, { 
-          type: 'toggleFloatingBall',
-          isEnabled: val 
-        }).catch(() => {
-          // 忽略发送失败的错误（可能是页面未加载内容脚本）
-        });
-      }
     });
   });
 };

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -3,10 +3,10 @@ import { constants } from "@/entrypoints/utils/constant";
 import { getCenterPoint } from "@/entrypoints/utils/common";
 import pageStyles from './style.css?inline';
 import { config, configReady } from "@/entrypoints/utils/config";
-import { mountFloatingBall, unmountFloatingBall, toggleFloatingBallPosition } from "@/entrypoints/utils/floatingBall";
+import { mountFloatingBall, unmountFloatingBall } from "@/entrypoints/utils/floatingBall";
 import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoints/utils/selectionTranslator";
-import { cancelAllTranslations, translateText } from "@/entrypoints/utils/translateApi";
-import { mountNewApiComponent } from "@/entrypoints/utils/newApi";
+import { cancelAllTranslations } from "@/entrypoints/utils/translateApi";
+import { mountNewApiComponent, unmountNewApiComponent } from "@/entrypoints/utils/newApi";
 import { mountImageTranslator, unmountImageTranslator } from "@/entrypoints/utils/imageTranslation";
 import {
     getDeepActiveElement,
@@ -33,6 +33,80 @@ function installPageStyles(ctx: ContentScriptContext) {
     ctx.onInvalidated(() => style.remove());
 }
 
+function handleRuntimeMessage(
+    message: unknown,
+    ctx: ContentScriptContext,
+    sendResponse: (response?: unknown) => void,
+): boolean {
+    if (!message || typeof message !== 'object') return false;
+    const payload = message as Record<string, unknown>;
+
+    if (payload.message === 'clearCache') {
+        browser.runtime.sendMessage({ type: 'clearTranslationCache' })
+            .then(() => sendResponse())
+            .catch(() => sendResponse());
+        return true;
+    }
+
+    if (payload.type === 'toggleFloatingBall') {
+        const isEnabled = payload.isEnabled === true;
+        config.disableFloatingBall = !isEnabled;
+        if (isEnabled) {
+            void mountFloatingBall(ctx);
+        } else {
+            unmountFloatingBall();
+        }
+        sendResponse();
+        return true;
+    }
+
+    if (payload.type === 'updateSelectionTranslatorMode') {
+        const mode = payload.mode;
+        if (mode !== 'disabled' && mode !== 'bilingual' && mode !== 'translation-only') return false;
+
+        config.selectionTranslatorMode = mode;
+        config.disableSelectionTranslator = mode === 'disabled';
+        if (mode === 'disabled') {
+            unmountSelectionTranslator();
+        } else if (!document.getElementById('fluent-read-selection-translator-container')) {
+            void mountSelectionTranslator(ctx);
+        }
+        sendResponse();
+        return true;
+    }
+
+    if (payload.type === 'toggleImageTranslator') {
+        const isEnabled = payload.isEnabled === true;
+        config.disableImageTranslator = !isEnabled;
+        if (isEnabled) {
+            mountImageTranslator();
+        } else {
+            unmountImageTranslator();
+        }
+        sendResponse();
+        return true;
+    }
+
+    if (payload.type === 'contextMenuTranslate') {
+        if (config.on === false) {
+            sendResponse({ status: 'disabled' });
+            return true;
+        }
+        if (payload.action === 'fullPage') {
+            autoTranslateEnglishPage();
+            sendResponse({ status: 'success', action: 'translated' });
+            return true;
+        }
+        if (payload.action === 'restore') {
+            restoreOriginalContent();
+            sendResponse({ status: 'success', action: 'restored' });
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export default defineContentScript({
     matches: ['<all_urls>'],  // 匹配所有页面
     runAt: 'document_end',  // 在页面加载完成后运行
@@ -40,13 +114,35 @@ export default defineContentScript({
     async main(ctx) {
         contentScriptContext = ctx;
         installPageStyles(ctx);
-        await configReady // 等待配置加载完成
-        setupInputBoxTranslation();
+        await configReady; // 等待配置加载完成
+
+        const pageEventController = new AbortController();
+        let runtimeMessageListener: ((message: unknown, sender: unknown, sendResponse: (response?: unknown) => void) => boolean) | null = null;
+        let cleanedUp = false;
+        const cleanup = () => {
+            if (cleanedUp) return;
+            cleanedUp = true;
+            pageEventController.abort();
+            if (runtimeMessageListener) {
+                browser.runtime.onMessage.removeListener(runtimeMessageListener);
+            }
+            cancelAllTranslations();
+            unmountFloatingBall();
+            unmountSelectionTranslator();
+            unmountImageTranslator();
+            unmountNewApiComponent();
+            removeExistingTooltip();
+            contentScriptContext = null;
+        };
+        ctx.onInvalidated(cleanup);
+        window.addEventListener('beforeunload', cleanup, { once: true });
+
+        setupInputBoxTranslation(pageEventController.signal);
         if (config.on === false) return; // 如果配置关闭，则不执行任何操作
         // 添加手动翻译事件监听器
-        setupManualTranslationTriggers();
+        setupManualTranslationTriggers(pageEventController.signal);
         // 添加悬浮球快捷键事件监听器
-        setupFloatingBallHotkey();
+        setupFloatingBallHotkey(pageEventController.signal);
         // 当悬浮球关闭时，仍然允许使用快捷键进行全文翻译的独立开关
         let isFullPageTranslating = false;
         document.addEventListener('fluentread-toggle-translation', () => {
@@ -59,132 +155,38 @@ export default defineContentScript({
                     restoreOriginalContent();
                 }
             }
-        });
+        }, { signal: pageEventController.signal });
         // 添加自动翻译事件监听器
-        if (config.autoTranslate) autoTranslationEvent();
+        if (config.autoTranslate) autoTranslateEnglishPage();
 
         // 挂载悬浮球（如果配置未禁用）
         if (config.disableFloatingBall !== true) {
             // 使用配置中的位置
             await mountFloatingBall(ctx);
+            if (cleanedUp) return;
         }
         
         // 挂载划词翻译组件（如果配置未禁用）
         if (config.disableSelectionTranslator !== true) {
             await mountSelectionTranslator(ctx);
+            if (cleanedUp) return;
         }
         
         mountNewApiComponent();
         // 图片翻译使用独立覆盖层，不改写宿主页面的 img 元素；点击入口由事件委托处理动态图片。
         if (config.disableImageTranslator !== true) mountImageTranslator();
 
-        // background.ts
-        browser.runtime.onMessage.addListener((message: { message: string; }, sender: any, sendResponse: () => void) => {
-            if (message.message !== 'clearCache') {
-                sendResponse();
-                return true;
-            }
-
-            browser.runtime.sendMessage({ type: 'clearTranslationCache' })
-                .then(() => sendResponse())
-                .catch(() => sendResponse());
-            return true;
-        });
-        
-        // 处理悬浮球控制消息
-        browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: () => void) => {
-            if (message.type === 'toggleFloatingBall') {
-                // 弹窗修改的是存储配置，当前内容脚本还持有旧的内存配置。
-                // 先同步状态，否则启用时 mountFloatingBall 会被旧的禁用标记直接拦截。
-                const isEnabled = message.isEnabled === true;
-                config.disableFloatingBall = !isEnabled;
-                if (isEnabled) {
-                    void mountFloatingBall(ctx);
-                } else {
-                    unmountFloatingBall();
-                }
-                sendResponse();
-                return true;
-            }
-            return false;
-        });
-        
-        // 处理划词翻译控制消息
-        browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: () => void) => {
-            if (message.type === 'updateSelectionTranslatorMode') {
-                // 更新配置
-                config.selectionTranslatorMode = message.mode;
-                config.disableSelectionTranslator = message.mode === 'disabled';
-                
-                if (message.mode === 'disabled') {
-                    unmountSelectionTranslator();
-                } else {
-                    // 如果之前没有挂载，现在挂载
-                    if (!document.getElementById('fluent-read-selection-translator-container')) {
-                        void mountSelectionTranslator(ctx);
-                    }
-                }
-                sendResponse();
-                return true;
-            }
-            return false;
-        });
-
-        // 处理图片翻译控制消息
-        browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: () => void) => {
-            if (message.type === 'toggleImageTranslator') {
-                config.disableImageTranslator = message.isEnabled !== true;
-                if (message.isEnabled === true) {
-                    mountImageTranslator();
-                } else {
-                    unmountImageTranslator();
-                }
-                sendResponse();
-                return true;
-            }
-            return false;
-        });
-        
-        // 处理右键菜单触发的全文翻译和撤销
-        browser.runtime.onMessage.addListener((message: any, sender: any, sendResponse: (response?: any) => void) => {
-            if (message.type === 'contextMenuTranslate') {
-                // 检查插件是否已启用
-                if (config.on === false) {
-                    sendResponse({ status: 'disabled' });
-                    return true;
-                }
-                
-                if (message.action === 'fullPage') {
-                    // 触发全文翻译
-                    autoTranslateEnglishPage();
-                    sendResponse({ status: 'success', action: 'translated' });
-                    return true;
-                } else if (message.action === 'restore') {
-                    // 撤销翻译，恢复原文
-                    restoreOriginalContent();
-                    sendResponse({ status: 'success', action: 'restored' });
-                    return true;
-                }
-            }
-            return false;
-        });
-        
-        // 在页面卸载时清理资源
-        window.addEventListener('beforeunload', () => {
-            // 取消所有待处理的翻译任务
-            cancelAllTranslations();
-            // 移除悬浮球
-            unmountFloatingBall();
-            // 移除划词翻译组件
-            unmountSelectionTranslator();
-            unmountImageTranslator();
-            removeExistingTooltip();
-        });
+        runtimeMessageListener = (
+            message: unknown,
+            _sender: unknown,
+            sendResponse: (response?: unknown) => void,
+        ) => handleRuntimeMessage(message, ctx, sendResponse);
+        browser.runtime.onMessage.addListener(runtimeMessageListener);
     }
 })
 
 // 注册所有手动翻译触发事件监听器
-function setupManualTranslationTriggers() {
+function setupManualTranslationTriggers(signal: AbortSignal) {
     const screen = { mouseX: 0, mouseY: 0, hotkeyPressed: false, otherKeyPressed: false, hasSlideTranslation: false };
     let mouseHotkeysPressed = new Set<string>();
     
@@ -235,7 +237,7 @@ function setupManualTranslationTriggers() {
         screen.otherKeyPressed = false;
         screen.hasSlideTranslation = false;
         mouseHotkeysPressed.clear();
-    });
+    }, { signal });
 
     // 2. 按下按键时
     window.addEventListener('keydown', event => {
@@ -299,7 +301,7 @@ function setupManualTranslationTriggers() {
         } else if (screen.hotkeyPressed) {
             screen.otherKeyPressed = true;
         }
-    });
+    }, { signal });
 
     // 3. 抬起按键时
     window.addEventListener('keyup', event => {
@@ -343,9 +345,6 @@ function setupManualTranslationTriggers() {
         if (!event.metaKey) mouseHotkeysPressed.delete('control');
         if (!event.shiftKey) mouseHotkeysPressed.delete('shift');
         
-        // 获取当前配置的快捷键
-        const hotkeyParts = getConfiguredMouseHotkeyParts();
-        
         // 如果当前按键集合为空，且之前激活了快捷键，且配置的快捷键不包含当前释放的键，则触发翻译
         if (screen.hotkeyPressed && mouseHotkeysPressed.size === 0 && !screen.otherKeyPressed && !screen.hasSlideTranslation) {
             // 检查插件是否开启
@@ -360,7 +359,7 @@ function setupManualTranslationTriggers() {
             screen.otherKeyPressed = false;
             screen.hasSlideTranslation = false;
         }
-    });
+    }, { signal });
 
     // 4. 鼠标移动时更新位置，并根据 hotkeyPressed 决定是否触发翻译
     document.body.addEventListener('mousemove', event => {
@@ -370,7 +369,7 @@ function setupManualTranslationTriggers() {
             screen.hasSlideTranslation = true;
             handleTranslation(screen.mouseX, screen.mouseY, 50)
         }
-    });
+    }, { signal });
 
     // 5、手机端触摸事件，取中心点翻译
     document.body.addEventListener('touchstart', event => {
@@ -393,7 +392,7 @@ function setupManualTranslationTriggers() {
         if (config.on) {
             handleTranslation(coordinate!.x, coordinate!.y);
         }
-    });
+    }, { signal });
 
     // 6、双击鼠标翻译事件
     document.body.addEventListener('dblclick', event => {
@@ -404,12 +403,12 @@ function setupManualTranslationTriggers() {
             // 调用 handleTranslation 函数进行翻译
             handleTranslation(mouseX, mouseY);
         }
-    });
+    }, { signal });
 
     // 7、长按鼠标翻译事件（长按事件时鼠标不能移动）
     let timer: number;
     let startPos = { x: 0, y: 0 }; // startPos 记录鼠标按下时的位置
-    document.body.addEventListener('mouseup', () => clearTimeout(timer));
+    document.body.addEventListener('mouseup', () => clearTimeout(timer), { signal });
     document.body.addEventListener('mousedown', event => {
         if (config.hotkey === constants.LongPress) {
             clearTimeout(timer); // 清除之前的计时器
@@ -423,22 +422,13 @@ function setupManualTranslationTriggers() {
                 }
             }, 500) as unknown as number;
         }
-    });
+    }, { signal });
     document.body.addEventListener('mousemove', event => {
         // 如果鼠标移动超过10像素，取消长按事件
         if (Math.abs(event.clientX - startPos.x) > 10 || Math.abs(event.clientY - startPos.y) > 10) {
             clearTimeout(timer);
         }
-    });
-    document.body.addEventListener('mousemove', event => {
-        // 检测鼠标是否移动，如果鼠标移动超过10像素，取消长按事件
-        if (config.hotkey === constants.LongPress
-            && Math.abs(event.clientX - startPos.x) > 10 || Math.abs(event.clientY - startPos.y) > 10) {
-            clearTimeout(timer);
-        }
-    });
-
-
+    }, { signal });
     // 8、鼠标中键翻译事件
     document.body.addEventListener('mousedown', event => {
         if (config.hotkey === constants.MiddleClick && config.on) {
@@ -448,7 +438,7 @@ function setupManualTranslationTriggers() {
                 handleTranslation(mouseX, mouseY);
             }
         }
-    });
+    }, { signal });
 
 
     // 9、触屏设备双击/三击翻译事件
@@ -475,11 +465,16 @@ function setupManualTranslationTriggers() {
                 handleTranslation(event.touches[0].clientX, event.touches[0].clientY);
             }
         }
-    });
+    }, { signal });
+
+    signal.addEventListener('abort', () => {
+        clearTimeout(timer);
+        clearTimeout(touchTimer);
+    }, { once: true });
 }
 
-        // 设置全文翻译快捷键（与悬浮球解耦）
-function setupFloatingBallHotkey() {
+// 设置全文翻译快捷键（与悬浮球解耦）
+function setupFloatingBallHotkey(signal: AbortSignal) {
     // 如果快捷键设置为 "none"，则禁用快捷键
     if (config.floatingBallHotkey === 'none') return;
 
@@ -604,7 +599,7 @@ function setupFloatingBallHotkey() {
                 console.log(`[FluentRead] 触发悬浮球翻译，快捷键: ${activeHotkey}`);
             }
         }
-    });
+    }, { signal });
     
     // 监听按键释放事件
     document.addEventListener('keyup', (event) => {
@@ -647,24 +642,18 @@ function setupFloatingBallHotkey() {
         if (!event.ctrlKey) hotkeysPressed.delete('control');
         if (!event.metaKey) hotkeysPressed.delete('control');
         if (!event.shiftKey) hotkeysPressed.delete('shift');
-    });
+    }, { signal });
     
     // 页面失焦或切换标签页时，清除所有按键状态
     window.addEventListener('blur', () => {
         hotkeysPressed.clear();
-    });
-}
-
-// 注册自动翻译事件
-function autoTranslationEvent() {
-    // 自动翻译英文页面
-    autoTranslateEnglishPage();
+    }, { signal });
 }
 
 /**
  * 输入框翻译功能
  */
-function setupInputBoxTranslation() {
+function setupInputBoxTranslation(signal: AbortSignal) {
     let keyPressCount = 0;
     let keyPressTimer: ReturnType<typeof setTimeout> | null = null;
     let lastInputElement: HTMLElement | null = null;
@@ -738,11 +727,8 @@ function setupInputBoxTranslation() {
     };
 
     // 使用捕获阶段，兼容会在冒泡阶段停止传播键盘事件的富文本编辑器。
-    document.addEventListener('keydown', handleKeyDown, true);
-    contentScriptContext?.onInvalidated(() => {
-        document.removeEventListener('keydown', handleKeyDown, true);
-        resetKeyPresses();
-    });
+    document.addEventListener('keydown', handleKeyDown, { capture: true, signal });
+    signal.addEventListener('abort', resetKeyPresses, { once: true });
 }
 
 /**
@@ -940,8 +926,6 @@ async function translateWithMicrosoft(text: string, targetLang: string): Promise
  * 处理输入框翻译
  */
 async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
-    let tooltip: HTMLElement | null = null;
-    
     try {
         const originalText = getInputBoxText(element);
         
@@ -958,7 +942,7 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
         
         // 显示翻译中的动画和提示
         addInputBoxAnimation(element, 'translating');
-        tooltip = await createTranslationTooltip(element, '微软翻译中', 'translating');
+        await createTranslationTooltip(element, '微软翻译中', 'translating');
         
         try {
             // 直接调用微软翻译API，不使用缓存
@@ -974,20 +958,20 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
                 // 显示成功动画和提示
                 addInputBoxAnimation(element, 'success');
                 removeExistingTooltip();
-                tooltip = await createTranslationTooltip(element, '翻译成功', 'success');
+                await createTranslationTooltip(element, '翻译成功', 'success');
             } else {
                 // 翻译结果与原文相同或为空
                 element.classList.remove('fluent-input-translating');
                 addInputBoxAnimation(element, 'error');
                 removeExistingTooltip();
-                tooltip = await createTranslationTooltip(element, '内容无需翻译', 'error');
+                await createTranslationTooltip(element, '内容无需翻译', 'error');
             }
         } catch (translationError) {
             // 翻译失败
             element.classList.remove('fluent-input-translating');
             addInputBoxAnimation(element, 'error');
             removeExistingTooltip();
-            tooltip = await createTranslationTooltip(element, '微软翻译失败', 'error');
+            await createTranslationTooltip(element, '微软翻译失败', 'error');
             console.error('微软翻译失败:', translationError);
         }
         
@@ -1003,7 +987,7 @@ async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
         // 显示错误动画和提示
         addInputBoxAnimation(element, 'error');
         removeExistingTooltip();
-        tooltip = await createTranslationTooltip(element, '翻译服务暂时不可用', 'error');
+        await createTranslationTooltip(element, '翻译服务暂时不可用', 'error');
         
         // 自动隐藏错误提示
         setTimeout(() => removeExistingTooltip(), 3000);

--- a/entrypoints/main/compat.ts
+++ b/entrypoints/main/compat.ts
@@ -2,10 +2,7 @@
 
 import {findMatchingElement} from "@/entrypoints/utils/common";
 
-type ReplaceFunction = (node: any, text: any) => any;
 type SelectFunction = (node: any) => any | {skip: boolean} | false;
-
-const parser = new DOMParser();
 
 // 调试相关
 const isDev = process.env.NODE_ENV === 'development';
@@ -52,10 +49,6 @@ function debugLog(type: string, message: string, ...args: any[]): void {
     // 常规日志输出
     console.log(prefix, color, message, ...args);
   }
-}
-
-interface ReplaceCompatFn {
-    [domain: string]: ReplaceFunction;
 }
 
 interface SelectCompatFn {
@@ -157,52 +150,6 @@ function isSpecialContent(text: string): boolean {
     
     return false;
 }
-
-// 文本替换环节的兼容函数，主域名 : 兼容函数
-export const replaceCompatFn: ReplaceCompatFn = {
-    ["youtube.com"]: (node: any, text: any) => {
-        // 使用DOMParser解析翻译后的HTML
-        const doc = parser.parseFromString(text, 'text/html');
-        const newNode = doc.body.firstChild as HTMLElement;
-        
-        // 针对YouTube特有的格式化字符串进行特殊处理
-        if (node.tagName.toLowerCase() === 'yt-formatted-string') {
-            // 尝试保留原有的属性和样式
-            if (node.hasAttribute('has-link-only_')) {
-                node.innerHTML = newNode.innerHTML;
-                return;
-            }
-            
-            // 处理具有特殊格式的内容
-            if (node.querySelector('a') || node.querySelector('span')) {
-                // 尝试保留链接和格式，但更新文本内容
-                const links = node.querySelectorAll('a');
-                const spans = node.querySelectorAll('span');
-                
-                if (links.length > 0 || spans.length > 0) {
-                    // 创建临时元素存储新文本
-                    const tempDiv = document.createElement('div');
-                    tempDiv.innerHTML = newNode.innerHTML;
-                    
-                    // 保留原有的链接和格式元素
-                    node.childNodes.forEach((child: Node) => {
-                        if (child.nodeType === Node.ELEMENT_NODE) {
-                            // 保留原有的HTML元素
-                            if (child.nodeName.toLowerCase() === 'a' || child.nodeName.toLowerCase() === 'span') {
-                                // 更新元素内容，但保留属性
-                                (child as HTMLElement).textContent = tempDiv.textContent || '';
-                            }
-                        }
-                    });
-                    return;
-                }
-            }
-        }
-        
-        // 默认处理：直接替换innerHTML
-        node.innerHTML = newNode.innerHTML;
-    }
-};
 
 // 元素 node 选择环节的兼容函数
 export const selectCompatFn: SelectCompatFn = {

--- a/entrypoints/main/dom.ts
+++ b/entrypoints/main/dom.ts
@@ -1,5 +1,4 @@
 import { getMainDomain, selectCompatFn } from "@/entrypoints/main/compat";
-import { html } from 'js-beautify';
 
 // 语义块标签只用于识别候选内容块；真正的块级判断还会结合 computed style。
 const directSet = new Set([
@@ -19,7 +18,7 @@ const structuralIgnoreSet = new Set(['header', 'footer', 'nav', 'aside']);
 const controlSet = new Set(['button']);
 
 // 内联元素集合（可以包含在其他元素内的元素）
-export const inlineSet = new Set([
+const inlineSet = new Set([
     'a', 'b', 'strong', 'span', 'em', 'i', 'u', 'small', 'sub', 'sup',
     'font', 'mark', 'cite', 'q', 'abbr', 'time', 'ruby', 'bdi', 'bdo',
     'code', 'kbd', 'samp', 'var', 'img', 'br', 'wbr', 'svg'
@@ -561,49 +560,17 @@ export function LLMStandardHTML(node: any) {
     return text;
 }
 
-export function beautyHTML(text: string): string {
-    // 1. 先替换 SVG 中的大小写敏感词
-    // 2. 再使用 js-beautify 格式化 HTML
-    text = replaceSensitiveWords(text);
-    return html(text)
-}
-
-// 替换 svg 标签中的一些大小写敏感的词（html 不区分大小写，但 svg 标签区分大小写）
-function replaceSensitiveWords(text: string): string {
-    // 1. 使用正则匹配大小写敏感词
-    // 2. 逐个替换为正确大小写形式
-    return text.replace(/viewbox|preserveaspectratio|clippathunits|gradienttransform|patterncontentunits|lineargradient|clippath/gi, (match) => {
-        switch (match.toLowerCase()) {
-            case 'viewbox':
-                return 'viewBox';
-            case 'preserveaspectratio':
-                return 'preserveAspectRatio';
-            case 'clippathunits':
-                return 'clipPathUnits';
-            case 'gradienttransform':
-                return 'gradientTransform';
-            case 'patterncontentunits':
-                return 'patternContentUnits';
-            case 'lineargradient':
-                return 'linearGradient';
-            case 'clippath':
-                return 'clipPath';
-            default:
-                return match;
-        }
-    });
-}
-
 // 移除特定样式
-export function checkAndRemoveStyle(node: any, styleProperty: any) {
+function checkAndRemoveStyle(node: HTMLElement, styleProperty: string) {
     // 1. 若节点存在样式且对应属性不为 undefined，则清空该属性
-    if (node.style && node.style[styleProperty] !== undefined) {
-        node.style[styleProperty] = '';
+    const style = node.style as unknown as Record<string, string | undefined>;
+    if (style[styleProperty] !== undefined) {
+        style[styleProperty] = '';
     }
 }
 
 // 移除截断样式
-export function smashTruncationStyle(node: any) {
+export function smashTruncationStyle(node: HTMLElement) {
     // 1. 先调用 checkAndRemoveStyle 移除 webkitLineClamp 属性
     // 2. 将节点的相关样式设为 'unset'
     checkAndRemoveStyle(node, 'webkitLineClamp');

--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -33,12 +33,6 @@ import {
     setTranslatedHTML,
 } from "@/entrypoints/main/translationState";
 
-/**
- * 兼容旧调用方保留的导出。新的实现不再使用 innerHTML 字符串作为节点身份，
- * 实际恢复由 translationState 的 WeakMap + 原始 ChildNode 快照负责。
- */
-export const originalContents = new Map<string, string>();
-
 const TRANSLATION_ARTIFACT_SELECTOR = [
     ".fluent-read-bilingual-content",
     ".fluent-read-loading",
@@ -495,7 +489,6 @@ export function restoreOriginalContent(): void {
     stopFullPageSession();
     cancelAllTranslations();
     restoreAllTranslations();
-    originalContents.clear();
 
     // 兼容升级前遗留的 wrapper/属性；新状态机不会依赖这些标记，但旧页面
     // 不应在扩展热更新后留下半截译文。
@@ -574,8 +567,4 @@ export function handleSingleTranslation(node: unknown, slide: boolean): void {
     const target = asHTMLElement(node);
     if (!target) return;
     void translateTarget(target, "single", slide);
-}
-
-export function singleTranslate(node: unknown): void {
-    handleSingleTranslation(node, false);
 }

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -214,7 +214,7 @@ async function handleTranslationRequest(data: any): Promise<string> {
 }
 
 // 监听来自 background script 的消息
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     // console.log('Offscreen 收到消息:', message);
     
     if (message.type === 'CHROME_TRANSLATE_OFFSCREEN') {

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -14,7 +14,6 @@ import {
   ElInput,
   ElInputNumber,
   ElLink,
-  ElMessage,
   ElOption,
   ElOptionGroup,
   ElRow,

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -21,7 +21,6 @@ import {
   ElTooltip,
   ElEmpty,
   ElIcon,
-  ElMessage,
   ElLink,
   ElText,
   ElButton,

--- a/entrypoints/service/azure-openai.ts
+++ b/entrypoints/service/azure-openai.ts
@@ -1,4 +1,4 @@
-import {method, urls} from "../utils/constant";
+import {method} from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";

--- a/entrypoints/service/coze.ts
+++ b/entrypoints/service/coze.ts
@@ -1,4 +1,3 @@
-import {Config} from "../utils/model";
 import {method, urls} from "../utils/constant";
 import {cozeTemplate} from "@/entrypoints/utils/template";
 import {config} from "@/entrypoints/utils/config";

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -1,4 +1,4 @@
-import { method, urls } from "../utils/constant";
+import { method } from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import { config } from "@/entrypoints/utils/config";
 import { contentPostHandler } from "@/entrypoints/utils/check";

--- a/entrypoints/service/tencent.ts
+++ b/entrypoints/service/tencent.ts
@@ -1,5 +1,4 @@
 import { method } from "../utils/constant";
-import { services } from "../utils/option";
 import { config } from "@/entrypoints/utils/config";
 
 // 腾讯云机器翻译语言代码映射

--- a/entrypoints/utils/check.ts
+++ b/entrypoints/utils/check.ts
@@ -69,21 +69,6 @@ export function hasRetryTag(node: Node): boolean {
     return false;
 }
 
-// Search for a node with a specific class name
-export function searchClassName(node: Node, className: string): Node | null {
-    if (node instanceof Element && node.classList.contains(className)) return node;
-
-    // Check children only if the node is an Element
-    if (node instanceof Element) {
-        for (let child of node.children) {
-            let result = searchClassName(child, className);
-            if (result) return result;
-        }
-    }
-
-    return null;
-}
-
 export function contentPostHandler(text: string) {
     // Never render model reasoning tags in translated page content.
     return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();

--- a/entrypoints/utils/declare.d.ts
+++ b/entrypoints/utils/declare.d.ts
@@ -1,2 +1,1 @@
 declare module 'entrypoints/utils/declare';
-declare module 'js-beautify';

--- a/entrypoints/utils/floatingBall.ts
+++ b/entrypoints/utils/floatingBall.ts
@@ -14,12 +14,8 @@ let mountRequestId = 0;
 let contentScriptContext: ContentScriptContext | null = null;
 let isTranslated = false; // 添加状态变量跟踪翻译状态
 
-/**
- * 创建并挂载悬浮球
- * @param position 悬浮球位置 'left' | 'right'，如果不传入则使用配置中的值
- * @returns 
- */
-export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' | 'right') {
+/** 创建并挂载悬浮球 */
+export function mountFloatingBall(ctx?: ContentScriptContext) {
   if (ctx) contentScriptContext = ctx;
 
   // 如果配置禁用了悬浮球或已存在实例，则不创建
@@ -29,8 +25,7 @@ export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' 
 
   if (!contentScriptContext) return;
 
-  // 使用传入的位置参数或配置中的位置
-  const ballPosition = position || config.floatingBallPosition || 'right';
+  const ballPosition = config.floatingBallPosition || 'right';
   const requestId = ++mountRequestId;
   // 更新配置
   config.floatingBallPosition = ballPosition;
@@ -88,17 +83,6 @@ export function mountFloatingBall(ctx?: ContentScriptContext, position?: 'left' 
 }
 
 /**
- * 切换悬浮球翻译状态
- * 通过键盘快捷键触发时使用
- */
-export function toggleFloatingBallTranslation() {
-  if (!floatingBallInstance) return;
-  // 快捷键与鼠标点击必须复用组件的同一条状态切换路径。
-  // 组件会负责更新 aria-pressed、展开提示和回调翻译生命周期。
-  document.dispatchEvent(new CustomEvent('fluentread-toggle-translation'));
-}
-
-/**
  * 卸载悬浮球
  */
 export function unmountFloatingBall() {
@@ -114,37 +98,4 @@ export function unmountFloatingBall() {
     floatingBallInstance = null;
     app = null;
   }
-}
-
-/**
- * 切换悬浮球可见性
- */
-export function toggleFloatingBall() {
-  if (floatingBallInstance) {
-    unmountFloatingBall();
-    config.disableFloatingBall = true;
-  } else {
-    config.disableFloatingBall = false;
-    mountFloatingBall();
-  }
-  
-  // 保存配置到存储
-  void saveConfig().catch((error) => console.error('Failed to save config:', error));
-}
-
-/**
- * 切换悬浮球位置
- */
-export function toggleFloatingBallPosition() {
-  const newPosition = config.floatingBallPosition === 'left' ? 'right' : 'left';
-  if (floatingBallInstance) {
-    unmountFloatingBall();
-    config.floatingBallPosition = newPosition;
-    mountFloatingBall(undefined, newPosition);
-  } else {
-    config.floatingBallPosition = newPosition;
-  }
-  
-  // 保存配置到存储
-  void saveConfig().catch((error) => console.error('Failed to save config:', error));
 }

--- a/entrypoints/utils/hotkey.ts
+++ b/entrypoints/utils/hotkey.ts
@@ -269,8 +269,6 @@ export function validateHotkeyConflicts(parsedHotkey: ParsedHotkey): {
   }
 
   const { modifiers, key } = parsedHotkey;
-  const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-
   // 常见的系统快捷键冲突检测
   const commonConflicts = [
     // Windows/Linux 系统快捷键
@@ -324,24 +322,3 @@ export function validateHotkeyConflicts(parsedHotkey: ParsedHotkey): {
 
   return { hasConflict: false };
 }
-
-/**
- * 预设的快捷键选项
- */
-export const PRESET_HOTKEYS = [
-  { value: "Alt+T", label: "Alt+T / Option+T" },
-  { value: "Alt+A", label: "Alt+A / Option+A" },
-  { value: "Alt+S", label: "Alt+S / Option+S" },
-  { value: "Alt+D", label: "Alt+D / Option+D" },
-  { value: "Alt+Q", label: "Alt+Q / Option+Q" },
-  { value: "Ctrl+Alt+T", label: "Ctrl+Alt+T / Control+Option+T" },
-  { value: "Ctrl+Alt+A", label: "Ctrl+Alt+A / Control+Option+A" },
-  { value: "Ctrl+Shift+T", label: "Ctrl+Shift+T / Control+Shift+T" },
-  { value: "Ctrl+Shift+A", label: "Ctrl+Shift+A / Control+Shift+A" },
-  { value: "F9", label: "F9" },
-  { value: "F10", label: "F10" },
-  { value: "F11", label: "F11" },
-  { value: "F12", label: "F12" },
-  { value: "none", label: "禁用快捷键" },
-  { value: "custom", label: "自定义快捷键..." },
-];

--- a/entrypoints/utils/icon.ts
+++ b/entrypoints/utils/icon.ts
@@ -7,7 +7,7 @@ import {
 } from "@/entrypoints/main/trans";
 import { config } from "@/entrypoints/utils/config";
 import { styles } from "@/entrypoints/utils/constant";
-import { services, options } from "./option";
+import { options } from "./option";
 
 const icon = {
   retry: `<svg fill="none" viewBox="0 0 40 40" height="40" width="40" style="display: inline; align-items: center; justify-content: center; width: 1em; height: 1em; margin-left: 1em; pointer-events: none;">

--- a/entrypoints/utils/selectionTranslator.ts
+++ b/entrypoints/utils/selectionTranslator.ts
@@ -1,5 +1,5 @@
 import SelectionTranslator from '@/components/SelectionTranslator.vue';
-import { config, saveConfig } from '@/entrypoints/utils/config';
+import { config } from '@/entrypoints/utils/config';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
 import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
@@ -58,22 +58,4 @@ export function unmountSelectionTranslator() {
     selectionTranslatorInstance = null;
     app = null;
   }
-}
-
-/**
- * 切换选词翻译组件的启用状态
- */
-export function toggleSelectionTranslator() {
-  if (selectionTranslatorInstance) {
-    unmountSelectionTranslator();
-    config.disableSelectionTranslator = true;
-  } else {
-    config.disableSelectionTranslator = false;
-    mountSelectionTranslator();
-  }
-  
-  // 保存配置到存储
-  void saveConfig().catch((error) => {
-    console.error('Failed to save config:', error);
-  });
 }

--- a/entrypoints/utils/tip.ts
+++ b/entrypoints/utils/tip.ts
@@ -6,7 +6,7 @@ function isCredentialMessage(message: string): boolean {
     return /API Key|访问令牌/.test(message);
 }
 
-function getNoticeTitle(message: string, type: 'error' | 'success', credential: boolean): string {
+function getNoticeTitle(type: 'error' | 'success', credential: boolean): string {
     if (credential) return '配置提醒';
     return type === 'success' ? '操作完成' : '翻译提醒';
 }
@@ -26,7 +26,7 @@ function createNoticeContent(message: string, type: 'error' | 'success', credent
         h('span', {class: 'fluent-read-notice-heading'}, [
             h('strong', {class: 'fluent-read-notice-brand'}, '流畅阅读'),
             h('span', {class: 'fluent-read-notice-divider', 'aria-hidden': 'true'}, '·'),
-            h('span', {class: 'fluent-read-notice-title'}, getNoticeTitle(message, type, credential)),
+            h('span', {class: 'fluent-read-notice-title'}, getNoticeTitle(type, credential)),
         ]),
         h('span', {class: 'fluent-read-notice-body'}, [
             h('span', {class: 'fluent-read-notice-detail'}, detail),
@@ -67,10 +67,5 @@ function _sendErrorMessage(message: string) {
     sendMessage(message, 'error');
 }
 
-function _sendSuccessMessage(message: string) {
-    sendMessage(message, 'success');
-}
-
 // 使用防抖函数包装，1s 内只能发送一次消息
 export const sendErrorMessage = throttle(_sendErrorMessage, 1000);
-export const sendSuccessMessage = throttle(_sendSuccessMessage, 1000);

--- a/entrypoints/utils/translateQueue.ts
+++ b/entrypoints/utils/translateQueue.ts
@@ -7,10 +7,7 @@ import { config } from './config';
 
 // 队列状态
 let activeTranslations = 0; // 当前活跃的翻译任务数量
-let pendingTranslations: Array<() => Promise<any>> = []; // 等待执行的翻译任务队列
-
-// 调试相关
-const isDev = process.env.NODE_ENV === 'development';
+let pendingTranslations: Array<() => Promise<unknown>> = []; // 等待执行的翻译任务队列
 
 // 获取最大并发翻译数量
 function getMaxConcurrentTranslations(): number {
@@ -47,7 +44,7 @@ export function enqueueTranslation<T>(translationTask: () => Promise<T>): Promis
     if (activeTranslations < getMaxConcurrentTranslations()) {
       // 直接执行任务
       activeTranslations++;
-      taskWrapper();
+      void taskWrapper().catch(() => undefined);
     } else {
       pendingTranslations.push(taskWrapper);
     }
@@ -78,14 +75,4 @@ export function clearTranslationQueue() {
   
   pendingTranslations = [];
   // 不重置activeTranslations，让活跃的翻译任务自然完成
-}
-
-/**
- * 检查是否可以添加更多任务
- * 当快速扫描页面，判断是否需要暂停扫描时使用
- */
-export function canAcceptMoreTasks(): boolean {
-  // 如果等待队列太长，返回false表示需要暂停扫描
-  const MAX_QUEUE_LENGTH = getMaxConcurrentTranslations() * 3;
-  return pendingTranslations.length < MAX_QUEUE_LENGTH;
 }

--- a/package.json
+++ b/package.json
@@ -21,14 +21,12 @@
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",
-    "@floating-ui/dom": "^1.7.4",
     "@wxt-dev/storage": "^1.0.1",
     "crypto-js": "^4.2.0",
     "defuddle": "^0.19.2",
     "dexie": "^4.4.4",
     "element-plus": "^2.9.3",
     "franc-min": "^6.2.0",
-    "js-beautify": "^1.15.1",
     "tesseract.js": "^6.0.1",
     "webextension-polyfill": "^0.12.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@element-plus/icons-vue':
         specifier: ^2.3.1
         version: 2.3.1(vue@3.5.13(typescript@5.7.3))
-      '@floating-ui/dom':
-        specifier: ^1.7.4
-        version: 1.7.4
       '@wxt-dev/storage':
         specifier: ^1.0.1
         version: 1.0.1
@@ -35,9 +32,6 @@ importers:
       franc-min:
         specifier: ^6.2.0
         version: 6.2.0
-      js-beautify:
-        specifier: ^1.15.1
-        version: 1.15.1
       tesseract.js:
         specifier: ^6.0.1
         version: 6.0.1
@@ -583,10 +577,6 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -628,13 +618,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@one-ini/wasm@0.1.1':
-    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1105,10 +1088,6 @@ packages:
     resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
 
-  abbrev@2.0.0:
-    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   acorn@8.14.0:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
@@ -1469,10 +1448,6 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
-
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -1540,6 +1515,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
@@ -1759,14 +1735,6 @@ packages:
   duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  editorconfig@1.0.4:
-    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   element-plus@2.9.3:
     resolution: {integrity: sha512-6tSLp5XytDS4TMZ0P3aGZnr7MXTagfNycepNfIDitd9IgwM9y01+Ssu6mglNi8RiXYhek6LBWNOd/cvpIO12+w==}
     peerDependencies:
@@ -1780,9 +1748,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2126,10 +2091,6 @@ packages:
   focus-trap@7.6.4:
     resolution: {integrity: sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==}
 
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
-    engines: {node: '>=14'}
-
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
     engines: {node: '>= 18'}
@@ -2229,13 +2190,9 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    hasBin: true
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -2608,9 +2565,6 @@ packages:
     resolution: {integrity: sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==}
     engines: {node: '>= 4'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2624,15 +2578,6 @@ packages:
     resolution: {integrity: sha512-WohhhHhqe22de7PU8hXs6Sr5d4BAvkrfA93NR5tGlHyPnFLgvEW/bH+q7fv65JgoiQDsd7SBwwQ/OGRBivU3Mw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  js-beautify@1.15.1:
-    resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2788,9 +2733,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -2909,20 +2851,12 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.1.1:
     resolution: {integrity: sha512-b3YZEYCEH4EdCAtYP7OlDyx7FdPwNzuNwLQ34SfJpM9dlbBZzeXndGavTrC+VCiRWomL21SWfMc6SCKO/U2ZNw==}
@@ -2987,11 +2921,6 @@ packages:
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
-
-  nopt@7.2.1:
-    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -3152,9 +3081,6 @@ packages:
     resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
     engines: {node: '>=4'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
@@ -3204,10 +3130,6 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@1.1.0:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
@@ -3681,10 +3603,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -4200,10 +4118,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -4650,15 +4564,6 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@mdit-vue/plugin-component@2.1.3':
@@ -4722,11 +4627,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
-
-  '@one-ini/wasm@0.1.1': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -5280,8 +5180,6 @@ snapshots:
   '@xmldom/xmldom@0.9.11':
     optional: true
 
-  abbrev@2.0.0: {}
-
   acorn@8.14.0: {}
 
   adm-zip@0.5.16: {}
@@ -5666,8 +5564,6 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander@10.0.1: {}
-
   commander@12.1.0: {}
 
   commander@2.9.0:
@@ -5982,15 +5878,6 @@ snapshots:
 
   duplexer3@0.1.5: {}
 
-  eastasianwidth@0.2.0: {}
-
-  editorconfig@1.0.4:
-    dependencies:
-      '@one-ini/wasm': 0.1.1
-      commander: 10.0.1
-      minimatch: 9.0.1
-      semver: 7.6.3
-
   element-plus@2.9.3(vue@3.5.13(typescript@5.7.3)):
     dependencies:
       '@ctrl/tinycolor': 3.6.1
@@ -6017,8 +5904,6 @@ snapshots:
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   end-of-stream@1.4.4:
     dependencies:
@@ -6376,11 +6261,6 @@ snapshots:
     dependencies:
       tabbable: 6.2.0
 
-  foreground-child@3.3.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   formdata-node@6.0.3: {}
 
   franc-min@6.2.0:
@@ -6480,15 +6360,6 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
-
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.0
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -6859,12 +6730,6 @@ snapshots:
       has-to-string-tag-x: 1.4.1
       is-object: 1.0.2
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   jiti@2.6.1: {}
 
   jpegtran-bin@5.0.2:
@@ -6877,16 +6742,6 @@ snapshots:
     dependencies:
       bin-build: 3.0.0
       bin-wrapper: 4.1.0
-
-  js-beautify@1.15.1:
-    dependencies:
-      config-chain: 1.1.13
-      editorconfig: 1.0.4
-      glob: 10.4.5
-      js-cookie: 3.0.5
-      nopt: 7.2.1
-
-  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
@@ -7045,8 +6900,6 @@ snapshots:
       longest: 1.0.1
       meow: 3.7.0
 
-  lru-cache@10.4.3: {}
-
   lru-cache@4.1.5:
     dependencies:
       pseudomap: 1.0.2
@@ -7176,17 +7029,11 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@9.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
-
-  minipass@7.1.2: {}
 
   minisearch@7.1.1: {}
 
@@ -7247,10 +7094,6 @@ snapshots:
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
-
-  nopt@7.2.1:
-    dependencies:
-      abbrev: 2.0.0
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -7436,8 +7279,6 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  package-json-from-dist@1.0.1: {}
-
   package-json@10.0.1:
     dependencies:
       ky: 1.8.2
@@ -7482,11 +7323,6 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
 
   path-type@1.1.0:
     dependencies:
@@ -7960,12 +7796,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
 
   string-width@7.2.0:
     dependencies:
@@ -8569,12 +8399,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- remove unused legacy translation and UI code
- unify content-script runtime messages and event cleanup
- remove dead component toggles and unused dependencies

## Validation
- `pnpm compile`
- `pnpm exec vue-tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `pnpm test` (17 files, 180 tests)
- `pnpm build`
- real Edge toggle test: counts `[1, 0, 1]`, neighbor counts `[0, 0, 0]`

## Summary by Sourcery

移除旧版的 content-script 翻译架构和 UI 连接逻辑，改用更简化的运行时；同时在主进程、弹出页和设置页入口中裁剪未使用的集成代码和废弃的功能开关。

Enhancements:
- 通过移除旧版 DOM/兼容性逻辑以及集中式队列/检查辅助工具，简化 content-script 的翻译流程。
- 从主 Vue 组件和工具方法中移除未使用的浮动球、划词翻译和自定义快捷键相关的 UI 粘合代码。
- 清理 offscreen、service adapter 和快捷键工具，以与当前的翻译后端接口保持一致。
- 精简弹出页/设置页的启动逻辑以及 Element Plus 相关接线，使之与缩减后的配置范围相匹配。

Chores:
- 更新或重新生成项目元数据和锁定文件，以反映依赖和构建方面的变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove legacy content-script translation architecture and UI wiring in favor of a simplified runtime, trimming unused integrations and dead feature toggles across main, popup, and options entrypoints.

Enhancements:
- Simplify content-script translation flow by removing legacy DOM/compat logic and centralised queue/check helpers.
- Drop unused floating-ball, selection-translator, and custom hotkey UI glue code from main Vue components and utilities.
- Clean up offscreen, service adapter, and hotkey utilities to align with the current translation backend surface.
- Trim popup/options bootstrapping and Element Plus wiring to match the reduced configuration surface.

Chores:
- Bump or regenerate project metadata and lockfile to reflect dependency and build changes.

</details>