### PR TITLE
feat: add polished AI translation context button

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -145,7 +145,7 @@
       <div class="translate-action">
         <button
           class="translate-button"
-          :class="{ translated: pageTranslated, 'has-ai-context': canUseAIContext }"
+          :class="{ translated: pageTranslated }"
           type="button"
           :disabled="!config.on || translating"
           :aria-pressed="pageTranslated"
@@ -162,12 +162,12 @@
           type="button"
           role="switch"
           :aria-checked="config.enableAIContext"
-          :aria-label="config.enableAIContext ? '关闭 AI 智能上下文' : '开启 AI 智能上下文'"
-          :title="config.enableAIContext ? '关闭 AI 智能上下文' : '开启 AI 智能上下文'"
+          :aria-label="config.enableAIContext ? '关闭 AI精翻' : '开启 AI精翻'"
+          :title="config.enableAIContext ? '关闭 AI精翻' : '开启 AI精翻'"
           :disabled="!config.on || translating"
           @click="toggleAIContext"
         >
-          <span class="ai-context-copy"><strong>AI 智能</strong><small>上下文</small></span>
+          <span class="ai-context-copy">AI精翻</span>
           <i aria-hidden="true" />
         </button>
       </div>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -160,15 +160,13 @@
           v-if="canUseAIContext"
           class="ai-context-toggle"
           type="button"
-          role="switch"
-          :aria-checked="config.enableAIContext"
+          :aria-pressed="config.enableAIContext"
           :aria-label="config.enableAIContext ? '关闭 AI精翻' : '开启 AI精翻'"
           :title="config.enableAIContext ? '关闭 AI精翻' : '开启 AI精翻'"
           :disabled="!config.on || translating"
           @click="toggleAIContext"
         >
           <span class="ai-context-copy">AI精翻</span>
-          <i aria-hidden="true" />
         </button>
       </div>
       <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -167,7 +167,7 @@
           @click="toggleAIContext"
         >
           <span class="ai-context-copy">AI精翻</span>
-          <span class="ai-context-state">{{ config.enableAIContext ? '已开启' : '已关闭' }}</span>
+          <span class="ai-context-indicator" aria-hidden="true" />
         </button>
       </div>
       <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -167,6 +167,7 @@
           @click="toggleAIContext"
         >
           <span class="ai-context-copy">AI精翻</span>
+          <span class="ai-context-state">{{ config.enableAIContext ? '已开启' : '已关闭' }}</span>
         </button>
       </div>
       <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -142,19 +142,35 @@
         <button type="button" @click="openOptions('settings-services')">去设置</button>
       </div>
 
