### PR TITLE
feat: add Xiaomi MiMo translation service

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -892,6 +892,7 @@ const createServiceCompute = (serviceSource: ServiceSource) => ({
   showCustom: computed(() => servicesType.isCustom(serviceSource.value)),
   showDeepLX: computed(() => serviceSource.value === 'deeplx'),
   showMiniMaxRegion: computed(() => serviceSource.value === services.minimax),
+  showMiMoRegion: computed(() => serviceSource.value === services.mimo),
   showCustomModel: computed(
     () =>
       servicesType.isAI(serviceSource.value) &&

--- a/components/ServiceConfiguration.vue
+++ b/components/ServiceConfiguration.vue
@@ -94,6 +94,41 @@
       <code>{{ minimaxEndpoint }}</code>
     </div>
 
+    <p v-if="compute.showMiMoRegion && mimoKeyMismatch" class="mimo-key-note is-warning">
+      {{ mimoKeyMismatch }}
+    </p>
+
+    <el-row v-show="compute.showMiMoRegion" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="按量付费和 Token Plan 使用不同的账户权益；请按小米 MiMo 控制台中 Key 的来源选择。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">小米 MiMo 计费方式<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.mimoBillingPlan" aria-label="小米 MiMo 计费方式" placeholder="请选择小米 MiMo 计费方式">
+          <el-option class="select-left" v-for="item in options.mimoBillingPlan" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
+    <el-row v-show="compute.showMiMoRegion" class="margin-bottom margin-left-2em">
+      <el-col :span="12" class="lightblue rounded-corner">
+        <el-tooltip class="box-item" effect="dark" content="Token Plan 必须使用购买页面提供的集群地址；中国、新加坡和欧洲集群的 tp- Key 不能混用。按量付费统一使用 api.xiaomimimo.com。" placement="top-start" :show-after="500">
+          <span class="popup-text popup-vertical-left">MiMo API 集群<el-icon class="icon-margin"><InfoFilled /></el-icon></span>
+        </el-tooltip>
+      </el-col>
+      <el-col :span="12">
+        <el-select v-model="config.mimoRegion" aria-label="小米 MiMo API 集群" placeholder="请选择小米 MiMo API 集群">
+          <el-option class="select-left" v-for="item in options.mimoRegion" :key="item.value" :label="item.label" :value="item.value" />
+        </el-select>
+      </el-col>
+    </el-row>
+
+    <div v-show="compute.showMiMoRegion" class="mimo-endpoint" data-mimo-endpoint>
+      <span>当前 API 地址</span>
+      <code>{{ mimoEndpoint }}</code>
+    </div>
+
     <el-row v-show="compute.showAzureOpenaiEndpoint" class="margin-bottom margin-left-2em">
       <el-col :span="12" class="lightblue rounded-corner">
         <el-tooltip class="box-item" effect="dark" content="Azure OpenAI 服务端点地址，必须包含完整的部署信息。" placement="top-start" :show-after="500">
@@ -186,7 +221,7 @@ import { options as optionConfig } from '@/entrypoints/utils/option'
 import { isValidCustomBody } from '@/entrypoints/utils/custom-body'
 import browser from 'webextension-polyfill'
 import { requestConfigSave } from '@/entrypoints/utils/config'
-import { CONNECTION_TEST_MESSAGE, MINIMAX_ENDPOINTS } from '@/entrypoints/utils/constant'
+import { CONNECTION_TEST_MESSAGE, getMimoEndpoint, MINIMAX_ENDPOINTS } from '@/entrypoints/utils/constant'
 
 const props = defineProps<{
   config: Config
@@ -224,6 +259,33 @@ const minimaxEndpoint = computed(() => {
   const plan = config.value.minimaxBillingPlan === 'token-plan' ? 'token-plan' : 'payg'
   const region = config.value.minimaxRegion === 'cn' ? 'cn' : 'global'
   return MINIMAX_ENDPOINTS[plan][region]
+})
+
+const mimoKeyKind = computed(() => {
+  const token = config.value.token[service.value]?.trim() || ''
+  if (token.startsWith('tp-')) return 'token-plan'
+  if (token.startsWith('sk-')) return 'payg'
+  return token ? 'other' : 'empty'
+})
+
+const mimoKeyMismatch = computed(() => {
+  if (mimoKeyKind.value === 'empty') return ''
+  if (config.value.mimoBillingPlan === 'token-plan' && mimoKeyKind.value !== 'token-plan') {
+    return '当前选择的是 MiMo Token Plan，但 Key 不是 tp- 开头；请确认 Key 来源和订阅状态。'
+  }
+  if (config.value.mimoBillingPlan === 'payg' && mimoKeyKind.value === 'token-plan') {
+    return '当前选择的是 MiMo 按量付费，但检测到 tp- Token Plan Key；两类 Key 不能互换，请切换计费方式或更换 Key。'
+  }
+  if (config.value.mimoBillingPlan === 'payg' && mimoKeyKind.value === 'other') {
+    return 'MiMo 按量付费 Key 通常以 sk- 开头；请确认 Key 来自 API Keys 页面。'
+  }
+  return config.value.mimoBillingPlan === 'token-plan'
+    ? '当前使用 MiMo Token Plan Key；请确认订阅仍在有效期内。'
+    : ''
+})
+
+const mimoEndpoint = computed(() => {
+  return getMimoEndpoint(config.value.mimoBillingPlan, config.value.mimoRegion)
 })
 
 type ConnectionTestState = 'idle' | 'testing' | 'success' | 'error'
@@ -369,7 +431,18 @@ watch(service, resetConnectionTest)
   line-height: 1.5;
 }
 
+.mimo-key-note {
+  margin: -8px 0 14px 2em;
+  color: #6d7890;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
 .minimax-key-note.is-warning {
+  color: #a52c48;
+}
+
+.mimo-key-note.is-warning {
   color: #a52c48;
 }
 
@@ -384,6 +457,22 @@ watch(service, resetConnectionTest)
 }
 
 .minimax-endpoint code {
+  overflow-wrap: anywhere;
+  color: #59657b;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.mimo-endpoint {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: -4px 0 14px 2em;
+  color: #8993a5;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.mimo-endpoint code {
   overflow-wrap: anywhere;
   color: #59657b;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/components/ServiceIcon.vue
+++ b/components/ServiceIcon.vue
@@ -95,6 +95,10 @@
     <svg v-else-if="service === 'minimax'" viewBox="0 0 24 24" role="img">
       <path d="M4.5 17V7l4 5 3.5-5v10M13 17V7l3.2 4.2L19.5 7v10" />
     </svg>
+    <svg v-else-if="service === 'mimo'" viewBox="0 0 24 24" role="img">
+      <path d="M4.5 17V8l3.8 4.3L12 8v9M12 17V8l3.7 4.3L19.5 8v9" />
+      <circle cx="12" cy="4.5" r="1.2" />
+    </svg>
     <svg v-else-if="service === 'jieyue'" viewBox="0 0 24 24" role="img">
       <path d="m12 3 1.7 6.3L20 11l-6.3 1.7L12 19l-1.7-6.3L4 11l6.3-1.7L12 3Z" />
       <path d="M17.5 16.5 20 19" />
@@ -185,6 +189,7 @@ const fallbackGlyph = computed(() => {
     deepseek: 'DS',
     lingyi: '01',
     minimax: 'MM',
+    mimo: 'Mi',
     jieyue: '阶',
     groq: 'G',
     cozecom: 'C',
@@ -325,6 +330,7 @@ const fallbackGlyph = computed(() => {
 }
 
 .service-brand-icon[data-service='minimax'],
+.service-brand-icon[data-service='mimo'],
 .service-brand-icon[data-service='jieyue'],
 .service-brand-icon[data-service='huanYuan'],
 .service-brand-icon[data-service='huanYuanTranslation'] {

--- a/docs/config/translation-engines.md
+++ b/docs/config/translation-engines.md
@@ -52,6 +52,16 @@ MiniMax 同时提供按量付费 API 和 Token Plan 两类权益。两类 Key �
 
 如果看到 `401` 或错误码 `2049`，优先检查计费方式、区域和 Key 是否来自同一套 MiniMax 账户权益；不要把截图或完整 Key 发到 Issue、聊天记录或仓库。
 
+## 小米 MiMo
+
+小米 MiMo 提供独立的按量付费 API 和 Token Plan。按量付费 Key 通常以 `sk-` 开头，Token Plan Key 以 `tp-` 开头，两类 Key 不能互换。FluentRead 会在 MiMo 服务配置中分别保存计费方式和集群，避免误用 MiniMax 的配置。
+
+- 按量付费：使用 `https://api.xiaomimimo.com/v1/chat/completions`。
+- Token Plan：中国集群使用 `token-plan-cn.xiaomimimo.com`，新加坡集群使用 `token-plan-sgp.xiaomimimo.com`，欧洲集群使用 `token-plan-ams.xiaomimimo.com`；应以 Token Plan 页面实际提供的 Base URL 为准。
+- 当前支持文本翻译的预设模型包括 `mimo-v2.5` 和 `mimo-v2.5-pro`，也可以填写自定义模型标识。
+
+如果遇到 `401`，先确认 Key 前缀、Token Plan 是否仍在有效期内，以及所选集群是否与购买页面提供的地址一致。
+
 ## Ollama 本地模型
 
 Ollama 适合希望在本机处理文本的用户。你需要在本机运行 Ollama、准备一个可用模型，并让浏览器扩展可以访问本地接口。

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -9,9 +9,9 @@ import {
     saveConfig,
     subscribeConfig,
 } from "@/entrypoints/utils/config";
-import {CONNECTION_TEST_MESSAGE, CONTEXT_MENU_IDS} from "@/entrypoints/utils/constant";
+import {CONNECTION_TEST_MESSAGE, CONTEXT_MENU_IDS, getMimoEndpoint, MINIMAX_ENDPOINTS} from "@/entrypoints/utils/constant";
 import {getMissingCredentialMessage} from "@/entrypoints/utils/configValidation";
-import {resolveConfiguredModel, servicesType} from "@/entrypoints/utils/option";
+import {resolveConfiguredModel, services, servicesType} from "@/entrypoints/utils/option";
 import {synthesizeEdgeTts} from "@/entrypoints/utils/edgeTts";
 import {
     buildTranslationCacheKey,
@@ -136,6 +136,14 @@ function getProviderEndpoint(service: string): string {
     if (service === 'custom') return config.custom;
     if (service === 'deeplx') return config.deeplx;
     if (service === 'newapi') return config.newApiUrl;
+    if (service === services.minimax) {
+        const plan = config.minimaxBillingPlan === 'token-plan' ? 'token-plan' : 'payg';
+        const region = config.minimaxRegion === 'cn' ? 'cn' : 'global';
+        return MINIMAX_ENDPOINTS[plan][region];
+    }
+    if (service === services.mimo) {
+        return getMimoEndpoint(config.mimoBillingPlan, config.mimoRegion);
+    }
     return '';
 }
 

--- a/entrypoints/service/_service.ts
+++ b/entrypoints/service/_service.ts
@@ -44,6 +44,7 @@ export const _service: ServiceMap = {
     [services.claude]: claude,
     [services.infini]: common,
     [services.minimax]: common,
+    [services.mimo]: common,
     [services.cozecom]: coze,
     [services.cozecn]: coze,
     [services.deepseek]: deepseek,

--- a/entrypoints/service/common.ts
+++ b/entrypoints/service/common.ts
@@ -1,4 +1,4 @@
-import {method, MINIMAX_ENDPOINTS, urls} from "../utils/constant";
+import {getMimoEndpoint, method, MINIMAX_ENDPOINTS, urls} from "../utils/constant";
 import {commonMsgTemplate} from "../utils/template";
 import {config} from "@/entrypoints/utils/config";
 import {contentPostHandler} from "@/entrypoints/utils/check";
@@ -23,6 +23,8 @@ async function common(message: any) {
                 ? MINIMAX_ENDPOINTS[
                     config.minimaxBillingPlan === 'token-plan' ? 'token-plan' : 'payg'
                 ][config.minimaxRegion === 'cn' ? 'cn' : 'global']
+                : service === services.mimo
+                    ? getMimoEndpoint(config.mimoBillingPlan, config.mimoRegion)
                 : urls[service]);
 
         const resp = await fetch(url, {

--- a/entrypoints/utils/constant.ts
+++ b/entrypoints/utils/constant.ts
@@ -1,5 +1,5 @@
 import { services } from "./option";
-import type { MiniMaxBillingPlan, MiniMaxRegion } from "./option";
+import type { MiniMaxBillingPlan, MiniMaxRegion, MiMoBillingPlan, MiMoRegion } from "./option";
 import {DEFAULT_DEEPLX_ENDPOINT} from "./deeplx";
 
 // MiniMax 的 OpenAI 兼容地址目前按区域区分；计费方案单独建模，用于
@@ -14,6 +14,27 @@ export const MINIMAX_ENDPOINTS: Record<MiniMaxBillingPlan, Record<MiniMaxRegion,
         cn: "https://api.minimaxi.com/v1/chat/completions",
     },
 };
+
+// MiMo 按量付费使用统一 API 地址；Token Plan 的 Base URL 必须使用购买页面
+// 返回的集群地址，且不同集群的 Token Plan Key 不能互换。
+export const MIMO_ENDPOINTS: Record<MiMoBillingPlan, Record<MiMoRegion, string>> = {
+    payg: {
+        cn: "https://api.xiaomimimo.com/v1/chat/completions",
+        sgp: "https://api.xiaomimimo.com/v1/chat/completions",
+        ams: "https://api.xiaomimimo.com/v1/chat/completions",
+    },
+    "token-plan": {
+        cn: "https://token-plan-cn.xiaomimimo.com/v1/chat/completions",
+        sgp: "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions",
+        ams: "https://token-plan-ams.xiaomimimo.com/v1/chat/completions",
+    },
+};
+
+export function getMimoEndpoint(billingPlan: string, region: string): string {
+    const plan = billingPlan === 'token-plan' ? 'token-plan' : 'payg';
+    const normalizedRegion = region === 'sgp' || region === 'ams' ? region : 'cn';
+    return MIMO_ENDPOINTS[plan][normalizedRegion];
+}
 
 // 常量工具类
 export const urls: any = {
@@ -34,6 +55,7 @@ export const urls: any = {
     [services.deepseek]: "https://api.deepseek.com/chat/completions",
     [services.infini]: "https://cloud.infini-ai.com/maas/v1/chat/completions",
     [services.minimax]: MINIMAX_ENDPOINTS.payg.cn,
+    [services.mimo]: MIMO_ENDPOINTS.payg.cn,
     [services.jieyue]: "https://api.stepfun.com/v1/chat/completions",
     [services.yiyan]: "https://qianfan.bj.baidubce.com/v2/chat/completions",
     [services.groq]: "https://api.groq.com/openai/v1/chat/completions",

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -1,5 +1,5 @@
 import { currentModelIds, defaultModels, defaultOption, services, servicesType } from "./option";
-import type { MiniMaxBillingPlan, MiniMaxRegion } from "./option";
+import type { MiniMaxBillingPlan, MiniMaxRegion, MiMoBillingPlan, MiMoRegion } from "./option";
 import { normalizeCustomBodyMapping } from "./custom-body";
 
 export type DeepSeekApiType = 'auto' | 'responses' | 'chat';
@@ -42,6 +42,8 @@ export class Config {
     requireApiKey: Record<string, boolean>; // 按服务和模型保存 API Key 校验开关
     minimaxBillingPlan: MiniMaxBillingPlan; // MiniMax 计费方案
     minimaxRegion: MiniMaxRegion; // MiniMax API 区域
+    mimoBillingPlan: MiMoBillingPlan; // MiMo 计费方案
+    mimoRegion: MiMoRegion; // MiMo Token Plan API 集群
     ak: string;
     sk: string;
     appid: string;
@@ -103,6 +105,8 @@ export class Config {
         this.requireApiKey = {};
         this.minimaxBillingPlan = 'payg';
         this.minimaxRegion = 'cn';
+        this.mimoBillingPlan = 'payg';
+        this.mimoRegion = 'cn';
         this.ak = '';
         this.sk = '';
         this.appid = '';
@@ -287,6 +291,14 @@ export function normalizeConfig(value: unknown): Config {
 
     if (!['global', 'cn'].includes(normalized.minimaxRegion)) {
         normalized.minimaxRegion = 'cn';
+    }
+
+    if (!['payg', 'token-plan'].includes(normalized.mimoBillingPlan)) {
+        normalized.mimoBillingPlan = 'payg';
+    }
+
+    if (!['cn', 'sgp', 'ams'].includes(normalized.mimoRegion)) {
+        normalized.mimoRegion = 'cn';
     }
 
     if (!['disabled', 'bilingual', 'translation-only'].includes(normalized.selectionTranslatorMode)) {

--- a/entrypoints/utils/option.ts
+++ b/entrypoints/utils/option.ts
@@ -27,6 +27,7 @@ export const services = {
     lingyi: "lingyi",
     deepseek: "deepseek",
     minimax: "minimax",
+    mimo: "mimo", // 小米 MiMo
     jieyue: "jieyue", // 阶跃星辰
     groq: "groq",
     cozecom: "cozecom", // coze 支持机器人不支持模型
@@ -57,6 +58,7 @@ export const servicesType = {
         services.deepseek,
         services.lingyi,
         services.minimax,
+        services.mimo,
         services.jieyue,
         services.groq,
         services.cozecom,
@@ -87,6 +89,7 @@ export const servicesType = {
         services.deepseek,
         services.lingyi,
         services.minimax,
+        services.mimo,
         services.jieyue,
         services.groq,
         services.custom,
@@ -115,6 +118,7 @@ export const servicesType = {
         services.deepseek,
         services.lingyi,
         services.minimax,
+        services.mimo,
         services.jieyue,
         services.groq,
         services.huanYuan,
@@ -142,6 +146,7 @@ export const servicesType = {
         services.baichuan,
         services.deepseek,
         services.lingyi,
+        services.mimo,
         services.jieyue,
         services.groq,
         services.cozecom,
@@ -199,6 +204,21 @@ export const minimaxRegions = [
 
 export type MiniMaxRegion = typeof minimaxRegions[number]["value"];
 
+export const mimoBillingPlans = [
+    {value: "payg", label: "按量付费（API）"},
+    {value: "token-plan", label: "Token Plan（套餐/积分）"},
+] as const;
+
+export type MiMoBillingPlan = typeof mimoBillingPlans[number]["value"];
+
+export const mimoRegions = [
+    {value: "cn", label: "中国集群（token-plan-cn.xiaomimimo.com）"},
+    {value: "sgp", label: "新加坡集群（token-plan-sgp.xiaomimimo.com）"},
+    {value: "ams", label: "欧洲集群（token-plan-ams.xiaomimimo.com）"},
+] as const;
+
+export type MiMoRegion = typeof mimoRegions[number]["value"];
+
 /** Resolve the model that is actually sent to a provider. */
 export function resolveConfiguredModel(selectedModel?: string, customModel?: string): string {
     return selectedModel === customModelString ? customModel || '' : selectedModel || '';
@@ -218,6 +238,7 @@ export const currentModelIds = {
     claudeHaiku: "claude-haiku-4-5",
     deepseek: "deepseek-v4-flash",
     minimax: "MiniMax-M2.7",
+    mimo: "mimo-v2.5-pro",
     jieyue: "step-3.5-flash",
     huanYuan: "hy3",
     grok: "grok-4.5",
@@ -246,6 +267,7 @@ export const defaultModelIds = {
     [services.lingyi]: "yi-lightning",
     [services.deepseek]: currentModelIds.deepseek,
     [services.minimax]: "MiniMax-M2.7-highspeed",
+    [services.mimo]: "mimo-v2.5",
     [services.jieyue]: currentModelIds.jieyue,
     [services.huanYuan]: currentModelIds.huanYuan,
     [services.huanYuanTranslation]: "hunyuan-translation-lite",
@@ -272,6 +294,7 @@ export const models = new Map<string, Array<string>>([
     [services.lingyi, [defaultModelIds[services.lingyi], customModelString]],
     [services.deepseek, [currentModelIds.deepseek, "deepseek-v4-pro", customModelString]],
     [services.minimax, [defaultModelIds[services.minimax], currentModelIds.minimax, "MiniMax-M2.5", "MiniMax-M2.5-highspeed", customModelString]],
+    [services.mimo, [defaultModelIds[services.mimo], currentModelIds.mimo, customModelString]],
     [services.jieyue, [currentModelIds.jieyue, "step-3", "step-2", customModelString]],
     [services.huanYuan, [currentModelIds.huanYuan, "hy3-preview", customModelString]],
     [services.huanYuanTranslation, [defaultModelIds[services.huanYuanTranslation], "hunyuan-translation", customModelString]],
@@ -297,6 +320,8 @@ export const defaultModels = new Map<string, string>(
 export const options = {
     minimaxBillingPlan: minimaxBillingPlans,
     minimaxRegion: minimaxRegions,
+    mimoBillingPlan: mimoBillingPlans,
+    mimoRegion: mimoRegions,
     on: [
         {value: true, label: "开启"},
         {value: false, label: "关闭"},
@@ -389,6 +414,7 @@ export const options = {
         {value: services.baichuan, label: "百川智能"},
         {value: services.lingyi, label: "零一万物"},
         {value: services.minimax, label: "MiniMax"},
+        {value: services.mimo, label: "小米 MiMo"},
         {value: services.jieyue, label: "阶跃星辰"},
         {value: services.infini, label: "无向芯穹"},
         {value: services.cozecom, label: "Coze国际"},

--- a/entrypoints/utils/serviceError.ts
+++ b/entrypoints/utils/serviceError.ts
@@ -12,6 +12,10 @@ export function formatServiceError(service: string, error: unknown): string {
         return 'MiniMax API Key 无效（错误码 2049）。如果 Key 以 sk-cp- 开头，它是 Token Plan Key：请确认订阅仍有效，并选择与 Key 来源匹配的区域；中国版使用 api.minimaxi.com，全球版使用 api.minimax.io。Token Plan Key 与按量付费 API Key 不能互换。';
     }
 
+    if (service === services.mimo && (/401|unauthorized|invalid api key/i.test(message))) {
+        return '小米 MiMo API Key 无效或集群不匹配。按量付费 Key 通常以 sk- 开头，Token Plan Key 以 tp- 开头；Token Plan 还必须选择购买页面对应的中国、新加坡或欧洲集群。';
+    }
+
     if (/failed to fetch|networkerror|网络错误|请求超时/i.test(message)) {
         return `网络连接失败：${message}`;
     }

--- a/tests/connection-test.test.ts
+++ b/tests/connection-test.test.ts
@@ -48,4 +48,15 @@ describe('翻译服务连接测试', () => {
         expect(message).toContain('api.minimax.io');
         expect(message).toContain('不能互换');
     });
+
+    it('将 MiMo 鉴权错误转换为 Key 前缀和集群提示', () => {
+        const message = formatServiceError(
+            services.mimo,
+            new Error('翻译失败: 401 Unauthorized body: {"message":"invalid api key"}'),
+        );
+
+        expect(message).toContain('sk-');
+        expect(message).toContain('tp-');
+        expect(message).toContain('中国、新加坡或欧洲集群');
+    });
 });

--- a/tests/mimo.test.ts
+++ b/tests/mimo.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchMock, mockConfig } = vi.hoisted(() => ({
+    fetchMock: vi.fn(),
+    mockConfig: {
+        service: 'mimo',
+        to: 'zh-Hans',
+        token: { mimo: '' } as Record<string, string>,
+        model: { mimo: 'mimo-v2.5-pro' } as Record<string, string>,
+        customModel: {} as Record<string, string>,
+        customBody: {} as Record<string, string>,
+        proxy: {} as Record<string, string>,
+        system_role: { mimo: 'You are a translator.' } as Record<string, string>,
+        user_role: { mimo: 'Translate to {{to}}: {{origin}}' } as Record<string, string>,
+        mimoBillingPlan: 'payg',
+        mimoRegion: 'cn',
+    },
+}));
+
+vi.mock('@/entrypoints/utils/config', () => ({ config: mockConfig }));
+
+import common from '@/entrypoints/service/common';
+import { services } from '@/entrypoints/utils/option';
+
+function successResponse() {
+    return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: '译文' } }] }),
+        text: async () => '',
+    };
+}
+
+describe('小米 MiMo OpenAI 兼容服务', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('fetch', fetchMock);
+        fetchMock.mockResolvedValue(successResponse());
+        mockConfig.service = services.mimo;
+        mockConfig.token.mimo = '';
+        mockConfig.mimoBillingPlan = 'payg';
+        mockConfig.mimoRegion = 'cn';
+    });
+
+    it('按量付费使用统一 API 地址并发送 sk Key', async () => {
+        mockConfig.token.mimo = 'sk-test';
+
+        await expect(common({ origin: 'hello', serviceOverride: services.mimo })).resolves.toBe('译文');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.xiaomimimo.com/v1/chat/completions',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const headers = fetchMock.mock.calls[0][1].headers as Headers;
+        expect(headers.get('Authorization')).toBe('Bearer sk-test');
+    });
+
+    it('Token Plan 使用所选集群地址并发送 tp Key', async () => {
+        mockConfig.token.mimo = 'tp-test';
+        mockConfig.mimoBillingPlan = 'token-plan';
+        mockConfig.mimoRegion = 'ams';
+
+        await expect(common({ origin: 'hello', serviceOverride: services.mimo })).resolves.toBe('译文');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://token-plan-ams.xiaomimimo.com/v1/chat/completions',
+            expect.objectContaining({ method: 'POST' }),
+        );
+        const headers = fetchMock.mock.calls[0][1].headers as Headers;
+        expect(headers.get('Authorization')).toBe('Bearer tp-test');
+    });
+});

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Config, normalizeConfig } from '@/entrypoints/utils/model';
-import { MINIMAX_ENDPOINTS, tongyiTokenPlanUrl, urls } from '@/entrypoints/utils/constant';
+import { getMimoEndpoint, MIMO_ENDPOINTS, MINIMAX_ENDPOINTS, tongyiTokenPlanUrl, urls } from '@/entrypoints/utils/constant';
 import { customModelString, defaultModelIds, defaultModels, defaultOption, models, options, resolveConfiguredModel, services, servicesType } from '@/entrypoints/utils/option';
 
 describe('AI 模型编号列表', () => {
@@ -35,6 +35,7 @@ describe('AI 模型编号列表', () => {
         expect(models.get(services.moonshot)).toContain('kimi-k2.7-code');
         expect(models.get(services.yiyan)).toContain('ernie-5.1');
         expect(models.get(services.minimax)).toContain('MiniMax-M2.7');
+        expect(models.get(services.mimo)).toContain('mimo-v2.5-pro');
         expect(models.get(services.jieyue)).toContain('step-3.5-flash');
         expect(models.get(services.huanYuan)).toContain('hy3');
         expect(models.get(services.grok)).toContain('grok-4.5');
@@ -45,6 +46,7 @@ describe('AI 模型编号列表', () => {
         expect(options.services[1]?.value).toBe(services.freeTranslation);
         expect(options.services.find(option => option.value === services.freeTranslation)?.description)
             .toContain('微软翻译、DeepLX、谷歌翻译依次尝试');
+        expect(options.services.find(option => option.value === services.mimo)?.label).toBe('小米 MiMo');
         expect(options.services.every(option => !/[🌟⭐★]/u.test(option.label))).toBe(true);
         expect(servicesType.isMachine(services.freeTranslation)).toBe(true);
         expect(defaultOption.service).toBe(services.freeTranslation);
@@ -259,6 +261,28 @@ describe('OpenAI 兼容服务端点', () => {
         expect(new Config().minimaxBillingPlan).toBe('payg');
         expect(normalizeConfig({minimaxBillingPlan: 'token-plan'}).minimaxBillingPlan).toBe('token-plan');
         expect(normalizeConfig({minimaxBillingPlan: 'unknown'}).minimaxBillingPlan).toBe('payg');
+    });
+
+    it('MiMo 配置独立处理 Token Plan 集群并清理非法值', () => {
+        expect(new Config().mimoBillingPlan).toBe('payg');
+        expect(new Config().mimoRegion).toBe('cn');
+        expect(normalizeConfig({mimoBillingPlan: 'token-plan', mimoRegion: 'sgp'})).toMatchObject({
+            mimoBillingPlan: 'token-plan',
+            mimoRegion: 'sgp',
+        });
+        expect(normalizeConfig({mimoBillingPlan: 'unknown', mimoRegion: 'unknown'})).toMatchObject({
+            mimoBillingPlan: 'payg',
+            mimoRegion: 'cn',
+        });
+    });
+
+    it('MiMo 按量付费与三套 Token Plan 集群使用不同端点', () => {
+        expect(MIMO_ENDPOINTS.payg.cn).toBe('https://api.xiaomimimo.com/v1/chat/completions');
+        expect(getMimoEndpoint('token-plan', 'cn')).toBe('https://token-plan-cn.xiaomimimo.com/v1/chat/completions');
+        expect(getMimoEndpoint('token-plan', 'sgp')).toBe('https://token-plan-sgp.xiaomimimo.com/v1/chat/completions');
+        expect(getMimoEndpoint('token-plan', 'ams')).toBe('https://token-plan-ams.xiaomimimo.com/v1/chat/completions');
+        expect(getMimoEndpoint('payg', 'ams')).toBe('https://api.xiaomimimo.com/v1/chat/completions');
+        expect(getMimoEndpoint('token-plan', 'invalid')).toBe('https://token-plan-cn.xiaomimimo.com/v1/chat/completions');
     });
 
     it('文心一言使用 Bearer Token，不再要求旧 AK/SK', () => {


### PR DESCRIPTION
## What changed

- Add Xiaomi MiMo as an OpenAI-compatible translation service.
- Add `mimo-v2.5`, `mimo-v2.5-pro`, and custom model support.
- Separate pay-as-you-go and Token Plan configuration.
- Support Token Plan China, Singapore, and Europe clusters while keeping pay-as-you-go on the unified API endpoint.
- Add `sk-`/`tp-` key guidance, endpoint display, cache-key coverage, error messages, documentation, and tests.

## Validation

- `pnpm compile`
- `pnpm test` — 29 files, 377 tests passed
- `pnpm build`
- Isolated Microsoft Edge options suite and targeted MiMo UI checks passed with no console errors.

The full UI suite still reaches an existing model-grid independent-scroll assertion that conflicts with the current expanded no-inner-scroll behavior; this is a stale baseline assertion, not a MiMo failure.