### PR TITLE
feat: simplify full-page translation context menu

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -307,6 +307,23 @@
       </el-col>
     </el-row>
 
+    <!-- 右键全文翻译开关 -->
+    <el-row v-if="config.on" class="settings-control-row">
+      <el-col :span="20" class="settings-control-label lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="在网页右键菜单中显示“流畅阅读翻译”或“流畅阅读取消翻译”入口；关闭后不会影响全文翻译快捷键和悬浮球" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">
+            右键全文翻译
+            <el-icon class="icon-margin">
+              <InfoFilled />
+            </el-icon>
+          </span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="4" class="settings-control-field flex-end">
+        <el-switch v-model="config.contextMenuEnabled" class="settings-toggle" aria-label="右键全文翻译" />
+      </el-col>
+    </el-row>
+
 
     <!-- 划词翻译模式选择 -->
     <el-row v-if="config.on" class="settings-control-row">

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -7,6 +7,7 @@ import {
     CONFIG_HISTORY_MESSAGE,
     CONFIG_PERSIST_MESSAGE,
     saveConfig,
+    subscribeConfig,
 } from "@/entrypoints/utils/config";
 import {CONNECTION_TEST_MESSAGE, CONTEXT_MENU_IDS} from "@/entrypoints/utils/constant";
 import {getMissingCredentialMessage} from "@/entrypoints/utils/configValidation";
