### PR TITLE
fix: hide selection translator for special elements

### DIFF
--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -46,7 +46,7 @@ import browser from 'webextension-polyfill';
 import { config } from '@/entrypoints/utils/config';
 import { translateText } from '@/entrypoints/utils/translateApi';
 import { detectlang } from '@/entrypoints/utils/common';
-import { calculateSelectionPopupPosition, chooseSelectionRect, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
+import { calculateSelectionPopupPosition, chooseSelectionRect, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, shouldIgnoreSelection, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
 
 type SelectionTrigger = 'direct' | 'icon' | 'dot';
 type AudioKind = 'source' | 'translation';
@@ -101,6 +101,7 @@ function readSelectionSnapshot(): SelectionSnapshot | null {
   if (!text || text.length > 4096) return null;
 
   const range = selection.getRangeAt(0).cloneRange();
+  if (shouldIgnoreSelection(range)) return null;
   const rects = Array.from(range.getClientRects()).map(toSelectionRect).filter(rect => rect.width > 0 || rect.height > 0);
   const visualRects = rects.length > 0 ? rects : [toSelectionRect(range.getBoundingClientRect())];
   const isForward = selection.anchorNode === range.startContainer && selection.anchorOffset === range.startOffset;
@@ -370,11 +371,11 @@ onBeforeUnmount(() => {
 <style scoped>
 .fr-selection-translator-root { position: fixed; inset: 0; z-index: 2147483647; width: 100vw; height: 100vh; pointer-events: none; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #25252a; }
 .fr-selection-indicator, .fr-translation-tooltip, .fr-copy-success-toast { pointer-events: auto; }
-.fr-selection-indicator { position: fixed; width: 22px; height: 22px; padding: 0; border: 0; border-radius: 50%; transform: translate(-50%, -50%); background: #ef4b86; color: #fff; box-shadow: 0 3px 10px rgba(204, 40, 104, .3), 0 0 0 2px rgba(255, 255, 255, .94); cursor: pointer; transition: transform .14s ease, box-shadow .14s ease; }
-.fr-selection-indicator--dot { width: 10px; height: 10px; }
+.fr-selection-indicator { position: fixed; width: 18px; height: 18px; padding: 0; border: 0; border-radius: 50%; transform: translate(-50%, -50%); background: #ef4b86; color: #fff; box-shadow: 0 2px 7px rgba(204, 40, 104, .28), 0 0 0 2px rgba(255, 255, 255, .94); cursor: pointer; transition: transform .14s ease, box-shadow .14s ease; }
+.fr-selection-indicator--dot { width: 8px; height: 8px; }
 .fr-selection-indicator--dot .fr-selection-indicator-glyph { display: none; }
 .fr-selection-indicator:hover, .fr-selection-indicator:focus-visible { transform: translate(-50%, -50%) scale(1.1); box-shadow: 0 4px 14px rgba(204, 40, 104, .4), 0 0 0 3px rgba(255, 255, 255, .95); outline: none; }
-.fr-selection-indicator-glyph { font-size: 12px; font-weight: 700; line-height: 1; }
+.fr-selection-indicator-glyph { font-size: 10px; font-weight: 700; line-height: 1; }
 .fr-translation-tooltip { position: fixed; width: min(344px, calc(100vw - 20px)); max-height: min(480px, calc(100vh - 20px)); overflow: hidden; border: 1px solid rgba(28, 28, 36, .08); border-radius: 16px; background: rgba(255, 255, 255, .98); box-shadow: 0 14px 34px rgba(30, 28, 40, .16), 0 2px 8px rgba(30, 28, 40, .07); backdrop-filter: blur(16px); }
 .fr-tooltip-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; border-bottom: 1px solid #f0f0f3; font-size: 14px; font-weight: 700; }
 .fr-tooltip-title { display: flex; align-items: baseline; gap: 6px; }

--- a/entrypoints/utils/selectionTranslatorCore.ts
+++ b/entrypoints/utils/selectionTranslatorCore.ts
@@ -71,6 +71,98 @@ export function normalizeSelectionText(value: string): string {
         .trim();
 }
 
+const selectionExcludedTagNames = new Set([
+    'audio', 'button', 'canvas', 'code', 'embed', 'iframe', 'img', 'input',
+    'kbd', 'math', 'object', 'option', 'picture', 'pre', 'samp', 'select',
+    'svg', 'template', 'textarea', 'var', 'video',
+]);
+
+const selectionExcludedRoles = new Set([
+    'button', 'checkbox', 'combobox', 'listbox', 'menuitem', 'menuitemcheckbox',
+    'menuitemradio', 'option', 'radio', 'scrollbar', 'slider', 'spinbutton',
+    'switch', 'tab', 'textbox',
+]);
+
+const selectionExcludedSelector = [
+    '.fluent-read-bilingual-content',
+    '.fluent-read-loading',
+    '.fluent-read-retry-wrapper',
+    '.notranslate',
+    '[aria-hidden="true"]',
+    '[data-fluent-read-ui]',
+    '[data-notranslate="true"]',
+    '[role="button"]',
+    '[role="checkbox"]',
+    '[role="combobox"]',
+    '[role="listbox"]',
+    '[role="menuitem"]',
+    '[role="menuitemcheckbox"]',
+    '[role="menuitemradio"]',
+    '[role="option"]',
+    '[role="radio"]',
+    '[role="scrollbar"]',
+    '[role="slider"]',
+    '[role="spinbutton"]',
+    '[role="switch"]',
+    '[role="tab"]',
+    '[role="textbox"]',
+    '[translate="no"]',
+    '[contenteditable="true"]',
+    '[contenteditable="plaintext-only"]',
+    ...Array.from(selectionExcludedTagNames, (tagName) => tagName),
+].join(',');
+
+export function isSelectionExcludedTagName(tagName: string): boolean {
+    return selectionExcludedTagNames.has(tagName.trim().toLowerCase());
+}
+
+function isEditableSelectionElement(element: Element): boolean {
+    if ((element as HTMLElement).isContentEditable) return true;
+
+    let current: Element | null = element;
+    while (current) {
+        if (current.hasAttribute('contenteditable')) {
+            return current.getAttribute('contenteditable')?.trim().toLowerCase() !== 'false';
+        }
+        current = current.parentElement;
+    }
+    return false;
+}
+
+function isSelectionExcludedElement(element: Element | null): boolean {
+    if (!element) return false;
+    if (isSelectionExcludedTagName(element.tagName)) return true;
+
+    const role = element.getAttribute('role')?.trim().toLowerCase();
+    if (role && selectionExcludedRoles.has(role)) return true;
+    if (isEditableSelectionElement(element)) return true;
+    return Boolean(element.closest(selectionExcludedSelector));
+}
+
+function elementFromSelectionNode(node: Node | null): Element | null {
+    if (!node) return null;
+    return node.nodeType === 1 ? node as Element : node.parentElement;
+}
+
+/**
+ * Selection translation is intended for page prose, not atomic or interactive
+ * widgets. Check both boundaries and the cloned range so image-only selections
+ * and selections that cross a special component do not leave a stale trigger.
+ */
+export function shouldIgnoreSelection(range: Range): boolean {
+    const boundaries = [
+        elementFromSelectionNode(range.startContainer),
+        elementFromSelectionNode(range.endContainer),
+    ];
+    if (boundaries.some(isSelectionExcludedElement)) return true;
+
+    try {
+        return Boolean(range.cloneContents().querySelector(selectionExcludedSelector));
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Select the visual edge closest to the selection focus. Using client rects
  * avoids placing the affordance in the middle of a multi-line selection.

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -3,6 +3,7 @@ import {
     calculateSelectionPopupPosition,
     chooseSelectionRect,
     isSameLanguage,
+    isSelectionExcludedTagName,
     normalizeSelectionText,
     normalizeSpeechLanguage,
 } from '@/entrypoints/utils/selectionTranslatorCore';
@@ -47,6 +48,14 @@ describe('selection translator text and speech language normalization', () => {
 
     it('normalizes browser whitespace without changing words', () => {
         expect(normalizeSelectionText('  hello\u00a0  world\n   again  ')).toBe('hello world\nagain');
+    });
+
+    it('classifies atomic and interactive elements as non-text selections', () => {
+        for (const tagName of ['img', 'svg', 'video', 'canvas', 'button', 'input', 'textarea', 'select', 'code', 'pre']) {
+            expect(isSelectionExcludedTagName(tagName)).toBe(true);
+        }
+        expect(isSelectionExcludedTagName('p')).toBe(false);
+        expect(isSelectionExcludedTagName('span')).toBe(false);
     });
 
     it('maps translation language codes to browser speech language codes', () => {


### PR DESCRIPTION
## Summary
- Prevent the selection translator entry from appearing for image/media selections, code blocks, form controls, button-like widgets, editable regions, extension UI, and explicit no-translate content.
- Shrink the selection icon from 22px to 18px; shrink dot mode from 10px to 8px.
- Add selection exclusion coverage.

## Root cause
The selection flow only validated selected text and geometry, so text-bearing special components could still create the selection entry.

## Validation
- pnpm test — 21 files, 209 tests passed
- pnpm compile
- pnpm build
- Isolated Microsoft Edge verification: ordinary text shows an 18×18px entry; mixed image selections, role=button, and code components do not show it.