### PR TITLE
fix: show all models when expanded

### DIFF
--- a/components/ServiceCatalog.vue
+++ b/components/ServiceCatalog.vue
@@ -73,7 +73,13 @@
               <strong>{{ modelQuery ? '搜索结果' : moreModelsOpen ? '全部模型' : '常用模型' }}</strong>
               <span>{{ displayedModels.length }}</span>
             </div>
-            <div id="model-options" class="model-grid" role="listbox" aria-label="可用模型">
+            <div
+              id="model-options"
+              class="model-grid"
+              :class="{ expanded: moreModelsOpen || modelQuery }"
+              role="listbox"
+              aria-label="可用模型"
+            >
               <button
                 v-for="model in displayedModels"
                 :key="model"
@@ -219,6 +225,7 @@ watch(modelQuery, () => {
 .model-list-heading strong { font-size: 12px; }
 .model-list-heading span { font-size: 11px; }
 .model-grid { display: grid; min-height: 0; max-height: 246px; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; align-content: start; overflow-y: auto; padding: 1px 4px 4px 1px; }
+.model-grid.expanded { max-height: none; overflow-y: visible; }
 .model-item { display: grid; grid-template-columns: 30px minmax(0, 1fr) 16px; align-items: center; gap: 9px; min-width: 0; padding: 10px; border: 1px solid #e4e7ee; border-radius: 12px; color: #172033; background: #fff; text-align: left; cursor: pointer; transition: 150ms ease; }
 .model-item:hover { border-color: #f0a9bc; transform: translateY(-1px); }
 .model-item.active { border-color: #ef4776; background: #fff4f7; box-shadow: 0 7px 16px rgba(214, 50, 96, .08); }


### PR DESCRIPTION
## Summary
- show every model immediately after clicking 更多模型
- remove the model grid's internal scroll limit while expanded or searching

## Validation
- pnpm test (19 files, 196 tests)
- pnpm compile
- pnpm build
- isolated Microsoft Edge production-extension regression: 4 common models before expansion, all 9 models after expansion, expanded grid scrollHeight equals clientHeight, no console errors
- existing full/services UI suites are blocked by stale baseline assertions for popup card and navigation counts before reaching this scenario

## Summary by Sourcery

改进：
- 为模型网格添加一个“展开状态”类，当显示所有模型或搜索结果时，解除 `max-height` 和 `overflow` 限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add an expanded state class to the model grid to lift max-height and overflow constraints when showing all or searched models.

</details>