### PR TITLE
feat: 在 popup 显示当前 AI 模型

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -74,11 +74,18 @@
           :disabled="!config.on"
           aria-haspopup="listbox"
           :aria-expanded="servicePickerOpen"
-          aria-label="翻译服务"
+          :aria-label="servicePickerAriaLabel"
+          :data-selected-model="serviceModelLabel || undefined"
           @click="toggleServicePicker"
         >
           <ServiceIcon :service="config.service" :label="serviceLabel" />
-          <span class="service-copy"><small>翻译服务</small><strong>{{ serviceLabel }}</strong></span>
+          <span class="service-copy">
+            <small>翻译服务</small>
+            <span class="service-value">
+              <strong>{{ serviceLabel }}</strong>
+              <em v-if="serviceModelLabel" class="service-model">{{ serviceModelLabel }}</em>
+            </span>
+          </span>
           <span class="chevron" :class="{ open: servicePickerOpen }">⌄</span>
         </button>
 
@@ -376,6 +383,7 @@ import { Setting } from '@element-plus/icons-vue';
 import { Config } from '@/entrypoints/utils/model';
 import { options } from '@/entrypoints/utils/option';
 import { getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
+import { getSelectedModelLabel } from '@/entrypoints/utils/serviceCatalog';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
 type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance' | 'image' | 'video';
@@ -422,6 +430,10 @@ const popularServiceOptions = computed(() => popularServiceValues
 const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !popularServiceValues.includes(item.value)));
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
+const serviceModelLabel = computed(() => getSelectedModelLabel(config.value.service, config.value.model, config.value.customModel));
+const servicePickerAriaLabel = computed(() => serviceModelLabel.value
+  ? `翻译服务：${serviceLabel.value}，当前模型：${serviceModelLabel.value}`
+  : `翻译服务：${serviceLabel.value}`);
 const credentialWarning = computed(() => getMissingCredentialMessage(config.value.service, config.value));
 const videoServiceLabel = computed(() => videoServiceOptions.value.find((item: any) => item.value === config.value.videoService)?.label || config.value.videoService);
 const styleLabel = computed(() => styleOptions.value.find((item: any) => item.value === config.value.style)?.label || '默认样式');

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -83,7 +83,7 @@
             <small>翻译服务</small>
             <span class="service-value">
               <strong>{{ serviceLabel }}</strong>
-              <em v-if="serviceModelLabel" class="service-model">{{ serviceModelLabel }}</em>
+              <em v-if="serviceModelLabel" class="service-model" :title="serviceModelLabel">{{ serviceModelLabel }}</em>
             </span>
           </span>
           <span class="chevron" :class="{ open: servicePickerOpen }">⌄</span>

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -127,7 +127,10 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-field:disabled { cursor: not-allowed; opacity: .5; }
 .service-copy { display: flex; flex: 1; flex-direction: column; min-width: 0; }
 .service-copy small { color: var(--muted); font-size: 9px; }