-      <button
-        class="translate-button"
-        :class="{ translated: pageTranslated }"
-        type="button"
-        :disabled="!config.on || translating"
-        :aria-pressed="pageTranslated"
-        @click="togglePageTranslation"
-      >
-        <span v-if="translating" class="spinner" />
-        <span v-else class="translate-glyph">A↔译</span>
-        <span class="translate-label">{{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}</span>
-        <kbd class="translate-hotkey" :class="{ disabled: fullPageHotkey === '未设置' }">{{ fullPageHotkey }}</kbd>
-      </button>
+      <div class="translate-action">
+        <button
+          class="translate-button"
+          :class="{ translated: pageTranslated, 'has-ai-context': canUseAIContext }"
+          type="button"
+          :disabled="!config.on || translating"
+          :aria-pressed="pageTranslated"
+          @click="togglePageTranslation"
+        >
+          <span v-if="translating" class="spinner" />
+          <span v-else class="translate-glyph">A↔译</span>
+          <span class="translate-label">{{ pageTranslated ? '恢复当前网页' : '翻译当前网页' }}</span>
+          <kbd class="translate-hotkey" :class="{ disabled: fullPageHotkey === '未设置' }">{{ fullPageHotkey }}</kbd>
+        </button>
+        <button
+          v-if="canUseAIContext"
+          class="ai-context-toggle"
+          type="button"
+          role="switch"
+          :aria-checked="config.enableAIContext"
+          :aria-label="config.enableAIContext ? '关闭 AI 智能上下文' : '开启 AI 智能上下文'"
+          :title="config.enableAIContext ? '关闭 AI 智能上下文' : '开启 AI 智能上下文'"
+          :disabled="!config.on || translating"
+          @click="toggleAIContext"
+        >
+          <span class="ai-context-copy"><strong>AI 智能</strong><small>上下文</small></span>
+          <i aria-hidden="true" />
+        </button>
+      </div>
       <p v-if="notice" class="notice" :class="noticeType">{{ notice }}</p>
     </section>
 
@@ -381,7 +397,7 @@ import {
 } from '@/entrypoints/utils/config';
 import { Setting } from '@element-plus/icons-vue';
 import { Config } from '@/entrypoints/utils/model';
-import { options } from '@/entrypoints/utils/option';
+import { options, resolveConfiguredModel, servicesType } from '@/entrypoints/utils/option';
 import { getMissingCredentialMessage } from '@/entrypoints/utils/configValidation';
 import { getSelectedModelLabel } from '@/entrypoints/utils/serviceCatalog';
 import ServiceIcon from '@/components/ServiceIcon.vue';
@@ -431,6 +447,11 @@ const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const serviceLabel = computed(() => serviceOptions.value.find((item: any) => item.value === config.value.service)?.label || config.value.service);
 const serviceModelLabel = computed(() => getSelectedModelLabel(config.value.service, config.value.model, config.value.customModel));
+const aiContextModel = computed(() => resolveConfiguredModel(
+  config.value.model[config.value.service],
+  config.value.customModel[config.value.service],
+));
+const canUseAIContext = computed(() => servicesType.isUseAIContext(config.value.service, aiContextModel.value));
 const servicePickerAriaLabel = computed(() => serviceModelLabel.value
   ? `翻译服务：${serviceLabel.value}，当前模型：${serviceModelLabel.value}`
   : `翻译服务：${serviceLabel.value}`);
@@ -534,6 +555,10 @@ function toggleServicePicker() {
 function selectService(value: string) {
   config.value.service = value;
   servicePickerOpen.value = false;
+}
+function toggleAIContext() {
+  if (!canUseAIContext.value || !config.value.on || translating.value) return;
+  config.value.enableAIContext = !config.value.enableAIContext;
 }
 onMounted(() => {
   document.addEventListener('pointerdown', closeServicePicker);

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -179,7 +179,7 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
-  position: relative; display: flex; flex: 0 0 64px; flex-direction: column; align-items: center; justify-content: center; gap: 2px; height: 42px; padding: 0 6px;
+  position: relative; display: flex; flex: 0 0 64px; align-items: center; justify-content: center; height: 42px; padding: 0 6px;
   overflow: hidden; border: 1px solid rgba(255, 255, 255, .34); border-radius: 10px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); cursor: pointer;
   transition: transform 160ms cubic-bezier(.2, .8, .2, 1), border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease;
@@ -193,7 +193,10 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .ai-context-toggle:focus-visible { outline: 2px solid rgba(239, 71, 118, .42); outline-offset: 2px; }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
 .ai-context-copy { position: relative; z-index: 1; min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; letter-spacing: .01em; line-height: 1; text-overflow: ellipsis; white-space: nowrap; }
-.ai-context-state { position: relative; z-index: 1; font-size: 8px; font-weight: 700; letter-spacing: .02em; line-height: 1; opacity: .76; white-space: nowrap; }
+.ai-context-indicator {
+  position: absolute; z-index: 1; top: 7px; right: 7px; width: 5px; height: 5px; border-radius: 50%; color: inherit; background: currentColor;
+  opacity: .48; box-shadow: 0 0 0 3px rgba(239, 71, 118, .08); transition: opacity 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
 .ai-context-toggle[aria-pressed="false"] {
   border-color: rgba(239, 71, 118, .18); color: rgba(210, 52, 96, .84);
   background: linear-gradient(180deg, rgba(255, 255, 255, .86), rgba(255, 237, 244, .72));
@@ -204,8 +207,10 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
   background: linear-gradient(180deg, rgba(255, 255, 255, .92), rgba(255, 232, 241, .8));
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, .78), 0 7px 14px rgba(233, 50, 103, .14);
 }
+.ai-context-toggle[aria-pressed="false"]:hover:not(:disabled) .ai-context-indicator { opacity: .72; box-shadow: 0 0 0 3px rgba(239, 71, 118, .14); }
 .ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); }
 .ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .32), 0 10px 19px rgba(233, 50, 103, .25); }
