### PR TITLE
fix: support custom endpoint models

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -660,7 +660,7 @@
 
 // Main 处理配置信息
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
-import { models, options, resolveConfiguredModel, servicesType, defaultOption } from "../entrypoints/utils/option";
+import { customModelString, models, options, resolveConfiguredModel, servicesType, defaultOption } from "../entrypoints/utils/option";
 import { Config, normalizeConfig } from "@/entrypoints/utils/model";
 import { InfoFilled, Refresh, Edit, Upload, Download } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
@@ -863,7 +863,7 @@ const createServiceCompute = (serviceSource: ServiceSource) => ({
   showCustomModel: computed(
     () =>
       servicesType.isAI(serviceSource.value) &&
-      config.value.model[serviceSource.value] === '自定义模型',
+      config.value.model[serviceSource.value] === customModelString,
   ),
   filteredServices,
   showRobotId: computed(() => servicesType.isCoze(serviceSource.value)),

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -174,7 +174,7 @@ const isValidAzureEndpoint = toRef(props, 'isValidAzureEndpoint')
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin: 0 1em 10px;
+  margin: 0 0 10px;
   padding: 12px 16px;
   border: 1px solid #edf0f5;
   border-radius: 16px;

--- a/entrypoints/utils/serviceCatalog.ts
+++ b/entrypoints/utils/serviceCatalog.ts
@@ -1,3 +1,5 @@
+import { customModelString } from '@/entrypoints/utils/option'
+
 export interface ServiceOption {
   value: string
   label: string
@@ -57,14 +59,24 @@ export function filterModels(modelOptions: string[], query: string) {
 }
 
 export function splitModelOptions(modelOptions: string[], selectedModel = '', visibleCount = 4) {
-  const common = modelOptions.slice(0, visibleCount)
+  // 自定义模型是一个输入入口，不应因为当前选中而被提到常用模型区。
+  // 即使调用方传入的列表顺序不稳定，也要保证它在完整列表的最后。
+  const regularModels = modelOptions.filter((model) => model !== customModelString)
+  const customModels = modelOptions.filter((model) => model === customModelString)
+  const orderedModels = [...regularModels, ...customModels]
+  const common = orderedModels.slice(0, visibleCount)
 
-  if (selectedModel && modelOptions.includes(selectedModel) && !common.includes(selectedModel)) {
+  if (
+    selectedModel
+    && selectedModel !== customModelString
+    && orderedModels.includes(selectedModel)
+    && !common.includes(selectedModel)
+  ) {
     common.splice(Math.max(visibleCount - 1, 0), 1, selectedModel)
   }
 
   return {
     common,
-    more: modelOptions.filter((model) => !common.includes(model)),
+    more: orderedModels.filter((model) => !common.includes(model)),
   }
 }

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -66,6 +66,13 @@ describe('service catalog helpers', () => {
     })
   })
 
+  it('keeps the custom model as the last option when it is selected', () => {
+    expect(splitModelOptions(['one', 'two', 'three', customModelString, 'four'], customModelString)).toEqual({
+      common: ['one', 'two', 'three', 'four'],
+      more: [customModelString],
+    })
+  })
+
   it('does not create a more group for a short model list', () => {
     expect(splitModelOptions(['one', 'two'], 'two')).toEqual({
       common: ['one', 'two'],

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -35,7 +35,7 @@ import {
     normalizeCustomBodyMapping,
 } from '@/entrypoints/utils/custom-body';
 import { buildHunyuanTranslationRequestBody } from '@/entrypoints/service/hunyuan-translation';
-import { services, servicesType } from '@/entrypoints/utils/option';
+import { customModelString, services, servicesType } from '@/entrypoints/utils/option';
 
 beforeEach(() => {
     // 每个用例前重置 mock 配置，避免相互污染
@@ -181,10 +181,18 @@ describe('commonMsgTemplate（集成）', () => {
     });
 
     it('选择“自定义模型”时使用 customModel 的值', () => {
-        mockConfig.model = { openai: '自定义模型' };
+        mockConfig.model = { openai: customModelString };
         mockConfig.customModel = { openai: 'gpt-4o-mini' };
         const body = JSON.parse(commonMsgTemplate('hello'));
         expect(body.model).toBe('gpt-4o-mini');
+    });
+
+    it('自定义接口选择自定义模型时使用 customModel 的值', () => {
+        mockConfig.service = services.custom;
+        mockConfig.model = { [services.custom]: customModelString };
+        mockConfig.customModel = { [services.custom]: 'local/translation-model' };
+        const body = JSON.parse(commonMsgTemplate('hello'));
+        expect(body.model).toBe('local/translation-model');
     });
 
     it('非法的自定义请求体被忽略，标准请求体保持完整', () => {


### PR DESCRIPTION
## Summary
- keep 自定义模型 as the final model option, including when selected
- use the configured custom model identifier in custom endpoint requests
- align the API Key policy card with the connection parameter rows

## Validation
- pnpm test (19 files, 196 tests)
- pnpm compile
- pnpm build
- isolated Microsoft Edge production-extension regression: custom model ordering, storage persistence, default/editing service state, API Key alignment, and no console errors
- repository UI suite still has pre-existing stale assertions for 4 popup cards and 6 navigation buttons; the focused regression passed

## Summary by Sourcery

确保自定义模型始终作为最后一个特殊选项处理，同时在所有服务中正确使用已配置的自定义标识符，并对齐 API 密钥策略的布局。

新特性：
- 支持使用已配置的自定义模型标识符进行自定义端点请求。

错误修复：
- 即使自定义模型被选中，也保持其在模型列表中的最后一项位置。
- 在配置和 UI 逻辑中一致使用共享的自定义模型哨兵字符串，以避免不匹配。
- 将 API 密钥策略卡片布局与周围的连接参数行对齐。

测试：
- 扩展集成测试和服务目录测试，以覆盖自定义端点模型选择和自定义模型选项排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure custom models are consistently treated as a special last-option entry while correctly using configured custom identifiers for all services and aligning the API key policy layout.

New Features:
- Support custom endpoint requests using the configured custom model identifier.

Bug Fixes:
- Keep the custom model option as the final entry in model lists even when selected.
- Use the shared custom model sentinel string consistently in configuration and UI logic to avoid mismatches.
- Align the API key policy card layout with surrounding connection parameter rows.

Tests:
- Extend integration and service catalog tests to cover custom endpoint model selection and custom model option ordering.

</details>