### PR TITLE
fix: inject AI context into YouTube subtitles

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -195,16 +195,16 @@ const pendingPageSummaries = new Map<string, Promise<string>>();
 const PAGE_SUMMARY_CACHE_SIZE = 8;
 const PAGE_SUMMARY_LIMIT = 1200;
 
-function buildPageSummaryCacheKey(pageContext: string): string {
+function buildPageSummaryCacheKey(pageContext: string, service = config.service): string {
     return buildTranslationCacheKey({
         requestMode: 'page-summary',
         sourceLanguage: config.from,
         targetLanguage: '',
         sourceText: pageContext,
-        service: config.service,
-        model: getSelectedModel(config.service),
-        endpoint: getProviderEndpoint(config.service),
-        customBody: config.customBody[config.service] || '',
+        service,
+        model: getSelectedModel(service),
+        endpoint: getProviderEndpoint(service),
+        customBody: config.customBody[service] || '',
     });
 }
 
@@ -223,12 +223,12 @@ function cachePageSummary(key: string, value: string): void {
  * A summary failure is deliberately non-fatal: the raw readable context is
  * still useful and the ordinary translation must continue.
  */
-async function addPageSummary(pageContext: string): Promise<string> {
-    if (!isAIContextEnabled() || !pageContext.trim()) {
+async function addPageSummary(pageContext: string, service = config.service): Promise<string> {
+    if (!isAIContextEnabled(service) || !pageContext.trim()) {
         return '';
     }
 
-    const key = buildPageSummaryCacheKey(pageContext);
+    const key = buildPageSummaryCacheKey(pageContext, service);
     const cached = pageSummaryCache.get(key);
     if (cached) return cached;
 
@@ -246,12 +246,13 @@ async function addPageSummary(pageContext: string): Promise<string> {
                 return persisted;
             }
 
-            const result = await getTranslationService()({
+            const result = await getTranslationService(service)({
                 origin: '',
                 context: '',
                 pageContext: '',
                 summaryPrompt: buildPageSummaryPrompt(pageContext),
                 summarySystemPrompt: buildPageSummarySystemPrompt(),
+                serviceOverride: service,
             });
             const summary = typeof result === 'string' ? result.trim().slice(0, PAGE_SUMMARY_LIMIT) : '';
             if (!summary) {
@@ -412,7 +413,7 @@ async function translateWithCache(message: TranslationRequestMessage): Promise<s
     }
     const context = typeof message.context === 'string' ? message.context : '';
     const rawPageContext = typeof message.pageContext === 'string' ? message.pageContext : '';
-    const pageContext = await addPageSummary(rawPageContext);
+    const pageContext = await addPageSummary(rawPageContext, selectedService);
     const useCache = isCacheEnabled(message);
 
     if (Array.isArray(message.origin)) {

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -275,15 +275,19 @@ export async function translateVideoText(origin: string): Promise<string> {
   const cleanedOrigin = origin?.replace(/[\s\u3000]/g, '') || '';
   if (!cleanedOrigin) return origin || '';
 
+  const service = config.videoService;
+  const pageContext = await resolvePageContext(undefined, service);
+
   // 视频字幕是高频、短文本请求。计数保留在内存中，并合并为低频写入，避免
   // storage 写入和配置订阅回调把播放器主线程拖入高频循环。
   scheduleVideoCountSave();
   return enqueueTranslation(async (lease) => {
     return waitForRequest(browser.runtime.sendMessage({
-        context: `YouTube 视频字幕：${document.title}`,
+        context: `YouTube 视频字幕：${typeof document === 'undefined' ? '' : document.title}`,
+        pageContext,
         origin,
         useCache: config.useCache,
-        serviceOverride: config.videoService,
+        serviceOverride: service,
       }), 20_000, undefined, lease) as Promise<string>;
   });
 }
@@ -326,8 +330,9 @@ function assertTranslationCredentials(): void {
   if (message) throw new Error(message);
 }
 
-async function resolvePageContext(suppliedContext?: string): Promise<string | undefined> {
-  const selectedModel = resolveConfiguredModel(config.model[config.service], config.customModel[config.service]);
-  if (!config.enableAIContext || !servicesType.isUseAIContext(config.service, selectedModel)) return undefined;
+async function resolvePageContext(suppliedContext?: string, serviceOverride = config.service): Promise<string | undefined> {
+  const service = serviceOverride || config.service;
+  const selectedModel = resolveConfiguredModel(config.model[service], config.customModel[service]);
+  if (!config.enableAIContext || !servicesType.isUseAIContext(service, selectedModel)) return undefined;
   return suppliedContext?.trim().slice(0, 4000) || await getPageTranslationContext() || undefined;
 }

--- a/scripts/run-video-subtitle-fixture-test.cjs
+++ b/scripts/run-video-subtitle-fixture-test.cjs
@@ -185,6 +185,12 @@ async function main() {
       await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
     }
     await page.waitForTimeout(2500);
+    await page.evaluate(() => {
+      const description = document.querySelector('meta[name="description"]') || document.createElement('meta');
+      description.setAttribute('name', 'description');
+      description.setAttribute('content', 'FluentRead fixture context: this video explains orbital habitat economics and launch terminology.');
+      if (!description.isConnected) document.head.append(description);
+    });
 
     await page.evaluate((videoDataUrl) => {
       const player = document.querySelector('#movie_player, .html5-video-player');
@@ -603,6 +609,7 @@ async function main() {
         ...(stored.config || {}),
         videoService: 'openai',
         videoServiceDefaultMigrated: true,
+        enableAIContext: true,
         useCache: false,
         token: { ...(stored.config?.token || {}), openai: 'fixture-token' },
         model: { ...(stored.config?.model || {}), openai: 'fixture-model' },
@@ -627,6 +634,10 @@ async function main() {
     const aiPrefetchRequests = aiTranslationSources.filter((source) => source.includes(aiPretranslatedSource));
     if (aiPrefetchRequests.length !== 1) {
       throw new Error(`AI 字幕没有按 30 秒窗口前置翻译：${JSON.stringify({ aiTranslationSources })}`);
+    }
+    const aiContextRequests = aiTranslationSources.filter((source) => source.includes('FluentRead fixture context: this video explains orbital habitat economics and launch terminology.'));
+    if (aiContextRequests.length === 0) {
+      throw new Error(`AI 字幕请求没有注入页面上下文：${JSON.stringify({ aiTranslationSources })}`);
     }
     await page.evaluate((source) => {
       const segment = document.querySelector('#ytp-caption-window-container .ytp-caption-segment');
@@ -743,6 +754,7 @@ async function main() {
       displayedPrefetchRequests,
       aiDisplayedPrefetchTranslation,
       aiTranslationRequests: aiPrefetchRequests.length,
+      aiContextRequests: aiContextRequests.length,
       timelineCatchUp,
       translationRequests,
       translationSources,

--- a/tests/translateApiPerformance.test.ts
+++ b/tests/translateApiPerformance.test.ts
@@ -2,12 +2,13 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   sendMessage: vi.fn(),
+  getPageTranslationContext: vi.fn(),
   saveConfig: vi.fn(async () => undefined),
   config: {
     count: 0,
     maxConcurrentTranslations: 6,
-    model: {mock: 'mock-model'} as Record<string, string>,
-    customModel: {mock: ''} as Record<string, string>,
+    model: {mock: 'mock-model', 'mock-ai': 'mock-ai-model'} as Record<string, string>,
+    customModel: {mock: '', 'mock-ai': ''} as Record<string, string>,
     service: 'mock',
     to: 'zh-CN',
     useCache: true,
@@ -26,13 +27,15 @@ vi.mock('@/entrypoints/utils/config', () => ({
 vi.mock('@/entrypoints/utils/common', () => ({detectlang: () => 'eng'}));
 vi.mock('@/entrypoints/utils/option', () => ({
   resolveConfiguredModel: (model: string) => model,
-  servicesType: {isUseAIContext: () => false},
+  servicesType: {isUseAIContext: (service: string) => service === 'mock-ai'},
 }));
-vi.mock('@/entrypoints/utils/pageContext', () => ({getPageTranslationContext: vi.fn()}));
+vi.mock('@/entrypoints/utils/pageContext', () => ({getPageTranslationContext: mocks.getPageTranslationContext}));
 vi.mock('@/entrypoints/utils/configValidation', () => ({getMissingCredentialMessage: () => null}));
 
-import {cancelAllTranslations, translateText} from '@/entrypoints/utils/translateApi';
+import {cancelAllTranslations, translateText, translateVideoText} from '@/entrypoints/utils/translateApi';
 import {clearTranslationQueue} from '@/entrypoints/utils/translateQueue';
+
+const originalDocument = globalThis.document;
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -48,15 +51,24 @@ describe('translation API request lifecycle performance', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mocks.sendMessage.mockReset();
+    mocks.getPageTranslationContext.mockReset();
     mocks.saveConfig.mockClear();
     mocks.config.count = 0;
     mocks.config.maxConcurrentTranslations = 6;
+    mocks.config.enableAIContext = false;
+    mocks.config.service = 'mock';
+    mocks.config.videoService = 'mock';
+    Object.defineProperty(globalThis, 'document', {
+      value: {title: 'Fixture video title'},
+      configurable: true,
+    });
   });
 
   afterEach(async () => {
     clearTranslationQueue();
     await vi.runAllTimersAsync();
     vi.useRealTimers();
+    Object.defineProperty(globalThis, 'document', {value: originalDocument, configurable: true});
   });
 
   it('clears successful request timeouts and coalesces count persistence', async () => {
@@ -160,5 +172,24 @@ describe('translation API request lifecycle performance', () => {
     firstTransport.reject(new Error('late transport rejection'));
     await Promise.resolve();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('uses the video AI service when resolving and sending page context', async () => {
+    mocks.config.enableAIContext = true;
+    mocks.config.videoService = 'mock-ai';
+    const pageContext = 'Page title: Fixture video title\nReadable page context for subtitle terminology.';
+    mocks.getPageTranslationContext.mockResolvedValue(pageContext);
+    mocks.sendMessage.mockResolvedValue('字幕译文');
+
+    await expect(translateVideoText('A subtitle source')).resolves.toBe('字幕译文');
+
+    expect(mocks.getPageTranslationContext).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage).toHaveBeenCalledWith({
+      context: 'YouTube 视频字幕：Fixture video title',
+      pageContext,
+      origin: 'A subtitle source',
+      useCache: true,
+      serviceOverride: 'mock-ai',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Inject the existing AI smart page context into YouTube subtitle translation requests.
- Resolve AI-context eligibility from the dedicated `videoService` and selected model.
- Generate and cache page summaries with the video service override instead of the regular page translation service.
- Add API regression coverage and a real YouTube fixture assertion for context-bearing AI requests.

## Root cause
`translateVideoText()` sent only the subtitle text, title context, cache flag, and `serviceOverride`; it never sent `pageContext`. The background summary path also checked `config.service`, so an AI selected only for YouTube subtitles could not receive the page context.

The existing global AI smart-context switch remains respected: when enabled, supported AI video services receive bounded title, description, and readable-page context; when disabled, no additional page extraction is performed.

## Validation
- `pnpm test` — 373/373 tests passed.
- `pnpm compile` — passed.
- `pnpm build` — passed.
- Isolated Microsoft Edge on live YouTube fixture — `pageErrors: []`, `aiContextRequests: 3`, `aiTranslationRequests: 1`, `progressiveRequests: 1`.