+.ai-context-toggle[aria-pressed="true"] .ai-context-indicator { opacity: 1; background: #fff; box-shadow: 0 0 0 3px rgba(255, 255, 255, .18), 0 0 8px rgba(255, 255, 255, .72); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -159,14 +159,13 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-more-meta b { color: var(--muted); font-size: 15px; line-height: .7; font-weight: 500; transform: translateY(-1px); transition: transform 160ms ease; }
 .service-more-meta b.open { transform: translateY(1px) rotate(180deg); }
 
-.translate-action { position: relative; margin-top: 11px; }
+.translate-action { display: flex; align-items: stretch; gap: 7px; margin-top: 11px; }
 .translate-button {
-  display: flex; align-items: center; justify-content: center; gap: 9px; width: 100%; height: 42px;
+  display: flex; flex: 1 1 auto; align-items: center; justify-content: center; gap: 9px; min-width: 0; height: 42px;
   border: 0; border-radius: 14px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
   box-shadow: 0 10px 22px rgba(233, 50, 103, .24); font-size: 13px; font-weight: 750; cursor: pointer;
   transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
-.translate-button.has-ai-context { padding-right: 88px; }
 .translate-button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
 .translate-button.translated { background: linear-gradient(135deg, #35b98a, #15966e); box-shadow: 0 10px 22px rgba(21, 150, 110, .24); }
 .translate-button.translated:hover:not(:disabled) { box-shadow: 0 13px 26px rgba(21, 150, 110, .3); }
@@ -180,20 +179,19 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
-  position: absolute; z-index: 1; top: 4px; right: 5px; bottom: 4px; display: flex; align-items: center; justify-content: center; gap: 5px; width: 80px;
-  padding: 0 5px; border: 1px solid rgba(255, 255, 255, .34); border-radius: 10px; color: #fff; background: rgba(255, 255, 255, .12);
-  cursor: pointer; transition: border-color 160ms ease, background 160ms ease, opacity 160ms ease;
+  display: flex; flex: 0 0 91px; align-items: center; justify-content: center; gap: 6px; height: 42px; padding: 0 8px;
+  border: 1px solid rgba(239, 71, 118, .28); border-radius: 14px; color: var(--brand-strong); background: var(--brand-soft);
+  box-shadow: 0 8px 18px rgba(233, 50, 103, .1); cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
-.ai-context-toggle:hover:not(:disabled) { border-color: rgba(255, 255, 255, .7); background: rgba(255, 255, 255, .2); }
+.ai-context-toggle:hover:not(:disabled) { border-color: rgba(239, 71, 118, .55); background: #ffe5ed; box-shadow: 0 10px 22px rgba(233, 50, 103, .15); }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
-.ai-context-copy { display: flex; min-width: 0; flex-direction: column; align-items: flex-end; line-height: 1.05; }
-.ai-context-copy strong { font-size: 8px; font-weight: 800; white-space: nowrap; }
-.ai-context-copy small { margin-top: 2px; font-size: 8px; white-space: nowrap; }
-.ai-context-toggle > i { position: relative; display: block; width: 27px; height: 15px; flex: none; border-radius: 999px; background: rgba(20, 26, 39, .3); transition: background 160ms ease; }
-.ai-context-toggle > i::after { position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; border-radius: 50%; background: #fff; box-shadow: 0 1px 3px rgba(20, 26, 39, .2); content: ''; transition: transform 180ms ease; }
-.ai-context-toggle[aria-checked="true"] { border-color: rgba(255, 255, 255, .7); background: rgba(255, 255, 255, .2); }
-.ai-context-toggle[aria-checked="true"] > i { background: rgba(255, 255, 255, .52); }
-.ai-context-toggle[aria-checked="true"] > i::after { background: #fff; transform: translateX(12px); }
+.ai-context-copy { min-width: 0; overflow: hidden; font-size: 11px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+.ai-context-toggle > i { position: relative; display: block; width: 25px; height: 14px; flex: none; border-radius: 999px; background: rgba(220, 49, 95, .22); transition: background 160ms ease; }
+.ai-context-toggle > i::after { position: absolute; top: 2px; left: 2px; width: 10px; height: 10px; border-radius: 50%; background: #fff; box-shadow: 0 1px 3px rgba(20, 26, 39, .2); content: ''; transition: transform 180ms ease; }
+.ai-context-toggle[aria-checked="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 22px rgba(233, 50, 103, .24); }
+.ai-context-toggle[aria-checked="true"] > i { background: rgba(255, 255, 255, .5); }
+.ai-context-toggle[aria-checked="true"] > i::after { background: #fff; transform: translateX(11px); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -210,7 +210,7 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .ai-context-toggle[aria-pressed="false"]:hover:not(:disabled) .ai-context-indicator { opacity: .72; box-shadow: 0 0 0 3px rgba(239, 71, 118, .14); }
 .ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); }
 .ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .32), 0 10px 19px rgba(233, 50, 103, .25); }
-.ai-context-toggle[aria-pressed="true"] .ai-context-indicator { opacity: 1; background: #fff; box-shadow: 0 0 0 3px rgba(255, 255, 255, .18), 0 0 8px rgba(255, 255, 255, .72); }
+.ai-context-toggle[aria-pressed="true"] .ai-context-indicator { opacity: 1; background: #24b47e; box-shadow: 0 0 0 3px rgba(36, 180, 126, .14), 0 0 8px rgba(36, 180, 126, .3); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -179,26 +179,32 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
-  display: flex; flex: 0 0 78px; align-items: center; justify-content: center; height: 36px; padding: 0 6px;
-  border: 1px solid rgba(255, 255, 255, .3); border-radius: 12px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
-  box-shadow: 0 8px 18px rgba(233, 50, 103, .2); cursor: pointer;
-  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+  position: relative; display: flex; flex: 0 0 64px; align-items: center; justify-content: center; height: 28px; padding: 0 6px;
+  overflow: hidden; border: 1px solid rgba(255, 255, 255, .34); border-radius: 10px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); cursor: pointer;
+  transition: transform 160ms cubic-bezier(.2, .8, .2, 1), border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease;
 }
-.ai-context-toggle:hover:not(:disabled) { border-color: rgba(255, 255, 255, .7); box-shadow: 0 10px 20px rgba(233, 50, 103, .26); transform: translateY(-1px); }
+.ai-context-toggle::before {
+  position: absolute; top: 1px; right: 1px; left: 1px; height: 45%; border-radius: inherit;
+  background: linear-gradient(180deg, rgba(255, 255, 255, .26), transparent); content: ''; pointer-events: none;
+}
+.ai-context-toggle:hover:not(:disabled) { border-color: rgba(255, 255, 255, .74); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .32), 0 10px 20px rgba(233, 50, 103, .26); transform: translateY(-1px); }
+.ai-context-toggle:active:not(:disabled) { box-shadow: inset 0 1px 2px rgba(138, 27, 67, .16), 0 3px 8px rgba(233, 50, 103, .14); transform: translateY(0) scale(.96); }
+.ai-context-toggle:focus-visible { outline: 2px solid rgba(239, 71, 118, .42); outline-offset: 2px; }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
-.ai-context-copy { min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+.ai-context-copy { position: relative; z-index: 1; min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; letter-spacing: .01em; text-overflow: ellipsis; white-space: nowrap; }
 .ai-context-toggle[aria-pressed="false"] {
-  border-color: rgba(255, 255, 255, .28); color: rgba(255, 255, 255, .9);
-  background: linear-gradient(rgba(148, 158, 171, .18), rgba(148, 158, 171, .18)), linear-gradient(135deg, #f35482, #e93267);
-  box-shadow: 0 7px 16px rgba(233, 50, 103, .14);
+  border-color: rgba(239, 71, 118, .18); color: rgba(210, 52, 96, .84);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .86), rgba(255, 237, 244, .72));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .96), 0 4px 10px rgba(233, 50, 103, .07);
 }
 .ai-context-toggle[aria-pressed="false"]:hover:not(:disabled) {
-  border-color: rgba(255, 255, 255, .52);
-  background: linear-gradient(rgba(148, 158, 171, .24), rgba(148, 158, 171, .24)), linear-gradient(135deg, #f35482, #e93267);
-  box-shadow: 0 9px 18px rgba(233, 50, 103, .2);
+  border-color: rgba(239, 71, 118, .36); color: var(--brand-strong);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .92), rgba(255, 232, 241, .8));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .78), 0 7px 14px rgba(233, 50, 103, .14);
 }
-.ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 8px 18px rgba(233, 50, 103, .2); }
-.ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 20px rgba(233, 50, 103, .26); }
+.ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); }
+.ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: inset 0 1px 0 rgba(255, 255, 255, .32), 0 10px 19px rgba(233, 50, 103, .25); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -159,7 +159,7 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-more-meta b { color: var(--muted); font-size: 15px; line-height: .7; font-weight: 500; transform: translateY(-1px); transition: transform 160ms ease; }
 .service-more-meta b.open { transform: translateY(1px) rotate(180deg); }
 
