### PR TITLE
feat: add Google Drive configuration sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Google OAuth client ID used by the optional Google Drive configuration sync.
+# The client ID is public extension metadata, not a client secret. Configure the
+# extension redirect URI for each published/dev extension ID in Google Cloud.
+WXT_GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ FluentRead brings translation into the reading flow. Keep the original text besi
 - **Free Translation**: a built-in fallback chain that tries Microsoft first, then DeepLX, then Google when a service returns an error or empty result.
 - **Image translation (Beta)**: local OCR for text in images, with downloadable language packs and a reversible translated overlay.
 - **Translation cache**: reuse recent results for the same service, model, language pair, and request settings.
+- **Google Drive sync (optional)**: sync configuration through Drive’s private `appDataFolder`, with field-level conflict choices when two profiles changed the same settings.
 - **Cross-browser support**: build targets for Chromium browsers and Firefox through WXT and Manifest V3.
 
 ## See it in action
@@ -70,7 +71,7 @@ Use focused settings pages for reading preferences, services and models, shortcu
 | Edge | [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/kakgmllfpjldjhcnkghpplmlbnmcoflp) |
 | Firefox | [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/%E6%B5%81%E7%95%85%E9%98%85%E8%AF%BB/) |
 
-For a local build, install dependencies with pnpm and load the generated `./.output/chrome-mv3` directory as an unpacked extension. See the [official documentation](https://fluent.thinkstu.com/) for setup and configuration details.
+For a local build, install dependencies with pnpm and load the generated `./.output/chrome-mv3` directory as an unpacked extension. To enable Google Drive sync, set `WXT_GOOGLE_CLIENT_ID` to a Google OAuth client ID whose extension redirect URI matches the build ID. See the [official documentation](https://fluent.thinkstu.com/) for setup and configuration details.
 
 ## Documentation and community
 

--- a/components/GoogleDriveSync.vue
+++ b/components/GoogleDriveSync.vue
@@ -1,0 +1,334 @@
+<template>
+  <section class="google-drive-sync" aria-labelledby="google-drive-sync-title">
+    <div class="google-drive-heading">
+      <div>
+        <span class="google-drive-kicker">云端同步</span>
+        <h3 id="google-drive-sync-title">Google Drive 云端同步</h3>
+        <p>把 FluentRead 配置保存到 Google Drive 的私有应用数据区，方便在不同浏览器配置之间迁移。</p>
+      </div>
+      <span class="google-drive-status" :class="{ connected: authUser }">
+        {{ authLoading ? '检查账号中…' : authUser ? '已连接' : '未连接' }}
+      </span>
+    </div>
+
+    <div v-if="authUser" class="google-drive-account">
+      <span class="google-drive-avatar" aria-hidden="true">{{ authUser.email.slice(0, 1).toUpperCase() }}</span>
+      <span class="google-drive-email">{{ authUser.email }}</span>
+      <button type="button" class="google-drive-link" @click="handleLogout">退出账号</button>
+    </div>
+
+    <div class="google-drive-actions">
+      <button type="button" class="google-drive-primary" :disabled="syncing" @click="handleSync">
+        <span v-if="syncing" class="google-drive-spinner" aria-hidden="true" />
+        {{ syncing ? '同步中…' : authUser ? '同步到 Google Drive' : '连接并同步 Google Drive' }}
+      </button>
+      <span v-if="lastSyncTime" class="google-drive-last-sync">最后同步：{{ formatTime(lastSyncTime) }}</span>
+    </div>
+
+    <p v-if="errorMessage" class="google-drive-error" role="alert">{{ errorMessage }}</p>
+    <p class="google-drive-note">配置中可能包含翻译服务令牌和自定义提示词；同步文件仅写入当前 Google 账号的 appDataFolder，不会出现在普通 Drive 文件列表中。</p>
+  </section>
+
+  <el-dialog
+    v-model="conflictDialogVisible"
+    title="配置同步冲突"
+    width="min(900px, calc(100vw - 32px))"
+    :close-on-click-modal="false"
+    @closed="resetConflictState"
+  >
+    <p class="conflict-description">本地和 Google Drive 都基于上次同步配置发生了修改。请为每个冲突字段选择保留本地值或云端值。</p>
+
+    <div v-if="conflictResult" class="conflict-toolbar">
+      <span>已选择 {{ resolvedConflictCount }} / {{ conflictResult.conflicts.length }} 项</span>
+      <div class="conflict-toolbar-actions">
+        <button type="button" class="conflict-bulk-button" @click="selectAll('local')">全部使用本地</button>
+        <button type="button" class="conflict-bulk-button" @click="selectAll('remote')">全部使用云端</button>
+      </div>
+    </div>
+
+    <div v-if="conflictResult" class="conflict-list">
+      <article v-for="conflict in conflictResult.conflicts" :key="pathKey(conflict.path)" class="conflict-item">
+        <div class="conflict-path">{{ formatPath(conflict.path) }}</div>
+        <div class="conflict-values">
+          <button
+            type="button"
+            class="conflict-value"
+            :class="{ selected: resolutions[pathKey(conflict.path)] === 'local' }"
+            @click="selectResolution(conflict.path, 'local')"
+          >
+            <span class="conflict-value-heading"><b class="local-dot" />本地值</span>
+            <code>{{ formatValue(conflict.localValue) }}</code>
+          </button>
+          <button
+            type="button"
+            class="conflict-value"
+            :class="{ selected: resolutions[pathKey(conflict.path)] === 'remote' }"
+            @click="selectResolution(conflict.path, 'remote')"
+          >
+            <span class="conflict-value-heading"><b class="remote-dot" />云端值</span>
+            <code>{{ formatValue(conflict.remoteValue) }}</code>
+          </button>
+        </div>
+      </article>
+    </div>
+
+    <p v-if="resolvedResult?.validationError" class="google-drive-error" role="alert">{{ resolvedResult.validationError }}</p>
+
+    <template #footer>
+      <button type="button" class="conflict-cancel-button" :disabled="syncing" @click="conflictDialogVisible = false">取消</button>
+      <button type="button" class="google-drive-primary" :disabled="!canConfirmConflict" @click="handleConfirmConflict">
+        {{ syncing ? '同步中…' : '确认合并并同步' }}
+      </button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { ElMessage } from 'element-plus';
+import type { GoogleUserInfo } from '@/entrypoints/utils/google-drive/auth';
+import {
+    clearAccessToken,
+    getAuthenticatedGoogleUser,
+} from '@/entrypoints/utils/google-drive/auth';
+import {
+    applyResolutions,
+    detectConflicts,
+    type ConflictResolution,
+    type DiffConflictsResult,
+} from '@/entrypoints/utils/google-drive/conflict-merge';
+import { getLastSyncedConfigAndMeta } from '@/entrypoints/utils/google-drive/storage';
+import { syncConfig, syncMergedConfig } from '@/entrypoints/utils/google-drive/sync';
+
+const authUser = ref<GoogleUserInfo | null>(null);
+const authLoading = ref(true);
+const syncing = ref(false);
+const errorMessage = ref('');
+const lastSyncTime = ref<number | null>(null);
+const conflictDialogVisible = ref(false);
+const conflictResult = ref<DiffConflictsResult | null>(null);
+const resolutions = ref<Record<string, ConflictResolution>>({});
+const conflictEmail = ref('');
+
+const resolvedResult = computed(() => conflictResult.value
+    ? applyResolutions(conflictResult.value, resolutions.value)
+    : null);
+const resolvedConflictCount = computed(() => Object.keys(resolutions.value).length);
+const allConflictsResolved = computed(() => Boolean(
+    conflictResult.value?.conflicts.every((conflict) => Boolean(resolutions.value[pathKey(conflict.path)])),
+));
+const canConfirmConflict = computed(() => Boolean(
+    !syncing.value
+    && allConflictsResolved.value
+    && resolvedResult.value
+    && !resolvedResult.value.validationError,
+));
+
+function pathKey(path: string[]): string {
+    return path.join('.');
+}
+
+function formatPath(path: string[]): string {
+    return path.length ? path.join(' › ') : '根配置';
+}
+
+function formatValue(value: unknown): string {
+    const serialized = JSON.stringify(value, null, 2);
+    if (serialized !== undefined) return serialized.length > 1_200 ? `${serialized.slice(0, 1_200)}…` : serialized;
+    return String(value);
+}
+
+function formatTime(timestamp: number): string {
+    return new Intl.DateTimeFormat('zh-CN', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    }).format(timestamp);
+}
+
+function toErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Google Drive 同步失败，请稍后重试';
+}
+
+async function refreshAuth(showError = false): Promise<void> {
+    authLoading.value = true;
+    try {
+        authUser.value = await getAuthenticatedGoogleUser();
+    } catch (error) {
+        authUser.value = null;
+        if (showError) errorMessage.value = toErrorMessage(error);
+    } finally {
+        authLoading.value = false;
+    }
+}
+
+async function refreshLastSync(): Promise<void> {
+    const lastSynced = await getLastSyncedConfigAndMeta();
+    lastSyncTime.value = lastSynced?.meta.lastSyncedAt ?? null;
+}
+
+function showSuccess(message: string): void {
+    ElMessage({message, type: 'success', duration: 2_000});
+}
+
+function getSyncSuccessMessage(action: 'uploaded' | 'downloaded' | 'same-changes' | 'no-change'): string {
+    return {
+        uploaded: '本地配置已同步到 Google Drive',
+        downloaded: 'Google Drive 配置已应用到本地',
+        'same-changes': '本地和云端修改一致，已完成同步',
+        'no-change': '本地和云端配置没有变化',
+    }[action];
+}
+
+async function handleSync(): Promise<void> {
+    if (syncing.value) return;
+    syncing.value = true;
+    errorMessage.value = '';
+    try {
+        const result = await syncConfig();
+        if (result.status === 'error') {
+            errorMessage.value = result.error.message;
+            return;
+        }
+
+        conflictEmail.value = result.email;
+        if (result.status === 'unresolved') {
+            conflictResult.value = detectConflicts(result.data.base, result.data.local, result.data.remote);
+            resolutions.value = {};
+            conflictDialogVisible.value = true;
+            return;
+        }
+
+        lastSyncTime.value = result.syncedAt;
+        showSuccess(getSyncSuccessMessage(result.action));
+    } catch (error) {
+        errorMessage.value = toErrorMessage(error);
+    } finally {
+        syncing.value = false;
+        await refreshAuth(false);
+    }
+}
+
+async function handleConfirmConflict(): Promise<void> {
+    if (!canConfirmConflict.value || !resolvedResult.value) return;
+    const email = conflictEmail.value || authUser.value?.email;
+    if (!email) {
+        errorMessage.value = '无法确认 Google 账号，请重新连接后重试';
+        conflictDialogVisible.value = false;
+        return;
+    }
+
+    syncing.value = true;
+    errorMessage.value = '';
+    try {
+        await syncMergedConfig(resolvedResult.value.config, email);
+        lastSyncTime.value = Date.now();
+        conflictDialogVisible.value = false;
+        showSuccess('冲突已解决，合并配置已同步到本地和 Google Drive');
+    } catch (error) {
+        errorMessage.value = toErrorMessage(error);
+    } finally {
+        syncing.value = false;
+        await refreshAuth(false);
+    }
+}
+
+function selectResolution(path: string[], resolution: ConflictResolution): void {
+    resolutions.value = {...resolutions.value, [pathKey(path)]: resolution};
+}
+
+function selectAll(resolution: ConflictResolution): void {
+    if (!conflictResult.value) return;
+    const next: Record<string, ConflictResolution> = {};
+    for (const conflict of conflictResult.value.conflicts) next[pathKey(conflict.path)] = resolution;
+    resolutions.value = next;
+}
+
+function resetConflictState(): void {
+    conflictResult.value = null;
+    resolutions.value = {};
+    conflictEmail.value = '';
+}
+
+async function handleLogout(): Promise<void> {
+    try {
+        await clearAccessToken();
+        authUser.value = null;
+        errorMessage.value = '';
+        showSuccess('已退出 Google Drive 账号');
+    } catch (error) {
+        errorMessage.value = toErrorMessage(error);
+    }
+}
+
+onMounted(() => {
+    void refreshAuth();
+    void refreshLastSync().catch(() => undefined);
+});
+</script>
+
+<style scoped>
+.google-drive-sync {
+  display: grid;
+  gap: 14px;
+  margin: 0 12px 20px;
+  padding: 18px 20px;
+  border: 1px solid #d8e8f5;
+  border-radius: 18px;
+  background: linear-gradient(135deg, #f7fbff, #fff);
+}
+.google-drive-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
+.google-drive-kicker { display: block; margin-bottom: 5px; color: #2678c9; font-size: 10px; font-weight: 800; letter-spacing: .1em; }
+.google-drive-heading h3 { margin: 0 0 6px; color: #172033; font-size: 17px; }
+.google-drive-heading p, .google-drive-note { margin: 0; color: #69768a; font-size: 11px; line-height: 1.6; }
+.google-drive-status { flex: none; padding: 5px 9px; border-radius: 999px; color: #778397; background: #eef2f7; font-size: 10px; font-weight: 750; }
+.google-drive-status.connected { color: #18835d; background: #eaf8f1; }
+.google-drive-account { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.google-drive-avatar { display: grid; width: 26px; height: 26px; flex: none; place-items: center; border-radius: 50%; color: #fff; background: #4285f4; font-size: 12px; font-weight: 800; }
+.google-drive-email { overflow: hidden; color: #334155; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.google-drive-link { margin-left: auto; padding: 0; border: 0; color: #2678c9; background: transparent; font-size: 11px; cursor: pointer; }
+.google-drive-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; }
+.google-drive-primary { display: inline-flex; min-height: 34px; align-items: center; justify-content: center; gap: 7px; padding: 0 14px; border: 0; border-radius: 9px; color: #fff; background: #2678c9; font-size: 12px; font-weight: 750; cursor: pointer; }
+.google-drive-primary:hover { background: #1d66ad; }
+.google-drive-primary:disabled { cursor: default; opacity: .55; }
+.google-drive-spinner { width: 12px; height: 12px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: google-drive-spin .8s linear infinite; }
+.google-drive-last-sync { color: #7b8799; font-size: 10px; }
+.google-drive-error { margin: 0; padding: 9px 10px; border-radius: 9px; color: #bd3154; background: #fff0f3; font-size: 11px; line-height: 1.5; }
+.google-drive-note { color: #8a94a5; font-size: 10px; }
+
+.conflict-description { margin: 0 0 14px; color: #69768a; font-size: 12px; line-height: 1.6; }
+.conflict-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; color: #69768a; font-size: 11px; }
+.conflict-toolbar-actions { display: flex; gap: 7px; }
+.conflict-bulk-button, .conflict-cancel-button { min-height: 30px; padding: 0 10px; border: 1px solid #dfe5ee; border-radius: 8px; color: #536174; background: #fff; font-size: 11px; cursor: pointer; }
+.conflict-bulk-button:hover, .conflict-cancel-button:hover { border-color: #a9c8e8; color: #2678c9; }
+.conflict-list { display: grid; max-height: 56vh; gap: 10px; overflow: auto; padding-right: 3px; }
+.conflict-item { padding: 11px; border: 1px solid #e8ebf1; border-radius: 11px; background: #fbfcfe; }
+.conflict-path { margin-bottom: 8px; color: #344054; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; font-weight: 700; word-break: break-all; }
+.conflict-values { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.conflict-value { min-width: 0; padding: 9px; border: 1px solid #e3e7ef; border-radius: 9px; color: #536174; background: #fff; text-align: left; cursor: pointer; }
+.conflict-value:hover, .conflict-value.selected { border-color: #70a9df; box-shadow: 0 0 0 2px rgba(38, 120, 201, .12); }
+.conflict-value.selected { background: #f4f9ff; }
+.conflict-value-heading { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; font-size: 10px; font-weight: 750; }
+.local-dot, .remote-dot { width: 7px; height: 7px; border-radius: 50%; }
+.local-dot { background: #23a36d; }
+.remote-dot { background: #4285f4; }
+.conflict-value code { display: block; max-height: 120px; overflow: auto; color: #344054; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10px; line-height: 1.45; white-space: pre-wrap; word-break: break-word; }
+
+:global(.dark) .google-drive-sync { border-color: #2c4860; background: linear-gradient(135deg, rgba(38, 120, 201, .13), #252830); }
+:global(.dark) .google-drive-heading h3, :global(.dark) .google-drive-email, :global(.dark) .conflict-path, :global(.dark) .conflict-value code { color: #f4f5f8; }
+:global(.dark) .google-drive-heading p, :global(.dark) .google-drive-note, :global(.dark) .google-drive-last-sync, :global(.dark) .conflict-description, :global(.dark) .conflict-toolbar { color: #a7adba; }
+:global(.dark) .conflict-item, :global(.dark) .conflict-value { border-color: #30333c; background: #252830; }
+:global(.dark) .conflict-value.selected { background: rgba(38, 120, 201, .15); }
+:global(.dark) .conflict-bulk-button, :global(.dark) .conflict-cancel-button { border-color: #3a414e; color: #c3c9d4; background: #252830; }
+
+@keyframes google-drive-spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 640px) {
+  .google-drive-heading, .conflict-toolbar { align-items: flex-start; flex-direction: column; }
+  .google-drive-status { align-self: flex-start; }
+  .conflict-values { grid-template-columns: 1fr; }
+  .conflict-toolbar-actions { width: 100%; }
+}
+</style>

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -559,6 +559,8 @@
     </section>
 
     <section v-show="props.activeSection === 'settings-data'" id="settings-data" class="settings-section data-section">
+        <GoogleDriveSync />
+
         <!-- 配置导入导出 -->
         <el-row class="margin-bottom margin-left-2em">
           <el-col :span="24">
@@ -686,6 +688,7 @@ import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 import ServiceCatalog from '@/components/ServiceCatalog.vue';
 import ServiceConfiguration from '@/components/ServiceConfiguration.vue';
+import GoogleDriveSync from '@/components/GoogleDriveSync.vue';
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
 import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
 import { getApiKeyRequirementKey, getMissingCredentialMessage, isApiKeyRequired } from '@/entrypoints/utils/configValidation';

--- a/components/Main.vue
+++ b/components/Main.vue
@@ -562,9 +562,52 @@
         <GoogleDriveSync />
 
         <!-- 配置导入导出 -->
-        <el-row class="margin-bottom margin-left-2em">
+        <el-row class="margin-bottom margin-left-2em config-transfer-heading">
           <el-col :span="24">
-            <el-divider content-position="center">配置管理</el-divider>
+            <el-divider content-position="center">本地导入与导出</el-divider>
+          </el-col>
+        </el-row>
+
+        <el-row class="margin-bottom margin-left-2em config-transfer-actions">
+          <el-col :span="12">
+            <el-button type="primary" @click="handleExport">
+              <el-icon>
+                <Download />
+              </el-icon>
+              导出配置
+            </el-button>
+          </el-col>
+          <el-col :span="12">
+            <el-button type="success" @click="handleImport">
+              <el-icon>
+                <Upload />
+              </el-icon>
+              导入配置
+            </el-button>
+          </el-col>
+        </el-row>
+
+        <!-- 导出配置 -->
+        <el-row v-if="showExportBox" class="margin-bottom margin-left-2em">
+          <el-col :span="24">
+            <el-input v-model="exportData" type="textarea" :rows="8" readonly />
+          </el-col>
+        </el-row>
+
+        <!-- 导入配置 -->
+        <el-row v-if="showImportBox" class="margin-bottom margin-left-2em">
+          <el-col :span="24">
+            <el-input v-model="importData" type="textarea" :rows="8" placeholder="请在此处粘贴您的JSON配置" />
+            <div style="margin-top: 10px; text-align: right;">
+              <el-button @click="saveImport">保存</el-button>
+            </div>
+          </el-col>
+        </el-row>
+
+        <!-- 配置历史 -->
+        <el-row class="margin-bottom margin-left-2em config-history-heading-row">
+          <el-col :span="24">
+            <el-divider content-position="center">配置历史</el-divider>
           </el-col>
         </el-row>
 
@@ -616,41 +659,6 @@
           <div v-else class="config-history-empty">还没有可恢复的配置版本。</div>
         </section>
 
-        <el-row class="margin-bottom margin-left-2em">
-          <el-col :span="12">
-            <el-button type="primary" @click="handleExport">
-              <el-icon>
-                <Download />
-              </el-icon>
-              导出配置
-            </el-button>
-          </el-col>
-          <el-col :span="12">
-            <el-button type="success" @click="handleImport">
-              <el-icon>
-                <Upload />
-              </el-icon>
-              导入配置
-            </el-button>
-          </el-col>
-        </el-row>
-
-        <!-- 导出配置 -->
-        <el-row v-if="showExportBox" class="margin-bottom margin-left-2em">
-          <el-col :span="24">
-            <el-input v-model="exportData" type="textarea" :rows="8" readonly />
-          </el-col>
-        </el-row>
-
-        <!-- 导入配置 -->
-        <el-row v-if="showImportBox" class="margin-bottom margin-left-2em">
-          <el-col :span="24">
-            <el-input v-model="importData" type="textarea" :rows="8" placeholder="请在此处粘贴您的JSON配置" />
-            <div style="margin-top: 10px; text-align: right;">
-              <el-button @click="saveImport">保存</el-button>
-            </div>
-          </el-col>
-        </el-row>
     </section>
     <!--    -->
   </div>

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -68,10 +68,10 @@ export const navigationGroups: NavigationGroup[] = [
         searchDescription: '缓存、动画、并发、悬浮球、输入框、代理与提示词',
       },
       {
-        id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出', group: '系统与数据',
-        heading: '备份与迁移配置', summary: '导出当前设置，或从已有配置恢复你的使用习惯。',
+        id: 'settings-data', icon: '⇅', label: '配置管理', description: '云端同步与导入导出', group: '系统与数据',
+        heading: '备份与同步配置', summary: '使用 Google Drive 云端同步，或导出当前设置完成本地备份与迁移。',
         kicker: '数据工具', title: '配置管理', detail: '通过 JSON 完成配置备份、迁移与恢复。',
-        searchDescription: '备份、迁移、导出与导入 JSON 配置',
+        searchDescription: 'Google Drive 云端同步、备份、迁移、导出与导入 JSON 配置',
       },
     ],
   },

--- a/entrypoints/utils/google-drive/api.ts
+++ b/entrypoints/utils/google-drive/api.ts
@@ -1,0 +1,114 @@
+import { clearAccessToken, getValidAccessToken } from './auth';
+
+const GOOGLE_DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
+const GOOGLE_DRIVE_UPLOAD_API_BASE = 'https://www.googleapis.com/upload/drive/v3';
+
+export interface GoogleDriveFile {
+    id: string;
+    name: string;
+    mimeType: string;
+    modifiedTime: string;
+    size?: string;
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseDriveFile(value: unknown): GoogleDriveFile {
+    if (!isRecord(value)
+        || typeof value.id !== 'string'
+        || typeof value.name !== 'string'
+        || typeof value.mimeType !== 'string'
+        || typeof value.modifiedTime !== 'string') {
+        throw new Error('Google Drive 文件响应格式无效');
+    }
+
+    return {
+        id: value.id,
+        name: value.name,
+        mimeType: value.mimeType,
+        modifiedTime: value.modifiedTime,
+        size: typeof value.size === 'string' ? value.size : undefined,
+    };
+}
+
+function parseFileList(value: unknown): GoogleDriveFile[] {
+    if (!isRecord(value) || !Array.isArray(value.files)) {
+        throw new Error('Google Drive 文件列表响应格式无效');
+    }
+    return value.files.map(parseDriveFile);
+}
+
+async function handleDriveError(response: Response, action: string): Promise<never> {
+    if (response.status === 401) {
+        await clearAccessToken();
+    }
+
+    let detail = '';
+    try {
+        detail = (await response.text()).trim().slice(0, 240);
+    } catch {
+        // The status text below is enough when the response body is unavailable.
+    }
+
+    throw new Error(`${action}失败：HTTP ${response.status}${detail ? `，${detail}` : ''}`);
+}
+
+export async function findFileInAppData(fileName: string): Promise<GoogleDriveFile | null> {
+    const accessToken = await getValidAccessToken();
+    const url = new URL(`${GOOGLE_DRIVE_API_BASE}/files`);
+    const escapedName = fileName.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    url.searchParams.set('spaces', 'appDataFolder');
+    url.searchParams.set('q', `name = '${escapedName}' and trashed = false`);
+    url.searchParams.set('fields', 'files(id,name,mimeType,modifiedTime,size)');
+
+    const response = await fetch(url.toString(), {
+        headers: {Authorization: `Bearer ${accessToken}`},
+    });
+    if (!response.ok) await handleDriveError(response, '搜索 Google Drive 配置文件');
+
+    const files = parseFileList(await response.json());
+    return files[0] || null;
+}
+
+export async function downloadFile(fileId: string): Promise<string> {
+    const accessToken = await getValidAccessToken();
+    const response = await fetch(`${GOOGLE_DRIVE_API_BASE}/files/${encodeURIComponent(fileId)}?alt=media`, {
+        headers: {Authorization: `Bearer ${accessToken}`},
+    });
+    if (!response.ok) await handleDriveError(response, '下载 Google Drive 配置');
+    return response.text();
+}
+
+export async function uploadFile(
+    fileName: string,
+    content: string,
+    fileId?: string,
+): Promise<GoogleDriveFile> {
+    const accessToken = await getValidAccessToken();
+    const metadata = {
+        name: fileName,
+        mimeType: 'application/json',
+        ...(!fileId ? {parents: ['appDataFolder']} : {}),
+    };
+    const boundary = '-------fluentread-google-drive-boundary';
+    const delimiter = `\r\n--${boundary}\r\n`;
+    const closeDelimiter = `\r\n--${boundary}--`;
+    const body = `${delimiter}Content-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}${delimiter}Content-Type: application/json; charset=UTF-8\r\n\r\n${content}${closeDelimiter}`;
+    const method = fileId ? 'PATCH' : 'POST';
+    const endpoint = fileId
+        ? `${GOOGLE_DRIVE_UPLOAD_API_BASE}/files/${encodeURIComponent(fileId)}`
+        : `${GOOGLE_DRIVE_UPLOAD_API_BASE}/files`;
+    const url = `${endpoint}?uploadType=multipart&fields=id,name,mimeType,modifiedTime,size`;
+
+    const response = await fetch(url, {
+        method,
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': `multipart/related; boundary=${boundary}`,
+        },
+        body,
+    });
+    if (!response.ok) await handleDriveError(response, '上传 Google Drive 配置');
+    return parseDriveFile(await response.json());
+}

--- a/entrypoints/utils/google-drive/auth.ts
+++ b/entrypoints/utils/google-drive/auth.ts
@@ -1,0 +1,159 @@
+import { storage } from '@wxt-dev/storage';
+import browser from 'webextension-polyfill';
+import {
+    GOOGLE_DRIVE_SCOPES,
+    GOOGLE_DRIVE_TOKEN_STORAGE_KEY,
+} from './constants';
+
+const GOOGLE_CLIENT_ID = process.env.WXT_GOOGLE_CLIENT_ID || '';
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+export interface GoogleAuthToken {
+    access_token: string;
+    expires_at: number;
+    token_type: string;
+}
+
+export interface GoogleUserInfo {
+    id: string;
+    email: string;
+    verified_email?: boolean;
+    picture?: string;
+}
+
+interface BrowserIdentityApi {
+    getRedirectURL: () => string;
+    launchWebAuthFlow: (details: {url: string; interactive: boolean}) => Promise<string | undefined>;
+}
+
+function getIdentityApi(): BrowserIdentityApi {
+    const identity = (browser as unknown as {identity?: BrowserIdentityApi}).identity;
+    if (!identity) {
+        throw new Error('当前浏览器不支持扩展身份认证');
+    }
+    return identity;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseStoredToken(value: unknown): GoogleAuthToken | null {
+    if (!isRecord(value)) return null;
+    if (typeof value.access_token !== 'string' || !value.access_token) return null;
+    if (typeof value.expires_at !== 'number' || !Number.isFinite(value.expires_at)) return null;
+    return {
+        access_token: value.access_token,
+        expires_at: value.expires_at,
+        token_type: typeof value.token_type === 'string' && value.token_type ? value.token_type : 'Bearer',
+    };
+}
+
+async function getTokenFromStorage(): Promise<GoogleAuthToken | null> {
+    const raw = await storage.getItem<unknown>(GOOGLE_DRIVE_TOKEN_STORAGE_KEY);
+    return parseStoredToken(raw);
+}
+
+function getOAuthError(params: URLSearchParams): Error | null {
+    const error = params.get('error');
+    if (!error) return null;
+    const description = params.get('error_description');
+    return new Error(`Google OAuth 授权失败：${description || error}`);
+}
+
+/**
+ * Use Google's implicit OAuth flow because extension identity redirects do not
+ * provide a safe place to keep a client secret.
+ */
+export async function authenticateGoogleDriveAndSaveToken(): Promise<string> {
+    if (!GOOGLE_CLIENT_ID) {
+        throw new Error('Google Drive 同步尚未配置 OAuth Client ID，请设置 WXT_GOOGLE_CLIENT_ID 后重新构建扩展');
+    }
+
+    const identity = getIdentityApi();
+    const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+    authUrl.searchParams.set('client_id', GOOGLE_CLIENT_ID);
+    authUrl.searchParams.set('response_type', 'token');
+    authUrl.searchParams.set('redirect_uri', identity.getRedirectURL());
+    authUrl.searchParams.set('scope', GOOGLE_DRIVE_SCOPES.join(' '));
+    authUrl.searchParams.set('prompt', 'select_account');
+
+    const responseUrl = await identity.launchWebAuthFlow({
+        url: authUrl.toString(),
+        interactive: true,
+    });
+
+    if (!responseUrl) {
+        throw new Error('Google OAuth 未返回授权结果');
+    }
+
+    const parsedUrl = new URL(responseUrl);
+    const hashParams = new URLSearchParams(parsedUrl.hash.replace(/^#/, ''));
+    const queryParams = parsedUrl.searchParams;
+    const oauthError = getOAuthError(hashParams) || getOAuthError(queryParams);
+    if (oauthError) throw oauthError;
+
+    const accessToken = hashParams.get('access_token') || queryParams.get('access_token');
+    if (!accessToken) {
+        throw new Error('Google OAuth 响应中缺少 access token');
+    }
+
+    const expiresIn = Number.parseInt(
+        hashParams.get('expires_in') || queryParams.get('expires_in') || '3600',
+        10,
+    );
+    const token: GoogleAuthToken = {
+        access_token: accessToken,
+        expires_at: Date.now() + (Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn * 1000 : 3_600_000),
+        token_type: 'Bearer',
+    };
+
+    await storage.setItem(GOOGLE_DRIVE_TOKEN_STORAGE_KEY, token);
+    return accessToken;
+}
+
+export async function getValidAccessToken(): Promise<string> {
+    const token = await getTokenFromStorage();
+    if (!token || Date.now() >= token.expires_at - TOKEN_EXPIRY_BUFFER_MS) {
+        return authenticateGoogleDriveAndSaveToken();
+    }
+    return token.access_token;
+}
+
+export async function getIsAuthenticated(): Promise<boolean> {
+    const token = await getTokenFromStorage();
+    return Boolean(token && Date.now() < token.expires_at - TOKEN_EXPIRY_BUFFER_MS);
+}
+
+export async function clearAccessToken(): Promise<void> {
+    await storage.removeItem(GOOGLE_DRIVE_TOKEN_STORAGE_KEY);
+}
+
+export async function getGoogleUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+    const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+        headers: {Authorization: `Bearer ${accessToken}`},
+    });
+
+    if (!response.ok) {
+        if (response.status === 401) await clearAccessToken();
+        throw new Error(`获取 Google 账号信息失败：HTTP ${response.status}`);
+    }
+
+    const data: unknown = await response.json();
+    if (!isRecord(data) || typeof data.id !== 'string' || typeof data.email !== 'string') {
+        throw new Error('Google 账号信息响应格式无效');
+    }
+
+    return {
+        id: data.id,
+        email: data.email,
+        verified_email: typeof data.verified_email === 'boolean' ? data.verified_email : undefined,
+        picture: typeof data.picture === 'string' ? data.picture : undefined,
+    };
+}
+
+export async function getAuthenticatedGoogleUser(): Promise<GoogleUserInfo | null> {
+    if (!(await getIsAuthenticated())) return null;
+    const accessToken = await getValidAccessToken();
+    return getGoogleUserInfo(accessToken);
+}

--- a/entrypoints/utils/google-drive/conflict-merge.ts
+++ b/entrypoints/utils/google-drive/conflict-merge.ts
@@ -1,0 +1,123 @@
+import { normalizeConfig, type Config } from '@/entrypoints/utils/model';
+
+export interface FieldConflict {
+    path: string[];
+    baseValue: unknown;
+    localValue: unknown;
+    remoteValue: unknown;
+}
+
+export interface DiffConflictsResult {
+    draft: Config;
+    conflicts: FieldConflict[];
+}
+
+export type ConflictResolution = 'local' | 'remote';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function configValuesEqual(left: unknown, right: unknown): boolean {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+        return left.every((value, index) => configValuesEqual(value, right[index]));
+    }
+    if (isRecord(left) || isRecord(right)) {
+        if (!isRecord(left) || !isRecord(right)) return false;
+        const leftKeys = Object.keys(left);
+        const rightKeys = Object.keys(right);
+        if (leftKeys.length !== rightKeys.length) return false;
+        return leftKeys.every((key) => Object.prototype.hasOwnProperty.call(right, key)
+            && configValuesEqual(left[key], right[key]));
+    }
+    return false;
+}
+
+function isAtomicValue(value: unknown): boolean {
+    return value === null || value === undefined || typeof value !== 'object' || Array.isArray(value);
+}
+
+/**
+ * Build a three-way merge draft. A changed leaf is kept at the base value
+ * until the user explicitly chooses local or remote, matching read-frog's
+ * conservative conflict UI.
+ */
+export function detectConflicts(base: Config, local: Config, remote: Config): DiffConflictsResult {
+    const conflicts: FieldConflict[] = [];
+
+    function traverse(path: string[], baseValue: unknown, localValue: unknown, remoteValue: unknown): unknown {
+        if (isAtomicValue(baseValue) || isAtomicValue(localValue) || isAtomicValue(remoteValue)) {
+            const localChanged = !configValuesEqual(localValue, baseValue);
+            const remoteChanged = !configValuesEqual(remoteValue, baseValue);
+            if (localChanged && remoteChanged && configValuesEqual(localValue, remoteValue)) return localValue;
+            if (localChanged || remoteChanged) {
+                conflicts.push({path, baseValue, localValue, remoteValue});
+            }
+            return baseValue;
+        }
+
+        if (!isRecord(baseValue) || !isRecord(localValue) || !isRecord(remoteValue)) {
+            return baseValue;
+        }
+
+        const result: Record<string, unknown> = {};
+        const keys = new Set([
+            ...Object.keys(baseValue),
+            ...Object.keys(localValue),
+            ...Object.keys(remoteValue),
+        ]);
+        for (const key of keys) {
+            result[key] = traverse(
+                [...path, key],
+                baseValue[key],
+                localValue[key],
+                remoteValue[key],
+            );
+        }
+        return result;
+    }
+
+    return {
+        draft: normalizeConfig(traverse([], base, local, remote)),
+        conflicts,
+    };
+}
+
+function applyFieldResolution(
+    result: Record<string, unknown>,
+    conflict: FieldConflict,
+    resolution: ConflictResolution,
+): void {
+    if (conflict.path.length === 0) return;
+    let current: Record<string, unknown> = result;
+    for (let index = 0; index < conflict.path.length - 1; index += 1) {
+        const next = current[conflict.path[index]!];
+        if (!isRecord(next)) return;
+        current = next;
+    }
+    current[conflict.path.at(-1)!] = resolution === 'local' ? conflict.localValue : conflict.remoteValue;
+}
+
+export interface ApplyResolutionsResult {
+    config: Config;
+    validationError: string | null;
+}
+
+export function applyResolutions(
+    diffConflictsResult: DiffConflictsResult,
+    resolutions: Record<string, ConflictResolution>,
+): ApplyResolutionsResult {
+    const result = structuredClone(diffConflictsResult.draft) as unknown as Record<string, unknown>;
+    for (const conflict of diffConflictsResult.conflicts) {
+        const resolution = resolutions[conflict.path.join('.')];
+        if (resolution) applyFieldResolution(result, conflict, resolution);
+    }
+
+    const config = normalizeConfig(result);
+    if (!configValuesEqual(config.on, true) && !configValuesEqual(config.on, false)) {
+        return {config, validationError: '插件状态字段无效'};
+    }
+    return {config, validationError: null};
+}

--- a/entrypoints/utils/google-drive/constants.ts
+++ b/entrypoints/utils/google-drive/constants.ts
@@ -1,0 +1,9 @@
+export const GOOGLE_DRIVE_CONFIG_FILENAME = 'fluentread-config.json' as const;
+export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = 'local:googleDriveToken' as const;
+export const GOOGLE_DRIVE_LAST_SYNC_STORAGE_KEY = 'local:googleDriveLastSync' as const;
+export const GOOGLE_DRIVE_SYNC_SCHEMA_VERSION = 1 as const;
+
+export const GOOGLE_DRIVE_SCOPES = [
+    'https://www.googleapis.com/auth/drive.appdata',
+    'https://www.googleapis.com/auth/userinfo.email',
+] as const;

--- a/entrypoints/utils/google-drive/storage.ts
+++ b/entrypoints/utils/google-drive/storage.ts
@@ -1,0 +1,173 @@
+import { storage } from '@wxt-dev/storage';
+import {
+    configReady,
+    getConfigSnapshot,
+    parseStoredConfig,
+    saveConfig,
+} from '@/entrypoints/utils/config';
+import {
+    normalizeConfig,
+    type Config,
+} from '@/entrypoints/utils/model';
+import {
+    GOOGLE_DRIVE_CONFIG_FILENAME,
+    GOOGLE_DRIVE_LAST_SYNC_STORAGE_KEY,
+    GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+} from './constants';
+import { downloadFile, findFileInAppData, uploadFile } from './api';
+import { getGoogleUserInfo, getValidAccessToken } from './auth';
+
+export interface ConfigSyncMeta {
+    schemaVersion: typeof GOOGLE_DRIVE_SYNC_SCHEMA_VERSION;
+    lastModifiedAt: number;
+}
+
+export interface ConfigValueAndMeta {
+    value: Config;
+    meta: ConfigSyncMeta;
+}
+
+export interface LastSyncedConfigMeta extends ConfigSyncMeta {
+    lastSyncedAt: number;
+    email: string;
+}
+
+export interface LastSyncedConfigValueAndMeta {
+    value: Config;
+    meta: LastSyncedConfigMeta;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseTimestamp(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function parseConfigValue(value: unknown): Config | null {
+    const parsed = parseStoredConfig(value);
+    return parsed ? normalizeConfig(parsed) : null;
+}
+
+export function parseRemoteConfig(content: string): ConfigValueAndMeta {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(content);
+    } catch {
+        throw new Error('Google Drive 配置不是有效的 JSON');
+    }
+
+    if (!isRecord(raw) || !isRecord(raw.meta)) {
+        throw new Error('Google Drive 配置缺少同步元数据');
+    }
+
+    const schemaVersion = raw.meta.schemaVersion;
+    if (schemaVersion !== GOOGLE_DRIVE_SYNC_SCHEMA_VERSION) {
+        if (typeof schemaVersion === 'number' && schemaVersion > GOOGLE_DRIVE_SYNC_SCHEMA_VERSION) {
+            throw new Error(`Google Drive 配置版本过新（${schemaVersion}），当前扩展仅支持版本 ${GOOGLE_DRIVE_SYNC_SCHEMA_VERSION}`);
+        }
+        throw new Error('Google Drive 配置版本不受支持');
+    }
+
+    const config = parseConfigValue(raw.value);
+    const lastModifiedAt = parseTimestamp(raw.meta.lastModifiedAt);
+    if (!config || lastModifiedAt === null) {
+        throw new Error('Google Drive 配置内容无效');
+    }
+
+    return {
+        value: config,
+        meta: {schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION, lastModifiedAt},
+    };
+}
+
+export async function getLocalConfigAndMeta(): Promise<ConfigValueAndMeta> {
+    await configReady;
+    return {
+        value: getConfigSnapshot(),
+        meta: {
+            schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+            lastModifiedAt: Date.now(),
+        },
+    };
+}
+
+export async function setLocalConfigAndMeta(config: Config): Promise<void> {
+    await saveConfig(normalizeConfig(config), {
+        recordHistory: true,
+        immediateHistory: true,
+    });
+}
+
+export async function getLastSyncedConfigAndMeta(): Promise<LastSyncedConfigValueAndMeta | null> {
+    const raw = await storage.getItem<unknown>(GOOGLE_DRIVE_LAST_SYNC_STORAGE_KEY);
+    if (!isRecord(raw) || !isRecord(raw.meta)) return null;
+
+    const value = parseConfigValue(raw.value);
+    const schemaVersion = raw.meta.schemaVersion;
+    const lastModifiedAt = parseTimestamp(raw.meta.lastModifiedAt);
+    const lastSyncedAt = parseTimestamp(raw.meta.lastSyncedAt);
+    const email = raw.meta.email;
+    if (!value
+        || schemaVersion !== GOOGLE_DRIVE_SYNC_SCHEMA_VERSION
+        || lastModifiedAt === null
+        || lastSyncedAt === null
+        || typeof email !== 'string'
+        || !email) {
+        return null;
+    }
+
+    return {
+        value,
+        meta: {
+            schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+            lastModifiedAt,
+            lastSyncedAt,
+            email,
+        },
+    };
+}
+
+export async function setLastSyncedConfigAndMeta(
+    config: Config,
+    meta: Omit<LastSyncedConfigMeta, 'schemaVersion'> & {schemaVersion?: typeof GOOGLE_DRIVE_SYNC_SCHEMA_VERSION},
+): Promise<void> {
+    await storage.setItem<LastSyncedConfigValueAndMeta>(GOOGLE_DRIVE_LAST_SYNC_STORAGE_KEY, {
+        value: normalizeConfig(config),
+        meta: {
+            schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+            lastModifiedAt: meta.lastModifiedAt,
+            lastSyncedAt: meta.lastSyncedAt,
+            email: meta.email,
+        },
+    });
+}
+
+export async function getRemoteConfigAndMetaWithUserEmail(): Promise<{
+    configValueAndMeta: ConfigValueAndMeta | null;
+    email: string;
+}> {
+    const accessToken = await getValidAccessToken();
+    const userInfo = await getGoogleUserInfo(accessToken);
+    const file = await findFileInAppData(GOOGLE_DRIVE_CONFIG_FILENAME);
+    if (!file) return {configValueAndMeta: null, email: userInfo.email};
+
+    const content = await downloadFile(file.id);
+    return {
+        configValueAndMeta: parseRemoteConfig(content),
+        email: userInfo.email,
+    };
+}
+
+export async function setRemoteConfigAndMeta(configValueAndMeta: ConfigValueAndMeta): Promise<void> {
+    const existingFile = await findFileInAppData(GOOGLE_DRIVE_CONFIG_FILENAME);
+    const content = JSON.stringify({
+        value: normalizeConfig(configValueAndMeta.value),
+        meta: {
+            schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+            lastModifiedAt: configValueAndMeta.meta.lastModifiedAt,
+        },
+    }, null, 2);
+    await uploadFile(GOOGLE_DRIVE_CONFIG_FILENAME, content, existingFile?.id);
+}

--- a/entrypoints/utils/google-drive/sync.ts
+++ b/entrypoints/utils/google-drive/sync.ts
@@ -1,0 +1,136 @@
+import { configReady, saveConfig } from '@/entrypoints/utils/config';
+import { normalizeConfig } from '@/entrypoints/utils/model';
+import {
+    configValuesEqual,
+} from './conflict-merge';
+import {
+    GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+} from './constants';
+import {
+    getLocalConfigAndMeta,
+    getLastSyncedConfigAndMeta,
+    getRemoteConfigAndMetaWithUserEmail,
+    setLastSyncedConfigAndMeta,
+    setLocalConfigAndMeta,
+    setRemoteConfigAndMeta,
+    type ConfigValueAndMeta,
+} from './storage';
+
+export type SyncAction = 'uploaded' | 'downloaded' | 'same-changes' | 'no-change';
+
+export interface UnresolvedConfigs {
+    base: ReturnType<typeof normalizeConfig>;
+    local: ReturnType<typeof normalizeConfig>;
+    remote: ReturnType<typeof normalizeConfig>;
+}
+
+export type SyncResult =
+    | {status: 'success'; action: SyncAction; email: string; syncedAt: number}
+    | {status: 'unresolved'; data: UnresolvedConfigs; email: string}
+    | {status: 'error'; error: Error};
+
+function createConfigValueAndMeta(value: ReturnType<typeof normalizeConfig>, lastModifiedAt = Date.now()): ConfigValueAndMeta {
+    return {
+        value: normalizeConfig(value),
+        meta: {
+            schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+            lastModifiedAt,
+        },
+    };
+}
+
+async function markSynced(
+    value: ReturnType<typeof normalizeConfig>,
+    email: string,
+    lastModifiedAt: number,
+    syncedAt: number,
+): Promise<void> {
+    await setLastSyncedConfigAndMeta(value, {
+        schemaVersion: GOOGLE_DRIVE_SYNC_SCHEMA_VERSION,
+        lastModifiedAt,
+        lastSyncedAt: syncedAt,
+        email,
+    });
+}
+
+export async function syncMergedConfig(mergedConfig: ReturnType<typeof normalizeConfig>, email: string): Promise<void> {
+    await configReady;
+    const now = Date.now();
+    const local = createConfigValueAndMeta(mergedConfig, now);
+    await saveConfig(local.value, {recordHistory: true, immediateHistory: true});
+    await setRemoteConfigAndMeta(local);
+    await markSynced(local.value, email, now, now);
+}
+
+export async function syncConfig(): Promise<SyncResult> {
+    try {
+        await configReady;
+        // Flush a change made immediately before clicking the sync button.
+        await saveConfig();
+
+        const local = await getLocalConfigAndMeta();
+        const lastSynced = await getLastSyncedConfigAndMeta();
+        const remoteResult = await getRemoteConfigAndMetaWithUserEmail();
+        const remote = remoteResult.configValueAndMeta;
+        const email = remoteResult.email;
+        const now = Date.now();
+
+        // A different Google account gets its own remote configuration as the
+        // source of truth, just like a first sync on a new browser profile.
+        if (!lastSynced || lastSynced.meta.email !== email) {
+            if (remote) {
+                await setLocalConfigAndMeta(remote.value);
+                await markSynced(remote.value, email, remote.meta.lastModifiedAt, now);
+                return {status: 'success', action: 'downloaded', email, syncedAt: now};
+            }
+
+            const localToUpload = createConfigValueAndMeta(local.value, now);
+            await setRemoteConfigAndMeta(localToUpload);
+            await markSynced(local.value, email, now, now);
+            return {status: 'success', action: 'uploaded', email, syncedAt: now};
+        }
+
+        const localChanged = !configValuesEqual(local.value, lastSynced.value);
+        const remoteChanged = Boolean(remote && !configValuesEqual(remote.value, lastSynced.value));
+
+        if (localChanged && remoteChanged && remote) {
+            if (configValuesEqual(local.value, remote.value)) {
+                const sameConfig = createConfigValueAndMeta(local.value, now);
+                await setRemoteConfigAndMeta(sameConfig);
+                await markSynced(local.value, email, now, now);
+                return {status: 'success', action: 'same-changes', email, syncedAt: now};
+            }
+
+            return {
+                status: 'unresolved',
+                data: {
+                    base: lastSynced.value,
+                    local: local.value,
+                    remote: remote.value,
+                },
+                email,
+            };
+        }
+
+        if (localChanged) {
+            const localToUpload = createConfigValueAndMeta(local.value, now);
+            await setRemoteConfigAndMeta(localToUpload);
+            await markSynced(local.value, email, now, now);
+            return {status: 'success', action: 'uploaded', email, syncedAt: now};
+        }
+
+        if (remoteChanged && remote) {
+            await setLocalConfigAndMeta(remote.value);
+            await markSynced(remote.value, email, remote.meta.lastModifiedAt, now);
+            return {status: 'success', action: 'downloaded', email, syncedAt: now};
+        }
+
+        await markSynced(local.value, email, lastSynced.meta.lastModifiedAt, now);
+        return {status: 'success', action: 'no-change', email, syncedAt: now};
+    } catch (error) {
+        return {
+            status: 'error',
+            error: error instanceof Error ? error : new Error(String(error)),
+        };
+    }
+}

--- a/tests/googleDriveConflict.test.ts
+++ b/tests/googleDriveConflict.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { Config, normalizeConfig } from '@/entrypoints/utils/model';
+import {
+    applyResolutions,
+    configValuesEqual,
+    detectConflicts,
+} from '@/entrypoints/utils/google-drive/conflict-merge';
+
+function makeConfig(): Config {
+    const config = new Config();
+    config.from = 'en';
+    config.to = 'zh-CN';
+    config.service = 'microsoft';
+    return normalizeConfig(config);
+}
+
+describe('Google Drive three-way config merge', () => {
+    it('compares object key order by value rather than serialization order', () => {
+        expect(configValuesEqual({a: 1, b: {c: 2}}, {b: {c: 2}, a: 1})).toBe(true);
+        expect(configValuesEqual({a: [1, 2]}, {a: [2, 1]})).toBe(false);
+    });
+
+    it('reports local-only and remote-only changes as choices', () => {
+        const base = makeConfig();
+        const local = normalizeConfig({...base, to: 'ja'});
+        const remote = normalizeConfig({...base, service: 'google'});
+
+        const result = detectConflicts(base, local, remote);
+
+        expect(result.conflicts.map((conflict) => conflict.path.join('.'))).toEqual(['to', 'service']);
+        expect(result.draft.to).toBe(base.to);
+        expect(result.draft.service).toBe(base.service);
+    });
+
+    it('auto-applies a value when both sides made the same change', () => {
+        const base = makeConfig();
+        const local = normalizeConfig({...base, to: 'ja'});
+        const remote = normalizeConfig({...base, to: 'ja'});
+
+        const result = detectConflicts(base, local, remote);
+
+        expect(result.conflicts).toHaveLength(0);
+        expect(result.draft.to).toBe('ja');
+    });
+
+    it('applies selected values and keeps the other fields from the draft', () => {
+        const base = makeConfig();
+        const local = normalizeConfig({...base, to: 'ja'});
+        const remote = normalizeConfig({...base, service: 'google'});
+        const diff = detectConflicts(base, local, remote);
+
+        const resolved = applyResolutions(diff, {
+            to: 'local',
+            service: 'remote',
+        });
+
+        expect(resolved.validationError).toBeNull();
+        expect(resolved.config.to).toBe('ja');
+        expect(resolved.config.service).toBe('google');
+    });
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 
 
 const packageJson = JSON.parse(fs.readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
+const googleClientId = process.env.WXT_GOOGLE_CLIENT_ID || '';
 const firefoxRunnerBinary = process.env.FLUENTREAD_FIREFOX_RUNNER_BINARY;
 const firefoxRunnerProfile = process.env.FLUENTREAD_FIREFOX_RUNNER_PROFILE;
 const firefoxRunnerStartUrl = process.env.FLUENTREAD_FIREFOX_RUNNER_START_URL;
@@ -72,10 +73,11 @@ export default defineConfig({
         plugins: [vue(), escapeExtensionNoncharacters()],
         define: {
             'process.env.VUE_APP_VERSION': JSON.stringify(packageJson.version),
+            'process.env.WXT_GOOGLE_CLIENT_ID': JSON.stringify(googleClientId),
         }
     }),
     manifest: {
-        permissions: ['storage', 'alarms', 'contextMenus', 'offscreen'],
+        permissions: ['storage', 'alarms', 'contextMenus', 'offscreen', 'identity'],
         content_security_policy: {
             extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
         },
@@ -83,6 +85,8 @@ export default defineConfig({
             'https://translate.google.com/*',
             'https://translate.google.co.uk/*',
             'https://translate.googleapis.com/*',
+            'https://accounts.google.com/*',
+            'https://www.googleapis.com/*',
             'https://dev.microsofttranslator.com/*',
             'https://*.tts.speech.microsoft.com/*',
             'https://deeplx.1stg.me/*',


### PR DESCRIPTION
## Summary

- add optional Google OAuth and Google Drive appDataFolder sync for FluentRead configuration
- persist local sync metadata and detect field-level local/remote conflicts before merge
- place local import/export immediately below the Google Drive sync card
- add setup documentation, build-time client ID configuration, and conflict-merge tests

## Validation

- pnpm compile
- pnpm test — 22 test files, 215 tests passed
- pnpm build — Chrome MV3 production build passed
- isolated Edge production targeted UI check — Google Drive → local import/export → configuration history order passed, buttons visible, console errors: 0
- git diff --check

## UI test note

The full UI helper was also run against the production artifact. It stops at an existing stale assertion expecting 备份与迁移配置; the current intended heading is 备份与同步配置. The targeted Google Drive layout assertions pass independently.

## Configuration

Live OAuth requires setting WXT_GOOGLE_CLIENT_ID before rebuilding the extension.