-.service-copy strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.service-value { display: flex; min-width: 0; align-items: baseline; gap: 6px; }
+.service-copy strong, .service-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.service-copy strong { font-size: 12px; }
+.service-model { color: var(--muted); font-size: 9px; font-style: normal; font-weight: 600; }
 .chevron { position: absolute; right: 14px; color: var(--muted); font-size: 18px; line-height: 1; transform: translateY(-2px); transition: transform 160ms ease; }
 .chevron.open { transform: translateY(1px) rotate(180deg); }
 .service-picker-panel {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -128,9 +128,9 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-copy { display: flex; flex: 1; flex-direction: column; min-width: 0; }
 .service-copy small { color: var(--muted); font-size: 9px; }
 .service-value { display: flex; min-width: 0; align-items: baseline; gap: 6px; }
-.service-copy strong, .service-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.service-copy strong { font-size: 12px; }
-.service-model { color: var(--muted); font-size: 9px; font-style: normal; font-weight: 600; }
+.service-copy strong, .service-model { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.service-copy strong { max-width: 45%; flex: 0 0 auto; font-size: 12px; }
+.service-model { flex: 1 1 0; color: var(--muted); font-size: 9px; font-style: normal; font-weight: 600; }
 .chevron { position: absolute; right: 14px; color: var(--muted); font-size: 18px; line-height: 1; transform: translateY(-2px); transition: transform 160ms ease; }
 .chevron.open { transform: translateY(1px) rotate(180deg); }
 .service-picker-panel {

--- a/entrypoints/utils/serviceCatalog.ts
+++ b/entrypoints/utils/serviceCatalog.ts
@@ -1,4 +1,4 @@
-import { customModelString } from '@/entrypoints/utils/option'
+import { customModelString, resolveConfiguredModel, servicesType } from '@/entrypoints/utils/option'
 
 export interface ServiceOption {
   value: string
@@ -56,6 +56,18 @@ export function filterModels(modelOptions: string[], query: string) {
   const keyword = query.trim().toLocaleLowerCase()
   if (!keyword) return modelOptions
   return modelOptions.filter((model) => model.toLocaleLowerCase().includes(keyword))
+}
+
+export function getSelectedModelLabel(
+  service: string,
+  selectedModels: Record<string, string>,
+  customModels: Record<string, string>,
+) {
+  if (!servicesType.isUseModel(service)) return ''
+
+  const selectedModel = selectedModels[service]
+  const configuredModel = resolveConfiguredModel(selectedModel, customModels[service])
+  return configuredModel || (selectedModel === customModelString ? customModelString : '未选择模型')
 }
 
 export function splitModelOptions(modelOptions: string[], selectedModel = '', visibleCount = 4) {

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -4,6 +4,7 @@ import {
   cleanServiceLabel,
   filterModels,
   filterServiceGroups,
+  getSelectedModelLabel,
   splitModelOptions,
 } from '@/entrypoints/utils/serviceCatalog'
 import { customModelString, defaultModels, models, servicesType } from '@/entrypoints/utils/option'
@@ -78,6 +79,14 @@ describe('service catalog helpers', () => {
       common: ['one', 'two'],
       more: [],
     })
+  })
+
+  it('shows the effective model only for services that use model selection', () => {
+    expect(getSelectedModelLabel('microsoft', { microsoft: 'ignored' }, {})).toBe('')
+    expect(getSelectedModelLabel('openai', { openai: 'gpt-5-mini' }, {})).toBe('gpt-5-mini')
+    expect(getSelectedModelLabel('openai', { openai: customModelString }, { openai: 'local-model' })).toBe('local-model')
+    expect(getSelectedModelLabel('openai', { openai: customModelString }, {})).toBe(customModelString)
+    expect(getSelectedModelLabel('openai', {}, {})).toBe('未选择模型')
   })
 
   it('为所有需要模型的 AI 服务提供自定义模型入口', () => {


### PR DESCRIPTION
## 变更内容

- 在 popup 的翻译服务卡中，为需要模型选择的 AI 服务在服务名右侧显示当前生效模型。
- 自定义模型显示实际配置的模型标识；机器翻译和不需要模型的服务不显示模型小字。
- 同步补充服务选择器的可访问名称和当前模型数据标记。
- 为模型显示逻辑补充机器翻译、普通模型、自定义模型和缺失模型测试。

## 验证结果

- `pnpm test`：20 个测试文件、203 个测试通过。
- `pnpm compile`：通过。
- `pnpm build`：通过，产物为 `.output/chrome-mv3`。
- 生产 Edge 独立临时 profile 的 popup 专项：通过，无控制台错误；popup 400×600、无横向溢出。
- 新增定向 UI 断言：机器翻译不显示模型；切换 OpenAI 后显示 `gpt-5.6-sol`，可访问名称同步包含当前模型。
- 生产 `--suite full` 在既有服务页滚动断言处停止：当前模型网格展开后 `scrollHeight === clientHeight === 373`，与本次 popup 改动无关，已保留 popup 证据。