-.translate-action { display: flex; align-items: stretch; gap: 7px; margin-top: 11px; }
+.translate-action { display: flex; align-items: center; gap: 7px; margin-top: 11px; }
 .translate-button {
   display: flex; flex: 1 1 auto; align-items: center; justify-content: center; gap: 9px; min-width: 0; height: 42px;
   border: 0; border-radius: 14px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
@@ -179,16 +179,26 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
-  display: flex; flex: 0 0 91px; align-items: center; justify-content: center; gap: 6px; height: 42px; padding: 0 8px;
-  border: 1px solid rgba(120, 128, 145, .26); border-radius: 14px; color: var(--muted); background: rgba(120, 128, 145, .16);
-  box-shadow: none; cursor: pointer;
-  transition: border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+  display: flex; flex: 0 0 78px; align-items: center; justify-content: center; height: 36px; padding: 0 6px;
+  border: 1px solid rgba(255, 255, 255, .3); border-radius: 12px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
+  box-shadow: 0 8px 18px rgba(233, 50, 103, .2); cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
-.ai-context-toggle:hover:not(:disabled) { border-color: rgba(120, 128, 145, .48); background: rgba(120, 128, 145, .24); }
+.ai-context-toggle:hover:not(:disabled) { border-color: rgba(255, 255, 255, .7); box-shadow: 0 10px 20px rgba(233, 50, 103, .26); transform: translateY(-1px); }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
-.ai-context-copy { min-width: 0; overflow: hidden; font-size: 11px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
-.ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 22px rgba(233, 50, 103, .24); }
-.ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
+.ai-context-copy { min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+.ai-context-toggle[aria-pressed="false"] {
+  border-color: rgba(255, 255, 255, .28); color: rgba(255, 255, 255, .9);
+  background: linear-gradient(rgba(148, 158, 171, .18), rgba(148, 158, 171, .18)), linear-gradient(135deg, #f35482, #e93267);
+  box-shadow: 0 7px 16px rgba(233, 50, 103, .14);
+}
+.ai-context-toggle[aria-pressed="false"]:hover:not(:disabled) {
+  border-color: rgba(255, 255, 255, .52);
+  background: linear-gradient(rgba(148, 158, 171, .24), rgba(148, 158, 171, .24)), linear-gradient(135deg, #f35482, #e93267);
+  box-shadow: 0 9px 18px rgba(233, 50, 103, .2);
+}
+.ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 8px 18px rgba(233, 50, 103, .2); }
+.ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 20px rgba(233, 50, 103, .26); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -159,12 +159,14 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .service-more-meta b { color: var(--muted); font-size: 15px; line-height: .7; font-weight: 500; transform: translateY(-1px); transition: transform 160ms ease; }
 .service-more-meta b.open { transform: translateY(1px) rotate(180deg); }
 
+.translate-action { position: relative; margin-top: 11px; }
 .translate-button {
-  display: flex; align-items: center; justify-content: center; gap: 9px; width: 100%; height: 42px; margin-top: 11px;
+  display: flex; align-items: center; justify-content: center; gap: 9px; width: 100%; height: 42px;
   border: 0; border-radius: 14px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
   box-shadow: 0 10px 22px rgba(233, 50, 103, .24); font-size: 13px; font-weight: 750; cursor: pointer;
   transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
+.translate-button.has-ai-context { padding-right: 88px; }
 .translate-button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
 .translate-button.translated { background: linear-gradient(135deg, #35b98a, #15966e); box-shadow: 0 10px 22px rgba(21, 150, 110, .24); }
 .translate-button.translated:hover:not(:disabled) { box-shadow: 0 13px 26px rgba(21, 150, 110, .3); }
@@ -177,6 +179,21 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 }
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
+.ai-context-toggle {
+  position: absolute; z-index: 1; top: 4px; right: 5px; bottom: 4px; display: flex; align-items: center; justify-content: center; gap: 5px; width: 80px;
+  padding: 0 5px; border: 1px solid rgba(255, 255, 255, .34); border-radius: 10px; color: #fff; background: rgba(255, 255, 255, .12);
+  cursor: pointer; transition: border-color 160ms ease, background 160ms ease, opacity 160ms ease;
+}
+.ai-context-toggle:hover:not(:disabled) { border-color: rgba(255, 255, 255, .7); background: rgba(255, 255, 255, .2); }
+.ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
+.ai-context-copy { display: flex; min-width: 0; flex-direction: column; align-items: flex-end; line-height: 1.05; }
+.ai-context-copy strong { font-size: 8px; font-weight: 800; white-space: nowrap; }
+.ai-context-copy small { margin-top: 2px; font-size: 8px; white-space: nowrap; }
+.ai-context-toggle > i { position: relative; display: block; width: 27px; height: 15px; flex: none; border-radius: 999px; background: rgba(20, 26, 39, .3); transition: background 160ms ease; }
+.ai-context-toggle > i::after { position: absolute; top: 2px; left: 2px; width: 11px; height: 11px; border-radius: 50%; background: #fff; box-shadow: 0 1px 3px rgba(20, 26, 39, .2); content: ''; transition: transform 180ms ease; }
+.ai-context-toggle[aria-checked="true"] { border-color: rgba(255, 255, 255, .7); background: rgba(255, 255, 255, .2); }
+.ai-context-toggle[aria-checked="true"] > i { background: rgba(255, 255, 255, .52); }
+.ai-context-toggle[aria-checked="true"] > i::after { background: #fff; transform: translateX(12px); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -179,7 +179,7 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-hotkey.disabled { opacity: .72; }
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
-  position: relative; display: flex; flex: 0 0 64px; align-items: center; justify-content: center; height: 28px; padding: 0 6px;
+  position: relative; display: flex; flex: 0 0 64px; flex-direction: column; align-items: center; justify-content: center; gap: 2px; height: 42px; padding: 0 6px;
   overflow: hidden; border: 1px solid rgba(255, 255, 255, .34); border-radius: 10px; color: #fff; background: linear-gradient(135deg, #f35482, #e93267);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, .24), 0 7px 15px rgba(233, 50, 103, .18); cursor: pointer;
   transition: transform 160ms cubic-bezier(.2, .8, .2, 1), border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease;
@@ -192,7 +192,8 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .ai-context-toggle:active:not(:disabled) { box-shadow: inset 0 1px 2px rgba(138, 27, 67, .16), 0 3px 8px rgba(233, 50, 103, .14); transform: translateY(0) scale(.96); }
 .ai-context-toggle:focus-visible { outline: 2px solid rgba(239, 71, 118, .42); outline-offset: 2px; }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
-.ai-context-copy { position: relative; z-index: 1; min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; letter-spacing: .01em; text-overflow: ellipsis; white-space: nowrap; }
+.ai-context-copy { position: relative; z-index: 1; min-width: 0; overflow: hidden; font-size: 10px; font-weight: 800; letter-spacing: .01em; line-height: 1; text-overflow: ellipsis; white-space: nowrap; }
+.ai-context-state { position: relative; z-index: 1; font-size: 8px; font-weight: 700; letter-spacing: .02em; line-height: 1; opacity: .76; white-space: nowrap; }
 .ai-context-toggle[aria-pressed="false"] {
   border-color: rgba(239, 71, 118, .18); color: rgba(210, 52, 96, .84);
   background: linear-gradient(180deg, rgba(255, 255, 255, .86), rgba(255, 237, 244, .72));

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -180,18 +180,15 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .translate-button.translated .translate-hotkey { border-color: rgba(255, 255, 255, .48); background: rgba(255, 255, 255, .18); }
 .ai-context-toggle {
   display: flex; flex: 0 0 91px; align-items: center; justify-content: center; gap: 6px; height: 42px; padding: 0 8px;
-  border: 1px solid rgba(239, 71, 118, .28); border-radius: 14px; color: var(--brand-strong); background: var(--brand-soft);
-  box-shadow: 0 8px 18px rgba(233, 50, 103, .1); cursor: pointer;
+  border: 1px solid rgba(120, 128, 145, .26); border-radius: 14px; color: var(--muted); background: rgba(120, 128, 145, .16);
+  box-shadow: none; cursor: pointer;
   transition: border-color 160ms ease, background 160ms ease, color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
-.ai-context-toggle:hover:not(:disabled) { border-color: rgba(239, 71, 118, .55); background: #ffe5ed; box-shadow: 0 10px 22px rgba(233, 50, 103, .15); }
+.ai-context-toggle:hover:not(:disabled) { border-color: rgba(120, 128, 145, .48); background: rgba(120, 128, 145, .24); }
 .ai-context-toggle:disabled { cursor: not-allowed; opacity: .58; }
 .ai-context-copy { min-width: 0; overflow: hidden; font-size: 11px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
-.ai-context-toggle > i { position: relative; display: block; width: 25px; height: 14px; flex: none; border-radius: 999px; background: rgba(220, 49, 95, .22); transition: background 160ms ease; }
-.ai-context-toggle > i::after { position: absolute; top: 2px; left: 2px; width: 10px; height: 10px; border-radius: 50%; background: #fff; box-shadow: 0 1px 3px rgba(20, 26, 39, .2); content: ''; transition: transform 180ms ease; }
-.ai-context-toggle[aria-checked="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 22px rgba(233, 50, 103, .24); }
-.ai-context-toggle[aria-checked="true"] > i { background: rgba(255, 255, 255, .5); }
-.ai-context-toggle[aria-checked="true"] > i::after { background: #fff; transform: translateX(11px); }
+.ai-context-toggle[aria-pressed="true"] { border-color: transparent; color: #fff; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 10px 22px rgba(233, 50, 103, .24); }
+.ai-context-toggle[aria-pressed="true"]:hover:not(:disabled) { border-color: transparent; background: linear-gradient(135deg, #f35482, #e93267); box-shadow: 0 13px 26px rgba(233, 50, 103, .3); }
 .spinner { width: 16px; height: 16px; border: 2px solid rgba(255, 255, 255, .45); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 .credential-warning {


### PR DESCRIPTION
## Summary

- Add a separate `AI精翻` action beside the main page-translation button for AI-context-capable models.
- Keep the AI context setting as a persisted `aria-pressed` toggle without a switch icon or bulky status text.
- Polish the compact button with the same 42px height as the main action, soft inactive treatment, pink active treatment, tactile states, and a green active status dot consistent with the popup feature cards.

## Validation

- `pnpm compile`
- `pnpm test -- tests/model.test.ts tests/serviceCatalog.test.ts tests/config.test.ts tests/selectionTranslatorCore.test.ts` — 79 tests passed
- `pnpm build`
- Production FluentRead popup suite in an isolated screen-off Microsoft Edge profile — all popup core, accessibility, drawer, persistence, keyboard-focus, and dark-theme assertions passed; no overflow, console errors, duplicate IDs, or unnamed interactive controls.
- Real popup proof confirmed the AI button is 64x42, the enabled indicator is `#24b47e`, and the enabled state persists after reload.

## Baseline note

The broader UI suite has an existing unrelated services assertion for the model list's independent scrolling area (`modelScrollHeight=373`, `modelClientHeight=373`). The focused production popup suite passes.
