### PR TITLE
fix: balance floating ball action icon sizes

### DIFF
--- a/components/FloatingBall.vue
+++ b/components/FloatingBall.vue
@@ -366,7 +366,7 @@ watch(() => props.position, (newPosition) => {
   border: 0;
   border-radius: 12px;
   background: transparent;
-  cursor: pointer;
+  cursor: grab;
   opacity: 1;
   overflow: visible;
 }
@@ -401,14 +401,14 @@ watch(() => props.position, (newPosition) => {
 }
 
 .translation-icon {
-  width: 21px;
-  height: 21px;
+  width: 18px;
+  height: 18px;
 }
 
 .floating-ball-tool {
   display: inline-flex;
-  width: 44px;
-  height: 44px;
+  width: 32px;
+  height: 32px;
   align-items: center;
   justify-content: center;
   padding: 0;
@@ -471,8 +471,8 @@ watch(() => props.position, (newPosition) => {
 }
 
 .floating-ball-settings svg {
-  width: 21px;
-  height: 21px;
+  width: 18px;
+  height: 18px;
 }
 
 .shortcut-tooltip {


### PR DESCRIPTION
## Summary

- Keep the center FluentRead logo display-only and draggable; clicking it does not trigger full-page translation.
- Reduce the top full-translation and bottom settings controls from 44px to 32px.
- Reduce both control icons from 21px to 18px so the three visible controls feel proportionate.

## Validation

- `pnpm compile`
- `pnpm test` — 28 files, 372 tests passed
- `pnpm build`
- `git diff --check`
- Real Microsoft Edge validation with a generated temporary profile and screen-off window:
  - center element is `DIV[role="img"]` with no click handler
  - tool buttons are 32px with 18px icons
  - center click leaves translation count at 0 and keeps the URL unchanged
  - screenshot: `/private/tmp/fluentread-floating-ball-size-evidence/floating-ball-after-hover.png`
