### PR TITLE
fix: tune AI translation default models

### DIFF
--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -44,6 +44,8 @@ AI 翻译更适合需要上下文、术语一致性或风格控制的内容。�
 
 不同供应商对兼容接口的实现并不完全相同。如果请求失败，先用服务商官方示例验证地址、模型和密钥，再回到 FluentRead 检查配置。
 
+首次配置 AI 服务时，FluentRead 会按服务选择近期的推荐档位：除 OpenAI 兼容服务默认使用 GPT-5.6 Luna 外，其他服务优先采用成本友好的小型档位（例如 mini、flash、haiku 或 lite）；你仍可以在“模型列表”中手动切换模型。
+
 ## MiniMax
 
 MiniMax 同时提供按量付费 API 和 Token Plan 两类权益。两类 Key 不能互换；Token Plan Key 通常以 `sk-cp-` 开头，并且要求对应订阅仍然有效。在 MiniMax 服务配置中分别选择“按量付费（API）”或“Token Plan（套餐/积分）”，再选择 Key 所属的“中国版”或“全球版”（默认中国版）。FluentRead 会根据区域使用对应的 OpenAI 兼容 Chat Completions 地址，并在页面显示当前地址。

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -206,7 +206,7 @@ export function resolveConfiguredModel(selectedModel?: string, customModel?: str
 
 // 当前官方模型编号的单一来源，同时供列表和旧配置迁移使用。
 export const currentModelIds = {
-    openai: "gpt-5.6-sol",
+    openai: "gpt-5.6-luna",
     zhipu: "glm-5.3",
     zhipuFlash: "glm-4.5-flash",
     tongyiTokenPlan: "qwen3.8-max-preview",
@@ -229,33 +229,61 @@ export const currentModelIds = {
     infiniGeneral: "qwen3.6-27b",
 } as const;
 
+// 各 AI 服务的开箱默认模型优先选择近期、低延迟或低成本档位。
+// currentModelIds 仍作为官方编号与旧配置迁移的单一来源；用户仍可在模型列表中主动选择更大的模型。
+export const defaultModelIds = {
+    [services.openai]: currentModelIds.openai,
+    [services.azureOpenai]: currentModelIds.openai,
+    [services.gemini]: "gemini-3.6-flash",
+    [services.yiyan]: currentModelIds.yiyanFast,
+    [services.tongyi]: "qwen3.6-flash",
+    [services.zhipu]: currentModelIds.zhipuFlash,
+    [services.moonshot]: currentModelIds.moonshotCompatible,
+    [services.claude]: currentModelIds.claudeHaiku,
+    [services.custom]: currentModelIds.openai,
+    [services.infini]: currentModelIds.deepseek,
+    [services.baichuan]: "Baichuan-M3",
+    [services.lingyi]: "yi-lightning",
+    [services.deepseek]: currentModelIds.deepseek,
+    [services.minimax]: "MiniMax-M2.7-highspeed",
+    [services.jieyue]: currentModelIds.jieyue,
+    [services.huanYuan]: currentModelIds.huanYuan,
+    [services.huanYuanTranslation]: "hunyuan-translation-lite",
+    [services.newapi]: currentModelIds.openai,
+    [services.grok]: "grok-4.3",
+    [services.doubao]: "doubao-seed-1-6-250615",
+    [services.siliconCloud]: "deepseek-ai/DeepSeek-V4-Flash",
+    [services.groq]: currentModelIds.groqSmall,
+    [services.openrouter]: "google/gemini-3.6-flash",
+} as const;
+
 export const models = new Map<string, Array<string>>([
-    [services.openai, [currentModelIds.openai, "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
-    [services.azureOpenai, [currentModelIds.openai, "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
-    [services.gemini, ["gemini-3.6-flash", "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", customModelString]],
-    [services.yiyan, [currentModelIds.yiyan, "ernie-5.0-thinking-preview", "ernie-x1.1-preview", "ernie-4.5-turbo-128k", "ernie-4.5-21b-a3b", currentModelIds.yiyanFast, customModelString]],
-    [services.tongyi, [currentModelIds.tongyiTokenPlan, "qwen3.7-max", "qwen3.7-plus", "qwen3.6-flash", "qwen-mt-plus", "qwen-mt-turbo", "qwen-mt-flash", "qwen-mt-lite", "qwen-long-latest", customModelString]],
-    [services.zhipu, [currentModelIds.zhipu, "glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5", "glm-4.7", currentModelIds.zhipuFlash, customModelString]],
-    [services.moonshot, [currentModelIds.moonshot, "kimi-k2.7-code-highspeed", "kimi-k2.7-code", currentModelIds.moonshotCompatible, "kimi-k2.5", customModelString]],
-    [services.claude, [currentModelIds.claude, currentModelIds.claudeOpus, currentModelIds.claudeSonnet, currentModelIds.claudeHaiku, "claude-opus-4-8", "claude-sonnet-4-6", customModelString]],
-    [services.custom, [currentModelIds.openai, "gpt-5.4-mini", "gemini-3.6-flash", currentModelIds.claude, currentModelIds.deepseek, "gemma:7b", "llama2:7b", "mistral:7b", customModelString]],
-    [services.infini, [currentModelIds.deepseek, "deepseek-v4-pro", currentModelIds.infiniZhipu, "kimi-k2.7-code", currentModelIds.infiniGeneral, "qwen3.6-35b-a3b", customModelString]],
-    [services.baichuan, ["Baichuan-M3-Plus", "Baichuan-M3", "Baichuan4-Air", "Baichuan4-Turbo", "Baichuan4", customModelString]],
-    [services.lingyi, ["yi-lightning", customModelString]],
+    [services.openai, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
+    [services.azureOpenai, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4-nano", "gpt-5-mini", "gpt-5-nano", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", customModelString]],
+    [services.gemini, [defaultModelIds[services.gemini], "gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro", customModelString]],
+    [services.yiyan, [defaultModelIds[services.yiyan], currentModelIds.yiyan, "ernie-5.0-thinking-preview", "ernie-x1.1-preview", "ernie-4.5-turbo-128k", "ernie-4.5-21b-a3b", customModelString]],
+    [services.tongyi, [defaultModelIds[services.tongyi], currentModelIds.tongyiTokenPlan, "qwen3.7-max", "qwen3.7-plus", "qwen-mt-plus", "qwen-mt-turbo", "qwen-mt-flash", "qwen-mt-lite", "qwen-long-latest", customModelString]],
+    [services.zhipu, [defaultModelIds[services.zhipu], currentModelIds.zhipu, "glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5", "glm-4.7", customModelString]],
+    [services.moonshot, [defaultModelIds[services.moonshot], currentModelIds.moonshot, "kimi-k2.7-code-highspeed", "kimi-k2.7-code", "kimi-k2.5", customModelString]],
+    [services.claude, [defaultModelIds[services.claude], currentModelIds.claude, currentModelIds.claudeOpus, currentModelIds.claudeSonnet, "claude-opus-4-8", "claude-sonnet-4-6", customModelString]],
+    [services.custom, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gemini-3.6-flash", currentModelIds.claude, currentModelIds.deepseek, "gemma:7b", "llama2:7b", "mistral:7b", customModelString]],
+    [services.infini, [defaultModelIds[services.infini], "deepseek-v4-pro", currentModelIds.infiniZhipu, "kimi-k2.7-code", currentModelIds.infiniGeneral, "qwen3.6-35b-a3b", customModelString]],
+    [services.baichuan, [defaultModelIds[services.baichuan], "Baichuan-M3-Plus", "Baichuan4-Air", "Baichuan4-Turbo", "Baichuan4", customModelString]],
+    [services.lingyi, [defaultModelIds[services.lingyi], customModelString]],
     [services.deepseek, [currentModelIds.deepseek, "deepseek-v4-pro", customModelString]],
-    [services.minimax, [currentModelIds.minimax, "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", customModelString]],
+    [services.minimax, [defaultModelIds[services.minimax], currentModelIds.minimax, "MiniMax-M2.5", "MiniMax-M2.5-highspeed", customModelString]],
     [services.jieyue, [currentModelIds.jieyue, "step-3", "step-2", customModelString]],
     [services.huanYuan, [currentModelIds.huanYuan, "hy3-preview", customModelString]],
-    [services.huanYuanTranslation, ["hunyuan-translation", "hunyuan-translation-lite", customModelString]],
-    [services.newapi, [currentModelIds.openai, "gpt-5.4-mini", "gemini-3.6-flash", "gemini-3.5-flash-lite", currentModelIds.claude, currentModelIds.deepseek, "kimi-k2.7-code", customModelString]],
-    [services.grok, [currentModelIds.grok, "grok-4.3", customModelString]],
+    [services.huanYuanTranslation, [defaultModelIds[services.huanYuanTranslation], "hunyuan-translation", customModelString]],
+    [services.newapi, [currentModelIds.openai, "gpt-5.4-mini", "gpt-5.6-sol", "gemini-3.6-flash", "gemini-3.5-flash-lite", currentModelIds.claude, currentModelIds.deepseek, "kimi-k2.7-code", customModelString]],
+    [services.grok, [defaultModelIds[services.grok], currentModelIds.grok, customModelString]],
     [services.doubao, ["doubao-seed-1-6-250615", customModelString]],
 
     // mix model
-    [services.siliconCloud, ["deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash", "zai-org/GLM-5.2", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-R1", customModelString]],
+    [services.siliconCloud, [defaultModelIds[services.siliconCloud], "deepseek-ai/DeepSeek-V4-Pro", "zai-org/GLM-5.2", "Qwen/Qwen3.6-27B", "Qwen/Qwen3.6-35B-A3B", "deepseek-ai/DeepSeek-V3.2", "deepseek-ai/DeepSeek-R1", customModelString]],
 
-    [services.groq, [currentModelIds.groqLarge, currentModelIds.groqSmall, "qwen/qwen3.6-27b", customModelString]],
-    [services.openrouter, ["openrouter/auto", "openai/gpt-5.6-sol", "google/gemini-3.6-flash", "anthropic/claude-fable-5", "anthropic/claude-opus-5", "x-ai/grok-4.5", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k3", "z-ai/glm-5.2", customModelString]]
+    [services.groq, [defaultModelIds[services.groq], currentModelIds.groqLarge, "qwen/qwen3.6-27b", customModelString]],
+    [services.openrouter, [defaultModelIds[services.openrouter], "openrouter/auto", "openai/gpt-5.6-luna", "openai/gpt-5.6-sol", "anthropic/claude-fable-5", "anthropic/claude-opus-5", "x-ai/grok-4.5", "deepseek/deepseek-v4-pro", "moonshotai/kimi-k3", "z-ai/glm-5.2", customModelString]]
 ]);
 
 // 每个需要模型选择的 AI 服务都把列表第一项作为开箱即用的默认模型。

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Config, normalizeConfig } from '@/entrypoints/utils/model';
 import { MINIMAX_ENDPOINTS, tongyiTokenPlanUrl, urls } from '@/entrypoints/utils/constant';
-import { customModelString, defaultOption, models, options, resolveConfiguredModel, services, servicesType } from '@/entrypoints/utils/option';
+import { customModelString, defaultModelIds, defaultModels, defaultOption, models, options, resolveConfiguredModel, services, servicesType } from '@/entrypoints/utils/option';
 
 describe('AI 模型编号列表', () => {
     it('AI 智能上下文默认关闭，并能从旧配置平滑补齐', () => {
@@ -18,16 +18,17 @@ describe('AI 模型编号列表', () => {
     });
 
     it('展示当前主流模型，并移除已退役或错误的预设编号', () => {
-        expect(models.get(services.openai)?.at(0)).toBe('gpt-5.6-sol');
+        expect(models.get(services.openai)?.at(0)).toBe('gpt-5.6-luna');
+        expect(models.get(services.openai)).toContain('gpt-5.6-sol');
         expect(models.get(services.openai)).not.toContain('gpt5');
         expect(models.get(services.gemini)).toContain('gemini-3.6-flash');
         expect(models.get(services.claude)).toContain('claude-fable-5');
         expect(models.get(services.claude)).toContain('claude-sonnet-5');
         expect(models.get(services.claude)?.at(-1)).toBe(customModelString);
-        expect(models.get(services.tongyi)?.at(0)).toBe('qwen3.8-max-preview');
+        expect(models.get(services.tongyi)?.at(0)).toBe('qwen3.6-flash');
         expect(models.get(services.tongyi)).toContain('qwen3.7-max');
         expect(models.get(services.tongyi)).not.toContain('qwen3.7-flash');
-        expect(models.get(services.zhipu)?.at(0)).toBe('glm-5.3');
+        expect(models.get(services.zhipu)?.at(0)).toBe('glm-4.5-flash');
         expect(models.get(services.zhipu)).toContain('glm-5.2');
         expect(models.get(services.infini)).toContain('glm-5.2');
         expect(models.get(services.infini)).not.toContain('glm-5.3');
@@ -47,6 +48,13 @@ describe('AI 模型编号列表', () => {
         expect(options.services.every(option => !/[🌟⭐★]/u.test(option.label))).toBe(true);
         expect(servicesType.isMachine(services.freeTranslation)).toBe(true);
         expect(defaultOption.service).toBe(services.freeTranslation);
+    });
+
+    it('所有需要模型的 AI 服务默认使用推荐模型档位', () => {
+        for (const [service, defaultModel] of Object.entries(defaultModelIds)) {
+            expect(defaultModels.get(service), `${service} 默认模型`).toBe(defaultModel);
+            expect(models.get(service)?.at(0), `${service} 模型列表首项`).toBe(defaultModel);
+        }
     });
 
     it('不会把下拉列表中仍可选择的模型当成退役编号改写', () => {
@@ -89,7 +97,7 @@ describe('旧模型编号兼容迁移', () => {
         });
 
         expect(normalized.model).toMatchObject({
-            [services.openai]: 'gpt-5.6-sol',
+            [services.openai]: 'gpt-5.6-luna',
             [services.zhipu]: 'glm-4.5-flash',
             [services.moonshot]: 'kimi-k3',
             [services.claude]: 'claude-sonnet-5',

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -42,7 +42,7 @@ beforeEach(() => {
     mockConfig.service = 'openai';
     mockConfig.to = 'zh-Hans';
     mockConfig.model = {
-        openai: 'gpt-5.6-sol',
+        openai: 'gpt-5.6-luna',
         moonshot: 'kimi-k3',
         deepseek: 'deepseek-chat',
         gemini: 'gemini-3.6-flash',
@@ -172,7 +172,7 @@ describe('commonMsgTemplate（集成）', () => {
     it('未配置自定义请求体时，生成标准 OpenAI 请求体', () => {
         const body = JSON.parse(commonMsgTemplate('hello'));
         expect(body).toEqual({
-            model: 'gpt-5.6-sol',
+            model: 'gpt-5.6-luna',
             messages: [
                 { role: 'system', content: 'You are a translator.' },
                 { role: 'user', content: 'Translate to zh-Hans: hello' },
@@ -198,7 +198,7 @@ describe('commonMsgTemplate（集成）', () => {
     it('非法的自定义请求体被忽略，标准请求体保持完整', () => {
         mockConfig.customBody = { openai: '{oops' };
         const body = JSON.parse(commonMsgTemplate('hello'));
-        expect(body.model).toBe('gpt-5.6-sol');
+        expect(body.model).toBe('gpt-5.6-luna');
         expect(body.thinking).toBeUndefined();
         expect(body.messages).toHaveLength(2);
     });


### PR DESCRIPTION
## What changed

- Set OpenAI, Azure OpenAI, Custom, and New API defaults to `gpt-5.6-luna` per the latest product requirement.
- Keep `gpt-5.6-sol` and other models available for manual selection.
- Set other AI services to their recent low-cost, low-latency, or smaller recommended model variants where available.
- Keep new-config initialization, legacy migration, request templates, tests, and documentation aligned.

## Validation

- `pnpm test` — 21 files, 209 tests passed
- `pnpm compile` passed
- `pnpm build` passed
- `pnpm docs:build` passed
- Isolated production Edge proof: OpenAI active model `gpt-5.6-luna`, console errors 0

The full UI suite still encounters the existing stale assertion requiring an internal model-list scrollbar; the targeted production proof for this change passed.