@@ -443,101 +444,91 @@ export default defineBackground({
         safari: false,
     },
     main() {
-        const isContextMenuSupported = !!browser.contextMenus
-        let contextMenusReady = false
+        const isContextMenuSupported = !!browser.contextMenus;
+        let contextMenusReady = false;
+        let contextMenuEnabled = true;
+        let contextMenuSyncQueue: Promise<void> = Promise.resolve();
 
-        // 开发模式会多次重载后台脚本。先清理本扩展已有菜单，避免重复 ID。
-        const setupContextMenus = async () => {
-            if (!isContextMenuSupported) {
-                console.log("不支持右键菜单")
-                return
-            }
-
-            try {
-                await browser.contextMenus.removeAll()
-
-                // 创建父菜单
-                browser.contextMenus.create({
-                    id: 'fluentread-parent',
-                    title: 'FluentRead',
-                    contexts: ['page', 'selection'],
-                });
-
-                // 创建全文翻译子菜单
-                browser.contextMenus.create({
-                    id: CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE,
-                    title: '全文翻译',
-                    parentId: 'fluentread-parent',
-                    contexts: ['page', 'selection'],
-                });
-
-                // 创建撤销翻译子菜单
-                browser.contextMenus.create({
-                    id: CONTEXT_MENU_IDS.RESTORE_ORIGINAL,
-                    title: '撤销翻译',
-                    parentId: 'fluentread-parent',
-                    contexts: ['page', 'selection'],
-                    enabled: false, // 初始状态为禁用
-                });
-                contextMenusReady = true
-            } catch (error) {
-                contextMenusReady = false
-                console.error('Error setting up context menu:', error);
-            }
-        }
-
-        void setupContextMenus()
-        setupTranslationCacheCleanup()
-
-        // 更新右键菜单状态
+        // 更新右键菜单状态。菜单只有一个入口，标题随当前标签页的全文翻译状态切换。
         const updateContextMenus = async (tabId: number) => {
-            if (!contextMenusReady) return
+            if (!isContextMenuSupported || !contextMenusReady) return;
             const isTranslated = translationStateMap.get(tabId) || false;
 
             try {
-                // 更新全文翻译菜单项
-                await Promise.all([
-                    browser.contextMenus.update(CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE, {
-                        enabled: !isTranslated,
-                        title: isTranslated ? '全文翻译 (已翻译)' : '全文翻译'
-                    }),
-                    // 更新撤销翻译菜单项
-                    browser.contextMenus.update(CONTEXT_MENU_IDS.RESTORE_ORIGINAL, {
-                        enabled: isTranslated,
-                        title: isTranslated ? '撤销翻译' : '撤销翻译 (无翻译)'
-                    })
-                ]);
+                await browser.contextMenus.update(CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE, {
+                    enabled: true,
+                    title: isTranslated ? '流畅阅读取消翻译' : '流畅阅读翻译',
+                });
             } catch (error) {
-                console.error('Failed to update context menus:', error);
+                console.error('Failed to update context menu:', error);
             }
         };
+
+        // 开发模式会多次重载后台脚本；先清理本扩展已有菜单，避免旧的二级菜单残留。
+        const syncContextMenus = () => {
+            const requestedEnabled = contextMenuEnabled;
+            contextMenuSyncQueue = contextMenuSyncQueue
+                .catch(() => undefined)
+                .then(async () => {
+                    if (requestedEnabled !== contextMenuEnabled) return;
+                    contextMenusReady = false;
+                    await browser.contextMenus.removeAll();
+                    if (!requestedEnabled || requestedEnabled !== contextMenuEnabled) return;
+
+                    await browser.contextMenus.create({
+                        id: CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE,
+                        title: '流畅阅读翻译',
+                        contexts: ['page', 'selection'],
+                    });
+                    if (requestedEnabled !== contextMenuEnabled) {
+                        await browser.contextMenus.removeAll();
+                        return;
+                    }
+
+                    contextMenusReady = true;
+                    const activeTabs = await browser.tabs.query({ active: true });
+                    const activeTab = activeTabs.find((tab) => typeof tab.id === 'number');
+                    if (activeTab?.id !== undefined) await updateContextMenus(activeTab.id);
+                })
+                .catch((error) => {
+                    contextMenusReady = false;
+                    console.error('Error syncing context menu:', error);
+                });
+            return contextMenuSyncQueue;
+        };
+
+        if (!isContextMenuSupported) {
+            console.log("不支持右键菜单");
+        } else {
+            void configReady.then(() => {
+                contextMenuEnabled = config.contextMenuEnabled !== false;
+                void syncContextMenus();
+                subscribeConfig((nextConfig) => {
+                    const nextEnabled = nextConfig.contextMenuEnabled !== false;
+                    if (nextEnabled === contextMenuEnabled) return;
+                    contextMenuEnabled = nextEnabled;
+                    void syncContextMenus();
+                });
+            });
+        }
+        setupTranslationCacheCleanup();
 
         // 监听右键菜单点击事件
         if (isContextMenuSupported) {
             browser.contextMenus.onClicked.addListener((info: any, tab: any) => {
-                if (!tab?.id) return;
+                if (!contextMenuEnabled || info.menuItemId !== CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE || !tab?.id) return;
 
-                if (info.menuItemId === CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE) {
-                    browser.tabs.sendMessage(tab.id, {
-                        type: 'contextMenuTranslate',
-                        action: 'fullPage'
-                    }).then(() => {
-                        translationStateMap.set(tab.id!, true);
-                        void updateContextMenus(tab.id!);
-                    }).catch((error: any) => {
-                        console.error('Failed to send message to content script:', error);
-                    });
-                } else if (info.menuItemId === CONTEXT_MENU_IDS.RESTORE_ORIGINAL) {
-                    browser.tabs.sendMessage(tab.id, {
-                        type: 'contextMenuTranslate',
-                        action: 'restore'
-                    }).then(() => {
-                        translationStateMap.set(tab.id!, false);
-                        void updateContextMenus(tab.id!);
-                    }).catch((error: any) => {
-                        console.error('Failed to send message to content script:', error);
-                    });
-                }
+                const isTranslated = translationStateMap.get(tab.id) || false;
+                browser.tabs.sendMessage(tab.id, {
+                    type: 'contextMenuTranslate',
+                    action: isTranslated ? 'restore' : 'fullPage',
+                }).then((response: any) => {
+                    if (response?.status === 'disabled') return;
+                    translationStateMap.set(tab.id!, !isTranslated);
+                    void updateContextMenus(tab.id!);
+                }).catch((error: any) => {
+                    console.error('Failed to send message to content script:', error);
+                });
             });
         }
 
@@ -578,6 +569,16 @@ export default defineBackground({
                             });
                         } else {
                             await browser.runtime.openOptionsPage();
+                        }
+                        resolve({ success: true });
+                        return;
+                    }
+
+                    if (message.type === 'fullPageTranslationState') {
+                        const tabId = sender?.tab?.id;
+                        if (typeof tabId === 'number') {
+                            translationStateMap.set(tabId, message.isTranslated === true);
+                            if (isContextMenuSupported) void updateContextMenus(tabId);
                         }
                         resolve({ success: true });
                         return;

--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -72,6 +72,15 @@ let hoverTimer: ReturnType<typeof setTimeout> | undefined;
 let fullPageSession: FullPageSession | null = null;
 let sessionSequence = 0;
 
+function notifyFullPageTranslationState(isTranslated: boolean): void {
+    void browser.runtime.sendMessage({
+        type: "fullPageTranslationState",
+        isTranslated,
+    }).catch(() => {
+        // 后台可能正在重载；页面内的翻译状态不应因此失败。
+    });
+}
+
 function asHTMLElement(node: unknown): HTMLElement | null {
     return node instanceof HTMLElement ? node : null;
 }
@@ -498,6 +507,7 @@ export function restoreOriginalContent(): void {
         root.querySelectorAll?.(".fluent-read-bilingual-content, .fluent-read-loading, .fluent-read-retry-wrapper").forEach((element) => element.remove());
         root.querySelectorAll?.(".fluent-read-bilingual").forEach((element) => element.classList.remove("fluent-read-bilingual"));
     }
+    notifyFullPageTranslationState(false);
 }
 
 /**
@@ -541,6 +551,7 @@ export function autoTranslateEnglishPage(): void {
     observeFullPageRoot(session, root);
     addFullPageBlocks(session, root);
     for (const shadowRoot of getOpenShadowRoots(root)) observeFullPageRoot(session, shadowRoot);
+    notifyFullPageTranslationState(true);
 }
 
 /**

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -42,7 +42,7 @@ export const navigationGroups: NavigationGroup[] = [
         id: 'settings-shortcuts', icon: '⌘', label: '交互与快捷键', description: '悬停、划词、全文', group: '阅读工具',
         heading: '让翻译顺手发生', summary: '统一设置鼠标悬停、划词和全文翻译的触发习惯。',
         kicker: '操作方式', title: '交互与快捷键', detail: '为高频动作选择容易记忆且不冲突的触发方式。',
-        searchDescription: '鼠标悬停、划词翻译、全文翻译与自定义按键',
+        searchDescription: '鼠标悬停、划词翻译、全文翻译、右键全文翻译与自定义按键',
       },
       {
         id: 'settings-image-translation', icon: '图', label: '图片翻译', description: 'OCR 与语言包', group: '阅读工具',

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -80,5 +80,4 @@ export const styles = {
 // 右键菜单ID常量
 export const CONTEXT_MENU_IDS = {
     TRANSLATE_FULL_PAGE: 'fluent-read-translate-full-page',
-    RESTORE_ORIGINAL: 'fluent-read-restore-original',
 }

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -50,6 +50,7 @@ export class Config {
     theme: string;  // 主题模式：'auto' | 'light' | 'dark'
     useCache: boolean; // 是否使用缓存
     enableAIContext: boolean; // 是否为 AI 翻译附加网页上下文
+    contextMenuEnabled: boolean; // 是否显示右键全文翻译菜单
     disableFloatingBall: boolean; // 是否禁用悬浮球
     floatingBallPosition: 'left' | 'right'; // 悬浮球位置
     floatingBallHotkey: string; // 悬浮球快捷键
@@ -109,6 +110,7 @@ export class Config {
         this.theme = 'auto';  // 默认跟随系统
         this.useCache = true; // 默认开启缓存
         this.enableAIContext = false; // 默认关闭 AI 智能上下文，避免意外增加请求体和费用
+        this.contextMenuEnabled = true; // 默认显示右键全文翻译入口
         this.disableFloatingBall = true; // 默认关闭悬浮球
         this.floatingBallPosition = 'right'; // 默认在右侧
         this.floatingBallHotkey = 'Alt+T'; // 默认快捷键为 Alt+T
@@ -285,6 +287,9 @@ export function normalizeConfig(value: unknown): Config {
     normalized.disableSelectionTranslator = normalized.selectionTranslatorMode === 'disabled';
     if (typeof normalized.selectionAreaEnabled !== 'boolean') {
         normalized.selectionAreaEnabled = false;
+    }
+    if (typeof normalized.contextMenuEnabled !== 'boolean') {
+        normalized.contextMenuEnabled = true;
     }
 
     return normalized;

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -84,6 +84,15 @@ describe('圈选翻译配置', () => {
     });
 });
 
+describe('右键全文翻译配置', () => {
+    it('默认开启，并保留用户主动关闭的状态', () => {
+        expect(new Config().contextMenuEnabled).toBe(true);
+        expect(normalizeConfig({}).contextMenuEnabled).toBe(true);
+        expect(normalizeConfig({contextMenuEnabled: false}).contextMenuEnabled).toBe(false);
+        expect(normalizeConfig({contextMenuEnabled: 'false'}).contextMenuEnabled).toBe(true);
+    });
+});
+
 describe('旧模型编号兼容迁移', () => {
     it('迁移官方服务中已退役或错误的模型编号', () => {
         const normalized = normalizeConfig({


### PR DESCRIPTION
## Summary

- Add a persisted settings switch for the full-page translation context menu.
- Replace the FluentRead context-menu submenu with one top-level action.
- Show `流畅阅读翻译` before translation and `流畅阅读取消翻译` after translation, with page state synchronization.

## Validation

- `pnpm compile`
- `pnpm test` — 21 files, 211 tests passed
- `pnpm build`
- Production options UI isolation — passed with no console errors
- Real isolated browser checks — settings persistence and single branded context-menu item verified

The full UI suite still has an unrelated baseline assertion requiring an independent model-list scroll region; the scoped options suite passes.
