### PR TITLE
fix: keep X usernames untranslated

### DIFF
--- a/entrypoints/translation-core/adapters/x.ts
+++ b/entrypoints/translation-core/adapters/x.ts
@@ -15,6 +15,13 @@ export const xAdapter = createDeclarativeAdapter({
             ],
             reason: 'x-composer',
         },
+        {
+            selector: [
+                '[data-testid="User-Name"]',
+                '[data-testid="UserName"]',
+            ],
+            reason: 'x-user-name',
+        },
     ],
     targets: [
         {

--- a/tests/translationCore.test.ts
+++ b/tests/translationCore.test.ts
@@ -680,6 +680,30 @@ describe('translation candidate core', () => {
         expect(core.resolve(title)?.element).toBe(title);
     });
 
+    it('keeps X usernames out of full and hover translation candidates', () => {
+        const {document, core} = page(`
+            <main>
+                <article>
+                    <div id="user-name" data-testid="User-Name">
+                        <a href="/example-user">
+                            <span>Example User</span>
+                            <span>@example_user</span>
+                        </a>
+                    </div>
+                    <div id="tweet-text" data-testid="tweetText">Translate this X post.</div>
+                </article>
+            </main>
+        `, 'https://x.com/home');
+        const userName = document.querySelector('#user-name')!;
+        const tweetText = document.querySelector('#tweet-text')!;
+
+        expect(core.discover(document).map((candidate) => candidate.element.id)).toEqual(['tweet-text']);
+        expect(core.discover(document).find((candidate) => candidate.element === tweetText))
+            .toMatchObject({adapterId: 'x', reason: 'x-post-text'});
+        expect(core.resolve(userName.querySelector('span')?.firstChild)).toBeNull();
+        expect(core.resolve(tweetText.firstChild)?.element).toBe(tweetText);
+    });
+
     it('keeps an exact adapter target out of an ancestor inline run', () => {
         const {document, core} = page(`
             <main><div id="row">


### PR DESCRIPTION
## Summary
- Keep X.com username display nodes out of translation candidates.
- Cover both full-page and hover-card username selectors.

## Validation
- pnpm test: 28 files, 373 tests passed
- pnpm test:translation-core: 98 tests passed
- pnpm compile
- pnpm build
- git diff --check
- Isolated Edge production-extension proof: username wrappers remained untranslated; restore/retranslate sequence passed [1, 0, 1].