### PR TITLE
Polish translation center comparison UI

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -108,10 +108,14 @@
   </div>
   </section>
 
-  <div v-if="!config.on && !['settings-general', 'settings-image-translation'].includes(props.activeSection)" class="disabled-section">
+  <div v-if="!config.on && !['settings-general', 'settings-image-translation', 'settings-translation-center'].includes(props.activeSection)" class="disabled-section">
     <strong>插件当前已关闭</strong>
     <p>请先在“通用设置”中启用插件，再调整该分类。</p>
   </div>
+
+  <section v-show="props.activeSection === 'settings-translation-center'" id="settings-translation-center" class="settings-section translation-center-section">
+    <TranslationCenter />
+  </section>
 
   <div v-show="config.on" class="settings-main-sections">
 
@@ -732,6 +736,7 @@ import { defineAsyncComponent } from 'vue';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 import ServiceCatalog from '@/components/ServiceCatalog.vue';
 import ServiceConfiguration from '@/components/ServiceConfiguration.vue';
+import TranslationCenter from '@/components/TranslationCenter.vue';
 import { parseHotkey } from '@/entrypoints/utils/hotkey';
 import { isConfigImportValid, sanitizeConfigForExport } from '@/entrypoints/utils/config-transfer';
 import { getApiKeyRequirementKey, getMissingCredentialMessage, isApiKeyRequired } from '@/entrypoints/utils/configValidation';

--- a/components/TranslationCenter.vue
+++ b/components/TranslationCenter.vue
@@ -15,7 +15,7 @@
     <div class="translation-center-toolbar">
       <div class="language-picker-group">
         <label for="translation-center-source">源语言</label>
-        <select id="translation-center-source" v-model="sourceLanguage" aria-label="翻译中心源语言">
+        <select id="translation-center-source" v-model="sourceLanguage" aria-label="翻译中心源语言" @change="persistTranslationCenterConfig">
           <option v-for="item in sourceLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
         </select>
       </div>
@@ -33,7 +33,7 @@
 
       <div class="language-picker-group">
         <label for="translation-center-target">目标语言</label>
-        <select id="translation-center-target" v-model="targetLanguage" aria-label="翻译中心目标语言">
+        <select id="translation-center-target" v-model="targetLanguage" aria-label="翻译中心目标语言" @change="persistTranslationCenterConfig">
           <option v-for="item in targetLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
         </select>
       </div>
@@ -43,27 +43,51 @@
           class="add-service-button"
           type="button"
           :aria-expanded="servicePickerOpen"
-          aria-haspopup="listbox"
+          aria-haspopup="dialog"
           @click.stop="servicePickerOpen = !servicePickerOpen"
         >
           <span>＋</span>
-          添加翻译服务
+          更多服务
           <b>{{ cards.length }}</b>
           <span class="add-service-chevron">⌄</span>
         </button>
-        <div v-if="servicePickerOpen" class="service-picker-menu" role="listbox" aria-label="添加翻译服务">
-          <button
-            v-for="item in availableServiceOptions"
-            :key="item.value"
-            type="button"
-            role="option"
-            @click="addService(item.value)"
-          >
-            <ServiceIcon :service="item.value" :label="item.label" size="small" />
-            <span>{{ item.label }}</span>
-            <b>添加</b>
-          </button>
-          <p v-if="availableServiceOptions.length === 0">所有服务都已加入对比</p>
+        <div v-if="servicePickerOpen" class="service-picker-popover" role="dialog" aria-label="添加更多翻译服务">
+          <header class="service-picker-header">
+            <div>
+              <span class="service-picker-kicker">翻译服务</span>
+              <strong>添加更多服务</strong>
+              <small>选择后会加入右侧对比列表，并自动保存。</small>
+            </div>
+            <button type="button" class="service-picker-close" aria-label="关闭更多服务" @click="servicePickerOpen = false">×</button>
+          </header>
+          <label class="service-picker-search">
+            <span aria-hidden="true">⌕</span>
+            <input v-model.trim="serviceSearchQuery" type="search" placeholder="搜索服务名称" aria-label="搜索翻译服务" />
+          </label>
+          <div class="service-picker-groups">
+            <section v-for="group in filteredServiceGroups" :key="group.key" class="service-picker-group">
+              <div class="service-picker-group-heading">
+                <strong>{{ group.label }}</strong>
+                <span>{{ group.items.length }}</span>
+              </div>
+              <button
+                v-for="item in group.items"
+                :key="item.value"
+                type="button"
+                class="service-picker-option"
+                @click="addService(item.value)"
+              >
+                <ServiceIcon :service="item.value" :label="item.label" size="small" />
+                <span class="service-picker-option-copy">
+                  <strong>{{ item.label }}</strong>
+                  <small>{{ serviceDescription(item.value) }}</small>
+                </span>
+                <b aria-hidden="true">＋</b>
+              </button>
+            </section>
+            <p v-if="filteredServiceGroups.length === 0">没有找到可添加的翻译服务</p>
+          </div>
+          <footer class="service-picker-footer">已选 {{ cards.length }} 个服务 · 右侧卡片可拖动排序</footer>
         </div>
       </div>
     </div>
@@ -107,14 +131,17 @@
             <span class="translation-panel-kicker">对比结果</span>
             <h3 id="translation-results-title">{{ cards.length }} 个翻译服务</h3>
           </div>
-          <button
-            class="copy-all-button"
-            type="button"
-            :disabled="successfulCards.length === 0"
-            @click="copyAllResults"
-          >
-            {{ copiedService === 'all' ? '已复制' : '复制全部' }}
-          </button>
+          <div class="results-heading-actions">
+            <span class="results-order-hint">⠿ 拖动卡片可排序</span>
+            <button
+              class="copy-all-button"
+              type="button"
+              :disabled="successfulCards.length === 0"
+              @click="copyAllResults"
+            >
+              {{ copiedService === 'all' ? '已复制' : '复制全部' }}
+            </button>
+          </div>
         </div>
 
         <div class="translation-result-list">
@@ -124,9 +151,22 @@
             class="translation-result-card"
             :data-service="card.service"
             :data-status="card.status"
+            :class="{ 'is-dragging': draggingService === card.service, 'is-drag-over': dragOverService === card.service }"
           >
             <header class="translation-result-card-header">
               <div class="translation-result-service-name">
+                <button
+                  class="drag-handle"
+                  type="button"
+                  :aria-label="`拖动${serviceLabel(card.service)}调整顺序`"
+                  title="拖动调整顺序，也可用 Alt+↑/↓"
+                  tabindex="0"
+                  @pointerdown.prevent.stop="startPointerDrag(card.service, $event)"
+                  @keydown.alt.arrow-up.prevent="moveCard(card.service, -1)"
+                  @keydown.alt.arrow-down.prevent="moveCard(card.service, 1)"
+                >
+                  ⠿
+                </button>
                 <ServiceIcon :service="card.service" :label="serviceLabel(card.service)" size="medium" />
                 <div>
                   <strong>{{ serviceLabel(card.service) }}</strong>
@@ -173,12 +213,6 @@
         </div>
       </section>
     </div>
-
-    <footer class="translation-center-note">
-      <span>提示</span>
-      <p>翻译中心不会改变网页翻译的默认服务。每次点击“再次翻译”都会重新请求服务，不复用上一轮结果。</p>
-      <button type="button" @click="openServiceSettings">前往服务设置</button>
-    </footer>
   </section>
 </template>
 
@@ -186,8 +220,8 @@
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import browser from 'webextension-polyfill'
 import ServiceIcon from './ServiceIcon.vue'
-import { options } from '@/entrypoints/utils/option'
-import { config, configReady } from '@/entrypoints/utils/config'
+import { options, servicesType } from '@/entrypoints/utils/option'
+import { config, configReady, requestConfigSave, subscribeConfig } from '@/entrypoints/utils/config'
 import { translateText } from '@/entrypoints/utils/translateApi'
 
 type TranslationCardStatus = 'idle' | 'loading' | 'success' | 'error'
@@ -201,6 +235,13 @@ type TranslationCard = {
   run: number
 }
 
+type ServiceOption = {
+  value: string
+  label: string
+  description?: string
+  disabled?: boolean
+}
+
 const DEFAULT_COMPARISON_SERVICES = ['freeTranslation', 'google', 'openai', 'deepseek', 'gemini', 'deeplx']
 const MAX_TEXT_LENGTH = 5000
 
@@ -210,33 +251,58 @@ const targetLanguage = ref('zh-Hans')
 const runCount = ref(0)
 const isRunning = ref(false)
 const servicePickerOpen = ref(false)
+const serviceSearchQuery = ref('')
 const copiedService = ref('')
 const servicePicker = ref<HTMLElement | null>(null)
 const cards = ref<TranslationCard[]>([])
+const draggingService = ref('')
+const dragOverService = ref('')
 let activeController: AbortController | null = null
 let activeRunId = 0
 let copiedTimer: ReturnType<typeof setTimeout> | undefined
+let unsubscribeConfig: (() => void) | undefined
+let configHydrated = false
+let pointerDrag: { service: string; pointerId: number } | null = null
 
-const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled))
+const serviceOptions = computed<ServiceOption[]>(() => options.services.filter((item: any) => !item.disabled) as ServiceOption[])
 const selectedServiceValues = computed(() => new Set(cards.value.map(card => card.service)))
-const availableServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !selectedServiceValues.value.has(item.value)))
+const availableServiceOptions = computed(() => serviceOptions.value.filter(item => !selectedServiceValues.value.has(item.value)))
 const successfulCards = computed(() => cards.value.filter(card => card.status === 'success' && card.result))
 const sourceLanguageOptions = computed(() => [
   { value: 'auto', label: '自动检测' },
   ...options.to,
 ])
 const targetLanguageOptions = computed(() => options.to)
+const filteredServiceGroups = computed(() => {
+  const keyword = serviceSearchQuery.value.toLocaleLowerCase()
+  const filterItems = (items: ServiceOption[]) => items.filter(item => {
+    if (!keyword) return true
+    return `${item.label}${item.description || ''}`.toLocaleLowerCase().includes(keyword)
+  })
+  return [
+    {
+      key: 'machine',
+      label: '机器翻译',
+      items: filterItems(availableServiceOptions.value.filter(item => servicesType.isMachine(item.value))),
+    },
+    {
+      key: 'ai',
+      label: 'AI 翻译',
+      items: filterItems(availableServiceOptions.value.filter(item => servicesType.isAI(item.value))),
+    },
+  ].filter(group => group.items.length > 0)
+})
 
 function createCard(service: string): TranslationCard {
   return { service, status: 'idle', result: '', error: '', duration: 0, run: 0 }
 }
 
 function serviceLabel(service: string): string {
-  return serviceOptions.value.find((item: any) => item.value === service)?.label || service
+  return serviceOptions.value.find(item => item.value === service)?.label || service
 }
 
 function serviceDescription(service: string): string {
-  const option = serviceOptions.value.find((item: any) => item.value === service) as any
+  const option = serviceOptions.value.find(item => item.value === service)
   if (option?.description) return option.description.split('；')[0]
   return service === 'freeTranslation' ? '无需密钥，自动尝试多个免费接口' : '使用设置中已保存的连接配置'
 }
@@ -246,15 +312,63 @@ function languageLabel(value: string): string {
   return targetLanguageOptions.value.find(item => item.value === value)?.label || value
 }
 
+function getValidServiceOrder(value: unknown): string[] {
+  const availableValues = new Set(serviceOptions.value.map(item => item.value))
+  if (!Array.isArray(value)) return []
+  return [...new Set(value.filter((item): item is string => typeof item === 'string' && availableValues.has(item)))]
+}
+
+function getDefaultServiceOrder(): string[] {
+  const configured = DEFAULT_COMPARISON_SERVICES.filter(service => serviceOptions.value.some(item => item.value === service))
+  return configured.length ? configured : [serviceOptions.value[0]?.value].filter(Boolean) as string[]
+}
+
+function getCurrentServiceOrder(): string[] {
+  return cards.value.map(card => card.service)
+}
+
+function applyServiceOrder(order: string[]): void {
+  cards.value = order.map(createCard)
+}
+
+function hasSameOrder(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((service, index) => service === right[index])
+}
+
+function persistTranslationCenterConfig(): void {
+  if (!configHydrated) return
+  config.translationCenterServices = getCurrentServiceOrder()
+  config.translationCenterSourceLanguage = sourceLanguage.value
+  config.translationCenterTargetLanguage = targetLanguage.value
+  void requestConfigSave(config, browser.runtime.sendMessage.bind(browser.runtime)).catch(error => {
+    console.warn('[FluentRead] 翻译中心配置保存失败', error)
+  })
+}
+
+function hydrateTranslationCenterConfig(nextConfig = config): void {
+  const storedOrder = getValidServiceOrder(nextConfig.translationCenterServices)
+  const nextOrder = storedOrder.length ? storedOrder : getDefaultServiceOrder()
+  if (!hasSameOrder(getCurrentServiceOrder(), nextOrder)) applyServiceOrder(nextOrder)
+  const storedSource = nextConfig.translationCenterSourceLanguage || nextConfig.from || 'auto'
+  const storedTarget = nextConfig.translationCenterTargetLanguage || nextConfig.to || 'zh-Hans'
+  const nextSource = sourceLanguageOptions.value.some(item => item.value === storedSource) ? storedSource : 'auto'
+  const nextTarget = targetLanguageOptions.value.some(item => item.value === storedTarget) ? storedTarget : 'zh-Hans'
+  if (sourceLanguage.value !== nextSource) sourceLanguage.value = nextSource
+  if (targetLanguage.value !== nextTarget) targetLanguage.value = nextTarget
+}
+
 function addService(service: string): void {
   if (selectedServiceValues.value.has(service)) return
   cards.value.push(createCard(service))
+  persistTranslationCenterConfig()
+  serviceSearchQuery.value = ''
   servicePickerOpen.value = false
 }
 
 function removeService(service: string): void {
   if (cards.value.length <= 1) return
   cards.value = cards.value.filter(card => card.service !== service)
+  persistTranslationCenterConfig()
 }
 
 function swapLanguages(): void {
@@ -262,6 +376,65 @@ function swapLanguages(): void {
   const nextSource = sourceLanguage.value
   sourceLanguage.value = targetLanguage.value
   targetLanguage.value = nextSource
+  persistTranslationCenterConfig()
+}
+
+function reorderCards(fromService: string, targetService: string): void {
+  const fromIndex = cards.value.findIndex(card => card.service === fromService)
+  const targetIndex = cards.value.findIndex(card => card.service === targetService)
+  if (fromIndex < 0 || targetIndex < 0 || fromIndex === targetIndex) return
+
+  const nextCards = [...cards.value]
+  const [movedCard] = nextCards.splice(fromIndex, 1)
+  nextCards.splice(targetIndex, 0, movedCard)
+  cards.value = nextCards
+  persistTranslationCenterConfig()
+}
+
+function startPointerDrag(service: string, event: PointerEvent): void {
+  if (event.button !== 0) return
+  pointerDrag = { service, pointerId: event.pointerId }
+  draggingService.value = service
+  dragOverService.value = ''
+  document.body.style.userSelect = 'none'
+  document.addEventListener('pointermove', handlePointerMove)
+  document.addEventListener('pointerup', finishPointerDrag)
+  document.addEventListener('pointercancel', finishPointerDrag)
+}
+
+function handlePointerMove(event: PointerEvent): void {
+  if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return
+  const target = document.elementFromPoint(event.clientX, event.clientY)?.closest<HTMLElement>('.translation-result-card')
+  const service = target?.dataset.service || ''
+  dragOverService.value = service && service !== pointerDrag.service ? service : ''
+}
+
+function finishPointerDrag(event: PointerEvent): void {
+  if (!pointerDrag || event.pointerId !== pointerDrag.pointerId) return
+  const targetService = dragOverService.value
+  if (targetService) reorderCards(pointerDrag.service, targetService)
+  endCardDrag()
+}
+
+function moveCard(service: string, offset: number): void {
+  const fromIndex = cards.value.findIndex(card => card.service === service)
+  const targetIndex = fromIndex + offset
+  if (fromIndex < 0 || targetIndex < 0 || targetIndex >= cards.value.length) return
+  const nextCards = [...cards.value]
+  const [movedCard] = nextCards.splice(fromIndex, 1)
+  nextCards.splice(targetIndex, 0, movedCard)
+  cards.value = nextCards
+  persistTranslationCenterConfig()
+}
+
+function endCardDrag(): void {
+  pointerDrag = null
+  document.removeEventListener('pointermove', handlePointerMove)
+  document.removeEventListener('pointerup', finishPointerDrag)
+  document.removeEventListener('pointercancel', finishPointerDrag)
+  document.body.style.userSelect = ''
+  draggingService.value = ''
+  dragOverService.value = ''
 }
 
 function formatError(error: unknown): string {
@@ -366,13 +539,10 @@ async function retryService(service: string): Promise<void> {
   }
 }
 
-function openServiceSettings(): void {
-  void browser.tabs.create({ url: `${browser.runtime.getURL('options.html')}#settings-services` })
-}
-
 function closeServicePicker(event: Event): void {
   if (servicePicker.value?.contains(event.target as Node)) return
   servicePickerOpen.value = false
+  serviceSearchQuery.value = ''
 }
 
 function handleKeydown(event: KeyboardEvent): void {
@@ -381,16 +551,20 @@ function handleKeydown(event: KeyboardEvent): void {
 
 onMounted(async () => {
   await configReady
-  sourceLanguage.value = config.from || 'auto'
-  targetLanguage.value = config.to || 'zh-Hans'
-  const configuredServices = DEFAULT_COMPARISON_SERVICES.filter(service => serviceOptions.value.some(item => item.value === service))
-  cards.value = (configuredServices.length ? configuredServices : [serviceOptions.value[0]?.value].filter(Boolean) as string[]).map(createCard)
+  hydrateTranslationCenterConfig()
+  configHydrated = true
+  unsubscribeConfig = subscribeConfig(nextConfig => {
+    if (!configHydrated || draggingService.value) return
+    hydrateTranslationCenterConfig(nextConfig)
+  })
   document.addEventListener('pointerdown', closeServicePicker)
   document.addEventListener('keydown', handleKeydown)
 })
 
 onUnmounted(() => {
   activeController?.abort()
+  endCardDrag()
+  unsubscribeConfig?.()
   document.removeEventListener('pointerdown', closeServicePicker)
   document.removeEventListener('keydown', handleKeydown)
   if (copiedTimer) clearTimeout(copiedTimer)
@@ -410,8 +584,7 @@ onUnmounted(() => {
 .translation-center-hero,
 .translation-center-toolbar,
 .translation-input-panel,
-.translation-results-panel,
-.translation-center-note {
+.translation-results-panel {
   border: 1px solid var(--line);
   background: var(--surface);
   box-shadow: 0 10px 30px rgba(31, 40, 61, .045);
@@ -516,26 +689,46 @@ onUnmounted(() => {
 .add-service-button > span:first-child { color: var(--brand); font-size: 18px; font-weight: 400; }
 .add-service-button b { display: inline-grid; place-items: center; min-width: 20px; height: 20px; padding: 0 5px; border-radius: 999px; color: #fff; background: var(--ink); font-size: 10px; }
 .add-service-chevron { color: var(--muted); font-size: 16px; }
-.service-picker-menu {
+.service-picker-popover {
   position: absolute;
   z-index: 8;
   top: calc(100% + 8px);
   right: 0;
-  display: grid;
-  width: 260px;
-  max-height: 330px;
-  padding: 7px;
-  overflow-y: auto;
+  display: flex;
+  width: min(370px, calc(100vw - 32px));
+  max-height: min(480px, calc(100vh - 150px));
+  flex-direction: column;
+  overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 14px;
+  border-radius: 16px;
   background: var(--surface);
-  box-shadow: 0 16px 36px rgba(31, 40, 61, .15);
+  box-shadow: 0 18px 44px rgba(31, 40, 61, .18);
 }
-.service-picker-menu button { display: flex; align-items: center; gap: 9px; padding: 9px; border: 0; border-radius: 9px; color: var(--ink); background: transparent; cursor: pointer; text-align: left; }
-.service-picker-menu button:hover { background: var(--surface-soft); }
-.service-picker-menu button span { flex: 1; font-size: 12px; font-weight: 650; }
-.service-picker-menu button b { color: var(--brand-strong); font-size: 10px; }
-.service-picker-menu p { margin: 12px 8px; color: var(--muted); font-size: 11px; text-align: center; }
+.service-picker-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 16px 16px 12px; border-bottom: 1px solid var(--line); }
+.service-picker-header > div { display: grid; gap: 3px; min-width: 0; }
+.service-picker-kicker { color: var(--brand-strong); font-size: 9px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.service-picker-header strong { color: var(--ink); font-size: 15px; }
+.service-picker-header small { color: var(--muted); font-size: 10px; line-height: 1.5; }
+.service-picker-close { display: grid; place-items: center; width: 26px; height: 26px; flex: none; border: 0; border-radius: 8px; color: var(--muted); background: transparent; cursor: pointer; font-size: 20px; line-height: 1; }
+.service-picker-close:hover { color: var(--brand-strong); background: var(--brand-soft); }
+.service-picker-search { display: flex; align-items: center; gap: 8px; margin: 12px 14px 8px; padding: 0 10px; height: 36px; border: 1px solid #e1e5ee; border-radius: 10px; color: var(--muted); background: var(--surface-soft); }
+.service-picker-search:focus-within { border-color: var(--brand); box-shadow: 0 0 0 3px rgba(239, 71, 118, .1); }
+.service-picker-search span { font-size: 18px; }
+.service-picker-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: var(--ink); background: transparent; font: inherit; font-size: 12px; }
+.service-picker-search input::placeholder { color: #a2a8b5; }
+.service-picker-groups { min-height: 0; flex: 1 1 auto; overflow-y: auto; padding: 0 9px 8px; }
+.service-picker-group + .service-picker-group { margin-top: 8px; }
+.service-picker-group-heading { display: flex; align-items: center; justify-content: space-between; padding: 7px 7px 5px; color: var(--muted); font-size: 10px; }
+.service-picker-group-heading strong { color: var(--ink); font-size: 10px; }
+.service-picker-group-heading span { display: inline-grid; min-width: 18px; height: 18px; place-items: center; border-radius: 999px; background: var(--surface-soft); font-size: 9px; }
+.service-picker-option { display: flex; align-items: center; width: 100%; min-height: 49px; gap: 10px; padding: 7px; border: 0; border-radius: 10px; color: var(--ink); background: transparent; cursor: pointer; text-align: left; }
+.service-picker-option:hover { background: var(--surface-soft); }
+.service-picker-option-copy { display: grid; min-width: 0; flex: 1; gap: 3px; }
+.service-picker-option-copy strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.service-picker-option-copy small { overflow: hidden; color: var(--muted); font-size: 9px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.service-picker-option > b { display: grid; place-items: center; width: 23px; height: 23px; flex: none; border-radius: 7px; color: var(--brand-strong); background: var(--brand-soft); font-size: 16px; font-weight: 400; }
+.service-picker-groups > p { margin: 28px 8px; color: var(--muted); font-size: 11px; text-align: center; }
+.service-picker-footer { padding: 10px 15px; border-top: 1px solid var(--line); color: var(--muted); background: var(--surface-soft); font-size: 9px; }
 
 .translation-center-layout { display: grid; grid-template-columns: minmax(300px, .88fr) minmax(420px, 1.12fr); gap: 18px; min-height: 0; }
 .translation-input-panel,
@@ -570,14 +763,22 @@ onUnmounted(() => {
 .translate-primary-button small { padding-left: 10px; border-left: 1px solid rgba(255,255,255,.35); font-size: 10px; font-weight: 600; }
 
 .results-heading { margin-bottom: 10px; }
+.results-heading-actions { display: flex; align-items: center; gap: 9px; }
+.results-order-hint { color: var(--muted); font-size: 9px; white-space: nowrap; }
 .copy-all-button { min-height: 30px; padding: 0 10px; border: 1px solid var(--line); border-radius: 9px; color: var(--brand-strong); background: var(--surface); cursor: pointer; font-size: 10px; font-weight: 700; }
 .copy-all-button:hover:not(:disabled) { border-color: #ef9ab1; background: var(--brand-soft); }
 .copy-all-button:disabled { cursor: not-allowed; color: #b4bac5; }
 .translation-result-list { display: grid; gap: 10px; min-height: 0; overflow-y: auto; padding: 2px 3px 3px 0; }
-.translation-result-card { padding: 13px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); }
+.translation-result-card { padding: 13px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); cursor: grab; transition: border-color .16s ease, box-shadow .16s ease, opacity .16s ease, transform .16s ease; }
+.translation-result-card:active { cursor: grabbing; }
+.translation-result-card.is-dragging { opacity: .5; transform: scale(.985); }
+.translation-result-card.is-drag-over { border-color: #ef9ab1; box-shadow: 0 -4px 0 -2px var(--brand); }
 .translation-result-card[data-status='success'] { border-color: #ecd8df; }
 .translation-result-card-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .translation-result-service-name { display: flex; align-items: center; min-width: 0; gap: 10px; }
+.drag-handle { display: grid; place-items: center; width: 18px; height: 28px; flex: none; padding: 0; border: 0; border-radius: 6px; color: #a6adba; background: transparent; cursor: grab; font-size: 18px; letter-spacing: -4px; line-height: 1; }
+.drag-handle:hover, .drag-handle:focus-visible { color: var(--brand-strong); background: var(--brand-soft); outline: none; }
+.drag-handle:active { cursor: grabbing; }
 .translation-result-service-name > div { display: grid; min-width: 0; gap: 3px; }
 .translation-result-service-name strong { overflow: hidden; color: var(--ink); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
 .translation-result-service-name small { overflow: hidden; max-width: 300px; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
@@ -605,11 +806,6 @@ onUnmounted(() => {
 .translation-result-error button { flex: none; padding: 4px 7px; border: 1px solid #efb1c1; border-radius: 7px; color: #a43755; background: transparent; cursor: pointer; font-size: 10px; font-weight: 700; }
 .translation-result-error button:disabled { cursor: not-allowed; opacity: .45; }
 
-.translation-center-note { display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-radius: 13px; color: var(--muted); background: var(--surface-soft); font-size: 10px; }
-.translation-center-note > span { padding: 4px 7px; border-radius: 6px; color: var(--brand-strong); background: var(--brand-soft); font-weight: 800; }
-.translation-center-note p { flex: 1; margin: 0; line-height: 1.5; }
-.translation-center-note button { padding: 0; border: 0; color: var(--brand-strong); background: transparent; cursor: pointer; font-size: 10px; font-weight: 750; white-space: nowrap; }
-
 @media (max-width: 1050px) {
   .translation-center { padding: 24px 28px 20px; }
   .translation-center-layout { grid-template-columns: minmax(270px, .8fr) minmax(360px, 1.2fr); }
@@ -626,14 +822,11 @@ onUnmounted(() => {
   .language-swap-button { align-self: flex-end; }
   .translation-center-service-picker { width: 100%; margin-left: 0; }
   .add-service-button { width: 100%; justify-content: center; }
-  .service-picker-menu { left: 0; right: 0; width: auto; }
+  .service-picker-popover { left: 0; right: 0; width: auto; }
   .translation-center-layout { grid-template-columns: 1fr; }
   .translation-input-panel { min-height: 330px; }
   .translation-results-panel { min-height: 360px; }
   .translation-result-service-name small { max-width: 160px; }
-  .translation-center-note { align-items: flex-start; flex-wrap: wrap; }
-  .translation-center-note p { flex-basis: calc(100% - 42px); }
-  .translation-center-note button { margin-left: 42px; }
 }
 
 @media (max-width: 480px) {
@@ -642,5 +835,6 @@ onUnmounted(() => {
   .translation-input-panel textarea { min-height: 220px; font-size: 17px; }
   .translation-result-service-name small { display: none; }
   .translation-result-card-actions .result-state { display: none; }
+  .results-order-hint { display: none; }
 }
 </style>

--- a/components/TranslationCenter.vue
+++ b/components/TranslationCenter.vue
@@ -1,0 +1,646 @@
+<template>
+  <section class="translation-center" aria-labelledby="translation-center-title">
+    <header class="translation-center-hero">
+      <div>
+        <span class="translation-center-kicker">翻译工具 · 多服务对比</span>
+        <h2 id="translation-center-title">翻译中心</h2>
+        <p>输入一句话，同时查看多个翻译服务的结果。可以反复提交同一句话，方便比较措辞和风格。</p>
+      </div>
+      <div class="translation-center-run-status" :class="{ active: isRunning }" aria-live="polite">
+        <i />
+        <span>{{ isRunning ? '正在翻译' : runCount ? `已翻译 ${runCount} 次` : '等待输入' }}</span>
+      </div>
+    </header>
+
+    <div class="translation-center-toolbar">
+      <div class="language-picker-group">
+        <label for="translation-center-source">源语言</label>
+        <select id="translation-center-source" v-model="sourceLanguage" aria-label="翻译中心源语言">
+          <option v-for="item in sourceLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+        </select>
+      </div>
+
+      <button
+        class="language-swap-button"
+        type="button"
+        aria-label="交换源语言和目标语言"
+        title="交换源语言和目标语言"
+        :disabled="sourceLanguage === 'auto'"
+        @click="swapLanguages"
+      >
+        ⇄
+      </button>
+
+      <div class="language-picker-group">
+        <label for="translation-center-target">目标语言</label>
+        <select id="translation-center-target" v-model="targetLanguage" aria-label="翻译中心目标语言">
+          <option v-for="item in targetLanguageOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
+        </select>
+      </div>
+
+      <div ref="servicePicker" class="translation-center-service-picker">
+        <button
+          class="add-service-button"
+          type="button"
+          :aria-expanded="servicePickerOpen"
+          aria-haspopup="listbox"
+          @click.stop="servicePickerOpen = !servicePickerOpen"
+        >
+          <span>＋</span>
+          添加翻译服务
+          <b>{{ cards.length }}</b>
+          <span class="add-service-chevron">⌄</span>
+        </button>
+        <div v-if="servicePickerOpen" class="service-picker-menu" role="listbox" aria-label="添加翻译服务">
+          <button
+            v-for="item in availableServiceOptions"
+            :key="item.value"
+            type="button"
+            role="option"
+            @click="addService(item.value)"
+          >
+            <ServiceIcon :service="item.value" :label="item.label" size="small" />
+            <span>{{ item.label }}</span>
+            <b>添加</b>
+          </button>
+          <p v-if="availableServiceOptions.length === 0">所有服务都已加入对比</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="translation-center-layout">
+      <section class="translation-input-panel" aria-labelledby="translation-input-title">
+        <div class="translation-panel-heading">
+          <div>
+            <span class="translation-panel-kicker">输入</span>
+            <h3 id="translation-input-title">待翻译文本</h3>
+          </div>
+          <span class="language-pair-label">{{ languageLabel(sourceLanguage) }} → {{ languageLabel(targetLanguage) }}</span>
+        </div>
+
+        <textarea
+          v-model="sourceText"
+          maxlength="5000"
+          placeholder="输入要翻译的句子…"
+          aria-label="待翻译文本"
+          @keydown.ctrl.enter.prevent="runTranslation"
+          @keydown.meta.enter.prevent="runTranslation"
+        />
+
+        <div class="translation-input-footer">
+          <span>{{ sourceText.length }}/5000</span>
+          <button
+            class="translate-primary-button"
+            type="button"
+            :disabled="!sourceText.trim() || !cards.length || isRunning"
+            @click="runTranslation"
+          >
+            <span>{{ isRunning ? '翻译中…' : runCount ? '再次翻译' : '开始翻译' }}</span>
+            <small>⌘↵</small>
+          </button>
+        </div>
+      </section>
+
+      <section class="translation-results-panel" aria-labelledby="translation-results-title">
+        <div class="translation-panel-heading results-heading">
+          <div>
+            <span class="translation-panel-kicker">对比结果</span>
+            <h3 id="translation-results-title">{{ cards.length }} 个翻译服务</h3>
+          </div>
+          <button
+            class="copy-all-button"
+            type="button"
+            :disabled="successfulCards.length === 0"
+            @click="copyAllResults"
+          >
+            {{ copiedService === 'all' ? '已复制' : '复制全部' }}
+          </button>
+        </div>
+
+        <div class="translation-result-list">
+          <article
+            v-for="card in cards"
+            :key="card.service"
+            class="translation-result-card"
+            :data-service="card.service"
+            :data-status="card.status"
+          >
+            <header class="translation-result-card-header">
+              <div class="translation-result-service-name">
+                <ServiceIcon :service="card.service" :label="serviceLabel(card.service)" size="medium" />
+                <div>
+                  <strong>{{ serviceLabel(card.service) }}</strong>
+                  <small>{{ serviceDescription(card.service) }}</small>
+                </div>
+              </div>
+              <div class="translation-result-card-actions">
+                <span v-if="card.status === 'success'" class="result-state success">完成</span>
+                <span v-else-if="card.status === 'loading'" class="result-state loading">翻译中</span>
+                <span v-else-if="card.status === 'error'" class="result-state error">失败</span>
+                <button
+                  class="remove-service-button"
+                  type="button"
+                  :aria-label="`移除${serviceLabel(card.service)}`"
+                  :disabled="cards.length <= 1"
+                  @click="removeService(card.service)"
+                >
+                  ×
+                </button>
+              </div>
+            </header>
+
+            <div v-if="card.status === 'idle'" class="translation-result-placeholder">
+              点击“开始翻译”，在这里查看结果
+            </div>
+            <div v-else-if="card.status === 'loading'" class="translation-result-placeholder loading-placeholder">
+              <span class="loading-bars"><i /><i /><i /></span>
+              正在请求 {{ serviceLabel(card.service) }}…
+            </div>
+            <div v-else-if="card.status === 'success'" class="translation-result-content">
+              <p>{{ card.result }}</p>
+              <footer>
+                <span>{{ card.duration }} ms · 第 {{ card.run }} 次</span>
+                <button type="button" @click="copyResult(card)">
+                  {{ copiedService === card.service ? '已复制' : '复制译文' }}
+                </button>
+              </footer>
+            </div>
+            <div v-else class="translation-result-error">
+              <p>{{ card.error }}</p>
+              <button type="button" :disabled="!sourceText.trim() || isRunning" @click="retryService(card.service)">重试</button>
+            </div>
+          </article>
+        </div>
+      </section>
+    </div>
+
+    <footer class="translation-center-note">
+      <span>提示</span>
+      <p>翻译中心不会改变网页翻译的默认服务。每次点击“再次翻译”都会重新请求服务，不复用上一轮结果。</p>
+      <button type="button" @click="openServiceSettings">前往服务设置</button>
+    </footer>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import browser from 'webextension-polyfill'
+import ServiceIcon from './ServiceIcon.vue'
+import { options } from '@/entrypoints/utils/option'
+import { config, configReady } from '@/entrypoints/utils/config'
+import { translateText } from '@/entrypoints/utils/translateApi'
+
+type TranslationCardStatus = 'idle' | 'loading' | 'success' | 'error'
+
+type TranslationCard = {
+  service: string
+  status: TranslationCardStatus
+  result: string
+  error: string
+  duration: number
+  run: number
+}
+
+const DEFAULT_COMPARISON_SERVICES = ['freeTranslation', 'google', 'openai', 'deepseek', 'gemini', 'deeplx']
+const MAX_TEXT_LENGTH = 5000
+
+const sourceText = ref('')
+const sourceLanguage = ref('auto')
+const targetLanguage = ref('zh-Hans')
+const runCount = ref(0)
+const isRunning = ref(false)
+const servicePickerOpen = ref(false)
+const copiedService = ref('')
+const servicePicker = ref<HTMLElement | null>(null)
+const cards = ref<TranslationCard[]>([])
+let activeController: AbortController | null = null
+let activeRunId = 0
+let copiedTimer: ReturnType<typeof setTimeout> | undefined
+
+const serviceOptions = computed(() => options.services.filter((item: any) => !item.disabled))
+const selectedServiceValues = computed(() => new Set(cards.value.map(card => card.service)))
+const availableServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !selectedServiceValues.value.has(item.value)))
+const successfulCards = computed(() => cards.value.filter(card => card.status === 'success' && card.result))
+const sourceLanguageOptions = computed(() => [
+  { value: 'auto', label: '自动检测' },
+  ...options.to,
+])
+const targetLanguageOptions = computed(() => options.to)
+
+function createCard(service: string): TranslationCard {
+  return { service, status: 'idle', result: '', error: '', duration: 0, run: 0 }
+}
+
+function serviceLabel(service: string): string {
+  return serviceOptions.value.find((item: any) => item.value === service)?.label || service
+}
+
+function serviceDescription(service: string): string {
+  const option = serviceOptions.value.find((item: any) => item.value === service) as any
+  if (option?.description) return option.description.split('；')[0]
+  return service === 'freeTranslation' ? '无需密钥，自动尝试多个免费接口' : '使用设置中已保存的连接配置'
+}
+
+function languageLabel(value: string): string {
+  if (value === 'auto') return '自动检测'
+  return targetLanguageOptions.value.find(item => item.value === value)?.label || value
+}
+
+function addService(service: string): void {
+  if (selectedServiceValues.value.has(service)) return
+  cards.value.push(createCard(service))
+  servicePickerOpen.value = false
+}
+
+function removeService(service: string): void {
+  if (cards.value.length <= 1) return
+  cards.value = cards.value.filter(card => card.service !== service)
+}
+
+function swapLanguages(): void {
+  if (sourceLanguage.value === 'auto') return
+  const nextSource = sourceLanguage.value
+  sourceLanguage.value = targetLanguage.value
+  targetLanguage.value = nextSource
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error && error.name === 'AbortError') return '本轮请求已取消'
+  const message = error instanceof Error ? error.message : String(error)
+  return message || '翻译服务未返回结果，请稍后重试。'
+}
+
+function resetCopiedState(value: string): void {
+  copiedService.value = value
+  if (copiedTimer) clearTimeout(copiedTimer)
+  copiedTimer = setTimeout(() => {
+    copiedService.value = ''
+  }, 1600)
+}
+
+async function copyText(text: string, copiedKey: string): Promise<void> {
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+    resetCopiedState(copiedKey)
+  } catch (error) {
+    console.warn('[FluentRead] 翻译中心复制失败', error)
+  }
+}
+
+function copyResult(card: TranslationCard): void {
+  void copyText(card.result, card.service)
+}
+
+function copyAllResults(): void {
+  const text = successfulCards.value
+    .map(card => `${serviceLabel(card.service)}\n${card.result}`)
+    .join('\n\n')
+  void copyText(text, 'all')
+}
+
+async function translateCard(card: TranslationCard, text: string, runId: number, controller: AbortController, run: number): Promise<void> {
+  const startedAt = performance.now()
+  card.status = 'loading'
+  card.error = ''
+  card.result = ''
+  card.run = run
+
+  try {
+    const result = await translateText(text, 'FluentRead 翻译中心', {
+      maxRetries: 0,
+      timeout: 30_000,
+      useCache: false,
+      serviceOverride: card.service,
+      sourceLanguage: sourceLanguage.value,
+      targetLanguage: targetLanguage.value,
+      signal: controller.signal,
+    })
+    if (runId !== activeRunId) return
+    card.status = 'success'
+    card.result = result.trim() || '服务返回了空译文。'
+    card.duration = Math.max(1, Math.round(performance.now() - startedAt))
+  } catch (error) {
+    if (runId !== activeRunId) return
+    if (controller.signal.aborted) return
+    card.status = 'error'
+    card.error = formatError(error)
+    card.duration = Math.max(1, Math.round(performance.now() - startedAt))
+  }
+}
+
+async function runTranslation(): Promise<void> {
+  const text = sourceText.value.trim()
+  if (!text || !cards.value.length || isRunning.value) return
+  if (text.length > MAX_TEXT_LENGTH) return
+
+  activeController?.abort()
+  const controller = new AbortController()
+  activeController = controller
+  const runId = ++activeRunId
+  const run = ++runCount.value
+  isRunning.value = true
+
+  await Promise.all(cards.value.map(card => translateCard(card, text, runId, controller, run)))
+  if (runId === activeRunId) {
+    isRunning.value = false
+    activeController = null
+  }
+}
+
+async function retryService(service: string): Promise<void> {
+  const text = sourceText.value.trim()
+  const card = cards.value.find(item => item.service === service)
+  if (!text || !card || isRunning.value) return
+
+  activeController?.abort()
+  const controller = new AbortController()
+  activeController = controller
+  const runId = ++activeRunId
+  const run = ++runCount.value
+  isRunning.value = true
+  await translateCard(card, text, runId, controller, run)
+  if (runId === activeRunId) {
+    isRunning.value = false
+    activeController = null
+  }
+}
+
+function openServiceSettings(): void {
+  void browser.tabs.create({ url: `${browser.runtime.getURL('options.html')}#settings-services` })
+}
+
+function closeServicePicker(event: Event): void {
+  if (servicePicker.value?.contains(event.target as Node)) return
+  servicePickerOpen.value = false
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') servicePickerOpen.value = false
+}
+
+onMounted(async () => {
+  await configReady
+  sourceLanguage.value = config.from || 'auto'
+  targetLanguage.value = config.to || 'zh-Hans'
+  const configuredServices = DEFAULT_COMPARISON_SERVICES.filter(service => serviceOptions.value.some(item => item.value === service))
+  cards.value = (configuredServices.length ? configuredServices : [serviceOptions.value[0]?.value].filter(Boolean) as string[]).map(createCard)
+  document.addEventListener('pointerdown', closeServicePicker)
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  activeController?.abort()
+  document.removeEventListener('pointerdown', closeServicePicker)
+  document.removeEventListener('keydown', handleKeydown)
+  if (copiedTimer) clearTimeout(copiedTimer)
+})
+</script>
+
+<style scoped>
+.translation-center {
+  display: grid;
+  gap: 18px;
+  min-height: 100%;
+  padding: 30px 36px 24px;
+  color: var(--ink);
+  background: #f8f9fc;
+}
+
+.translation-center-hero,
+.translation-center-toolbar,
+.translation-input-panel,
+.translation-results-panel,
+.translation-center-note {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: 0 10px 30px rgba(31, 40, 61, .045);
+}
+
+.translation-center-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 26px 28px;
+  border-color: #f3ced9;
+  border-radius: 22px;
+  background: linear-gradient(135deg, #fff8fa 0%, #fff 55%, #f7f8ff 100%);
+}
+
+.translation-center-kicker,
+.translation-panel-kicker {
+  display: block;
+  color: var(--brand-strong);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.translation-center-kicker { margin-bottom: 8px; }
+.translation-center-hero h2 { margin: 0 0 8px; font-size: 26px; letter-spacing: -.04em; }
+.translation-center-hero p { max-width: 680px; margin: 0; color: var(--muted); font-size: 13px; line-height: 1.7; }
+
+.translation-center-run-status {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: 8px;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  background: var(--surface-soft);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.translation-center-run-status i { width: 7px; height: 7px; border-radius: 50%; background: #b8becb; }
+.translation-center-run-status.active { color: var(--brand-strong); border-color: #f2bfd0; background: var(--brand-soft); }
+.translation-center-run-status.active i { background: var(--brand); box-shadow: 0 0 0 4px rgba(239, 71, 118, .12); }
+
+.translation-center-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 16px;
+}
+
+.language-picker-group { display: grid; gap: 6px; min-width: 154px; }
+.language-picker-group label { color: var(--muted); font-size: 10px; font-weight: 750; }
+.language-picker-group select {
+  min-width: 154px;
+  height: 40px;
+  padding: 0 30px 0 12px;
+  border: 1px solid #e1e5ee;
+  border-radius: 11px;
+  color: var(--ink);
+  background: var(--surface-soft);
+  font-size: 13px;
+  outline: none;
+}
+.language-picker-group select:focus { border-color: var(--brand); box-shadow: 0 0 0 3px rgba(239, 71, 118, .1); }
+
+.language-swap-button {
+  width: 38px;
+  height: 40px;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: var(--brand-strong);
+  background: var(--brand-soft);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+.language-swap-button:hover:not(:disabled) { border-color: #f1b2c5; transform: translateY(-1px); }
+.language-swap-button:disabled { cursor: not-allowed; opacity: .45; }
+
+.translation-center-service-picker { position: relative; margin-left: auto; }
+.add-service-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid #e1e5ee;
+  border-radius: 11px;
+  color: var(--ink);
+  background: var(--surface);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+}
+.add-service-button:hover { border-color: #ef9ab1; color: var(--brand-strong); background: var(--brand-soft); }
+.add-service-button > span:first-child { color: var(--brand); font-size: 18px; font-weight: 400; }
+.add-service-button b { display: inline-grid; place-items: center; min-width: 20px; height: 20px; padding: 0 5px; border-radius: 999px; color: #fff; background: var(--ink); font-size: 10px; }
+.add-service-chevron { color: var(--muted); font-size: 16px; }
+.service-picker-menu {
+  position: absolute;
+  z-index: 8;
+  top: calc(100% + 8px);
+  right: 0;
+  display: grid;
+  width: 260px;
+  max-height: 330px;
+  padding: 7px;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: 0 16px 36px rgba(31, 40, 61, .15);
+}
+.service-picker-menu button { display: flex; align-items: center; gap: 9px; padding: 9px; border: 0; border-radius: 9px; color: var(--ink); background: transparent; cursor: pointer; text-align: left; }
+.service-picker-menu button:hover { background: var(--surface-soft); }
+.service-picker-menu button span { flex: 1; font-size: 12px; font-weight: 650; }
+.service-picker-menu button b { color: var(--brand-strong); font-size: 10px; }
+.service-picker-menu p { margin: 12px 8px; color: var(--muted); font-size: 11px; text-align: center; }
+
+.translation-center-layout { display: grid; grid-template-columns: minmax(300px, .88fr) minmax(420px, 1.12fr); gap: 18px; min-height: 0; }
+.translation-input-panel,
+.translation-results-panel { min-width: 0; border-radius: 18px; }
+.translation-input-panel { display: flex; min-height: 390px; flex-direction: column; padding: 20px; }
+.translation-results-panel { display: flex; min-height: 390px; flex-direction: column; padding: 20px; }
+.translation-panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
+.translation-panel-kicker { margin-bottom: 5px; }
+.translation-panel-heading h3 { margin: 0; color: var(--ink); font-size: 17px; letter-spacing: -.02em; }
+.language-pair-label { padding: 5px 8px; border-radius: 999px; color: var(--muted); background: var(--surface-soft); font-size: 10px; white-space: nowrap; }
+
+.translation-input-panel textarea {
+  display: block;
+  width: 100%;
+  min-height: 270px;
+  flex: 1 1 auto;
+  padding: 4px 2px;
+  resize: vertical;
+  border: 0;
+  color: var(--ink);
+  background: transparent;
+  font: inherit;
+  font-size: 20px;
+  line-height: 1.65;
+  outline: none;
+}
+.translation-input-panel textarea::placeholder { color: #a2a8b5; }
+.translation-input-footer { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding-top: 14px; border-top: 1px solid var(--line); color: var(--muted); font-size: 10px; }
+.translate-primary-button { display: inline-flex; align-items: center; gap: 11px; min-height: 40px; padding: 0 14px; border: 0; border-radius: 11px; color: #fff; background: var(--brand); cursor: pointer; font-size: 12px; font-weight: 800; box-shadow: 0 8px 16px rgba(239, 71, 118, .2); }
+.translate-primary-button:hover:not(:disabled) { background: var(--brand-strong); transform: translateY(-1px); }
+.translate-primary-button:disabled { cursor: not-allowed; opacity: .48; box-shadow: none; }
+.translate-primary-button small { padding-left: 10px; border-left: 1px solid rgba(255,255,255,.35); font-size: 10px; font-weight: 600; }
+
+.results-heading { margin-bottom: 10px; }
+.copy-all-button { min-height: 30px; padding: 0 10px; border: 1px solid var(--line); border-radius: 9px; color: var(--brand-strong); background: var(--surface); cursor: pointer; font-size: 10px; font-weight: 700; }
+.copy-all-button:hover:not(:disabled) { border-color: #ef9ab1; background: var(--brand-soft); }
+.copy-all-button:disabled { cursor: not-allowed; color: #b4bac5; }
+.translation-result-list { display: grid; gap: 10px; min-height: 0; overflow-y: auto; padding: 2px 3px 3px 0; }
+.translation-result-card { padding: 13px; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); }
+.translation-result-card[data-status='success'] { border-color: #ecd8df; }
+.translation-result-card-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.translation-result-service-name { display: flex; align-items: center; min-width: 0; gap: 10px; }
+.translation-result-service-name > div { display: grid; min-width: 0; gap: 3px; }
+.translation-result-service-name strong { overflow: hidden; color: var(--ink); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.translation-result-service-name small { overflow: hidden; max-width: 300px; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.translation-result-card-actions { display: flex; align-items: center; flex: none; gap: 7px; }
+.result-state { padding: 4px 7px; border-radius: 999px; font-size: 9px; font-weight: 800; }
+.result-state.success { color: #16825f; background: #e9f8f1; }
+.result-state.loading { color: #91611c; background: #fff5df; }
+.result-state.error { color: #b1435e; background: #fff0f3; }
+.remove-service-button { display: grid; place-items: center; width: 24px; height: 24px; padding: 0; border: 0; border-radius: 7px; color: #8b93a1; background: transparent; cursor: pointer; font-size: 20px; line-height: 1; }
+.remove-service-button:hover:not(:disabled) { color: #b1435e; background: #fff0f3; }
+.remove-service-button:disabled { cursor: not-allowed; opacity: .35; }
+.translation-result-placeholder { display: flex; align-items: center; min-height: 54px; margin-top: 11px; padding: 10px 12px; border-radius: 10px; color: #9aa2b0; background: var(--surface-soft); font-size: 11px; }
+.loading-placeholder { gap: 9px; color: #9a6d2a; }
+.loading-bars { display: inline-flex; align-items: center; gap: 3px; }
+.loading-bars i { width: 4px; height: 14px; border-radius: 999px; background: #e8aa55; animation: translation-center-pulse .8s ease-in-out infinite alternate; }
+.loading-bars i:nth-child(2) { animation-delay: .18s; }
+.loading-bars i:nth-child(3) { animation-delay: .36s; }
+@keyframes translation-center-pulse { from { opacity: .35; transform: scaleY(.6); } to { opacity: 1; transform: scaleY(1); } }
+.translation-result-content { margin-top: 11px; padding: 12px; border-radius: 10px; color: var(--ink); background: #fff7f9; }
+.translation-result-content p { min-height: 24px; margin: 0; font-size: 14px; line-height: 1.7; white-space: pre-wrap; word-break: break-word; }
+.translation-result-content footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 10px; color: var(--muted); font-size: 9px; }
+.translation-result-content footer button { padding: 0; border: 0; color: var(--brand-strong); background: transparent; cursor: pointer; font-size: 10px; font-weight: 700; }
+.translation-result-error { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; margin-top: 11px; padding: 10px 12px; border-radius: 10px; color: #9f3d57; background: #fff3f5; }
+.translation-result-error p { flex: 1; margin: 0; font-size: 11px; line-height: 1.6; word-break: break-word; }
+.translation-result-error button { flex: none; padding: 4px 7px; border: 1px solid #efb1c1; border-radius: 7px; color: #a43755; background: transparent; cursor: pointer; font-size: 10px; font-weight: 700; }
+.translation-result-error button:disabled { cursor: not-allowed; opacity: .45; }
+
+.translation-center-note { display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-radius: 13px; color: var(--muted); background: var(--surface-soft); font-size: 10px; }
+.translation-center-note > span { padding: 4px 7px; border-radius: 6px; color: var(--brand-strong); background: var(--brand-soft); font-weight: 800; }
+.translation-center-note p { flex: 1; margin: 0; line-height: 1.5; }
+.translation-center-note button { padding: 0; border: 0; color: var(--brand-strong); background: transparent; cursor: pointer; font-size: 10px; font-weight: 750; white-space: nowrap; }
+
+@media (max-width: 1050px) {
+  .translation-center { padding: 24px 28px 20px; }
+  .translation-center-layout { grid-template-columns: minmax(270px, .8fr) minmax(360px, 1.2fr); }
+  .translation-result-service-name small { max-width: 200px; }
+}
+
+@media (max-width: 760px) {
+  .translation-center { padding: 16px 10px 14px; }
+  .translation-center-hero { padding: 20px; flex-direction: column; }
+  .translation-center-hero h2 { font-size: 23px; }
+  .translation-center-toolbar { align-items: stretch; flex-wrap: wrap; }
+  .language-picker-group { flex: 1 1 140px; }
+  .language-picker-group select { min-width: 0; width: 100%; }
+  .language-swap-button { align-self: flex-end; }
+  .translation-center-service-picker { width: 100%; margin-left: 0; }
+  .add-service-button { width: 100%; justify-content: center; }
+  .service-picker-menu { left: 0; right: 0; width: auto; }
+  .translation-center-layout { grid-template-columns: 1fr; }
+  .translation-input-panel { min-height: 330px; }
+  .translation-results-panel { min-height: 360px; }
+  .translation-result-service-name small { max-width: 160px; }
+  .translation-center-note { align-items: flex-start; flex-wrap: wrap; }
+  .translation-center-note p { flex-basis: calc(100% - 42px); }
+  .translation-center-note button { margin-left: 42px; }
+}
+
+@media (max-width: 480px) {
+  .translation-input-panel,
+  .translation-results-panel { padding: 15px; }
+  .translation-input-panel textarea { min-height: 220px; font-size: 17px; }
+  .translation-result-service-name small { display: none; }
+  .translation-result-card-actions .result-state { display: none; }
+}
+</style>

--- a/components/TranslationCenter.vue
+++ b/components/TranslationCenter.vue
@@ -574,9 +574,9 @@ onUnmounted(() => {
 <style scoped>
 .translation-center {
   display: grid;
-  gap: 18px;
-  min-height: 100%;
-  padding: 30px 36px 24px;
+  gap: 14px;
+  min-height: 0;
+  padding: 22px 28px 20px;
   color: var(--ink);
   background: #f8f9fc;
 }
@@ -595,9 +595,9 @@ onUnmounted(() => {
   align-items: flex-start;
   justify-content: space-between;
   gap: 24px;
-  padding: 26px 28px;
+  padding: 20px 24px;
   border-color: #f3ced9;
-  border-radius: 22px;
+  border-radius: 18px;
   background: linear-gradient(135deg, #fff8fa 0%, #fff 55%, #f7f8ff 100%);
 }
 
@@ -611,21 +611,21 @@ onUnmounted(() => {
   text-transform: uppercase;
 }
 
-.translation-center-kicker { margin-bottom: 8px; }
-.translation-center-hero h2 { margin: 0 0 8px; font-size: 26px; letter-spacing: -.04em; }
-.translation-center-hero p { max-width: 680px; margin: 0; color: var(--muted); font-size: 13px; line-height: 1.7; }
+.translation-center-kicker { margin-bottom: 6px; }
+.translation-center-hero h2 { margin: 0 0 6px; font-size: 23px; letter-spacing: -.04em; }
+.translation-center-hero p { max-width: 680px; margin: 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
 
 .translation-center-run-status {
   display: inline-flex;
   align-items: center;
   flex: none;
   gap: 8px;
-  padding: 9px 12px;
+  padding: 7px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--muted);
   background: var(--surface-soft);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
 }
 
@@ -637,15 +637,15 @@ onUnmounted(() => {
   display: flex;
   align-items: flex-end;
   gap: 10px;
-  padding: 14px 16px;
-  border-radius: 16px;
+  padding: 10px 12px;
+  border-radius: 14px;
 }
 
-.language-picker-group { display: grid; gap: 6px; min-width: 154px; }
+.language-picker-group { display: grid; gap: 4px; min-width: 142px; }
 .language-picker-group label { color: var(--muted); font-size: 10px; font-weight: 750; }
 .language-picker-group select {
-  min-width: 154px;
-  height: 40px;
+  min-width: 142px;
+  height: 36px;
   padding: 0 30px 0 12px;
   border: 1px solid #e1e5ee;
   border-radius: 11px;
@@ -658,7 +658,7 @@ onUnmounted(() => {
 
 .language-swap-button {
   width: 38px;
-  height: 40px;
+  height: 36px;
   border: 1px solid transparent;
   border-radius: 11px;
   color: var(--brand-strong);
@@ -675,7 +675,7 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  height: 40px;
+  height: 36px;
   padding: 0 12px;
   border: 1px solid #e1e5ee;
   border-radius: 11px;
@@ -730,11 +730,11 @@ onUnmounted(() => {
 .service-picker-groups > p { margin: 28px 8px; color: var(--muted); font-size: 11px; text-align: center; }
 .service-picker-footer { padding: 10px 15px; border-top: 1px solid var(--line); color: var(--muted); background: var(--surface-soft); font-size: 9px; }
 
-.translation-center-layout { display: grid; grid-template-columns: minmax(300px, .88fr) minmax(420px, 1.12fr); gap: 18px; min-height: 0; }
+.translation-center-layout { display: grid; grid-template-columns: minmax(300px, .88fr) minmax(420px, 1.12fr); gap: 14px; height: clamp(420px, calc(100vh - 420px), 560px); min-height: 0; }
 .translation-input-panel,
-.translation-results-panel { min-width: 0; border-radius: 18px; }
-.translation-input-panel { display: flex; min-height: 390px; flex-direction: column; padding: 20px; }
-.translation-results-panel { display: flex; min-height: 390px; flex-direction: column; padding: 20px; }
+.translation-results-panel { min-width: 0; border-radius: 15px; }
+.translation-input-panel { display: flex; min-height: 340px; flex-direction: column; padding: 16px; }
+.translation-results-panel { display: flex; min-height: 340px; flex-direction: column; padding: 16px; }
 .translation-panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
 .translation-panel-kicker { margin-bottom: 5px; }
 .translation-panel-heading h3 { margin: 0; color: var(--ink); font-size: 17px; letter-spacing: -.02em; }
@@ -807,15 +807,15 @@ onUnmounted(() => {
 .translation-result-error button:disabled { cursor: not-allowed; opacity: .45; }
 
 @media (max-width: 1050px) {
-  .translation-center { padding: 24px 28px 20px; }
+  .translation-center { padding: 20px 24px 18px; }
   .translation-center-layout { grid-template-columns: minmax(270px, .8fr) minmax(360px, 1.2fr); }
   .translation-result-service-name small { max-width: 200px; }
 }
 
 @media (max-width: 760px) {
   .translation-center { padding: 16px 10px 14px; }
-  .translation-center-hero { padding: 20px; flex-direction: column; }
-  .translation-center-hero h2 { font-size: 23px; }
+  .translation-center-hero { padding: 18px; flex-direction: column; }
+  .translation-center-hero h2 { font-size: 21px; }
   .translation-center-toolbar { align-items: stretch; flex-wrap: wrap; }
   .language-picker-group { flex: 1 1 140px; }
   .language-picker-group select { min-width: 0; width: 100%; }
@@ -823,9 +823,9 @@ onUnmounted(() => {
   .translation-center-service-picker { width: 100%; margin-left: 0; }
   .add-service-button { width: 100%; justify-content: center; }
   .service-picker-popover { left: 0; right: 0; width: auto; }
-  .translation-center-layout { grid-template-columns: 1fr; }
-  .translation-input-panel { min-height: 330px; }
-  .translation-results-panel { min-height: 360px; }
+  .translation-center-layout { grid-template-columns: 1fr; height: auto; }
+  .translation-input-panel { min-height: 300px; }
+  .translation-results-panel { min-height: 320px; }
   .translation-result-service-name small { max-width: 160px; }
 }
 

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -39,6 +39,7 @@ import {
     normalizeImageOcrLanguageCodes,
     type ImageOcrLanguageCode,
 } from "@/entrypoints/utils/imageOcrLanguages";
+import {getTranslationLanguages, type TranslationLanguageOverride} from "@/entrypoints/utils/translationLanguage";
 
 // 翻译状态管理
 let translationStateMap = new Map<number, boolean>(); // tabId -> isTranslated
@@ -68,6 +69,9 @@ interface TranslationRequestMessageBase {
     useCache?: boolean;
     /** 视频字幕使用的独立翻译服务；普通网页请求不设置。 */
     serviceOverride?: string;
+    /** 翻译中心仅对当前请求使用的语言，不改变全局设置。 */
+    sourceLanguage?: string;
+    targetLanguage?: string;
 }
 
 type TranslationSingleRequestMessage = TranslationRequestMessageBase & { origin: string };
@@ -194,14 +198,16 @@ function buildCacheKey(
     pageContext: string,
     mode: CacheRequestMode,
     serviceOverride?: string,
+    languageOverride?: TranslationLanguageOverride,
 ): string {
     const service = serviceOverride || config.service;
+    const {sourceLanguage, targetLanguage} = getTranslationLanguages(languageOverride);
 
     return buildTranslationCacheKey({
         requestMode: mode,
         sourceText: origin,
-        sourceLanguage: config.from,
-        targetLanguage: config.to,
+        sourceLanguage,
+        targetLanguage,
         service,
         model: getSelectedModel(service),
         endpoint: getProviderEndpoint(service),
@@ -343,7 +349,7 @@ async function translateSingleWithCache(
         return getTranslationService(service)({...message, context, pageContext});
     }
 
-    const key = buildCacheKey(message.origin, context, pageContext, 'single', service);
+    const key = buildCacheKey(message.origin, context, pageContext, 'single', service, message);
     const existing = pendingTranslations.get(key);
     if (existing) return existing;
 
@@ -383,13 +389,13 @@ async function translateBatchWithCache(
         return result as string[];
     }
 
-    const batchKey = buildCacheKey(message.origin, context, pageContext, 'batch', service);
+    const batchKey = buildCacheKey(message.origin, context, pageContext, 'batch', service, message);
     const existing = pendingBatches.get(batchKey);
     if (existing) return existing;
 
     const request = (async () => {
         const cached = await Promise.all(
-            message.origin.map((origin) => translationCache.get(buildCacheKey(origin, context, pageContext, 'batch', service))),
+            message.origin.map((origin) => translationCache.get(buildCacheKey(origin, context, pageContext, 'batch', service, message))),
         );
         const missingIndexes = cached
             .map((value, index) => value === null ? index : -1)
@@ -406,7 +412,7 @@ async function translateBatchWithCache(
         const uniqueMissingOrigins = Array.from(
             new Map(
                 missingEntries.map(({origin}) => [
-                    buildCacheKey(origin, context, pageContext, 'batch', service),
+                    buildCacheKey(origin, context, pageContext, 'batch', service, message),
                     origin,
                 ]),
             ).values(),
@@ -424,15 +430,15 @@ async function translateBatchWithCache(
         const result = [...cached] as Array<string | null>;
         const translatedByKey = new Map(
             uniqueMissingOrigins.map((origin, index) => [
-                buildCacheKey(origin, context, pageContext, 'batch', service),
+                buildCacheKey(origin, context, pageContext, 'batch', service, message),
                 translated[index],
             ]),
         );
         await Promise.all(missingEntries.map(async ({index, origin}) => {
-            const value = translatedByKey.get(buildCacheKey(origin, context, pageContext, 'batch', service));
+            const value = translatedByKey.get(buildCacheKey(origin, context, pageContext, 'batch', service, message));
             result[index] = value as string;
             if (isCacheableResult(origin, value)) {
-                await translationCache.set(buildCacheKey(origin, context, pageContext, 'batch', service), value);
+                await translationCache.set(buildCacheKey(origin, context, pageContext, 'batch', service, message), value);
             }
         }));
 

--- a/entrypoints/options/App.vue
+++ b/entrypoints/options/App.vue
@@ -44,8 +44,8 @@
       </div>
       <div v-else-if="query" class="search-empty">没有找到“{{ query }}”相关设置</div>
 
-      <section class="settings-card" :class="{ 'services-view': activeSection === 'settings-services' }" :aria-label="activeItem.heading">
-        <div v-if="!['settings-services', 'settings-about'].includes(activeSection)" class="card-intro">
+      <section class="settings-card" :class="{ 'services-view': activeSection === 'settings-services', 'translation-center-view': activeSection === 'settings-translation-center' }" :aria-label="activeItem.heading">
+        <div v-if="!['settings-services', 'settings-about', 'settings-translation-center'].includes(activeSection)" class="card-intro">
           <span class="eyebrow">{{ activeItem.kicker }}</span>
           <h2>{{ activeItem.title }}</h2>
           <p>{{ activeItem.detail }}</p>

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -36,6 +36,17 @@ export const navigationGroups: NavigationGroup[] = [
     ],
   },
   {
+    label: '翻译工具',
+    items: [
+      {
+        id: 'settings-translation-center', icon: '译', label: '翻译中心', description: '多服务对比', group: '翻译工具',
+        heading: '比较不同翻译服务', summary: '输入一句话，同时查看多个翻译服务的结果，并支持重复翻译。',
+        kicker: '翻译工具', title: '翻译中心', detail: '用同一句话比较不同服务的译文表现。',
+        searchDescription: '多服务翻译、翻译对比、重复翻译、句子翻译',
+      },
+    ],
+  },
+  {
     label: '阅读工具',
     items: [
       {

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -87,9 +87,9 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 }
 .settings-card.translation-center-view > .settings-main-sections { display: none !important; }
 .settings-card.translation-center-view > #settings-translation-center {
-  display: block !important; min-height: 0; height: 100%; flex: 1 1 auto; overflow: hidden;
+  display: flex !important; min-height: 0; height: 100%; flex: 1 1 auto; align-items: flex-start; justify-content: center; overflow: hidden;
 }
-.settings-card.translation-center-view .translation-center { height: 100%; overflow-y: auto; }
+.settings-card.translation-center-view .translation-center { width: min(100%, 1480px); height: auto; max-height: 100%; overflow-y: auto; }
 .card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
 .card-intro h2 { margin-bottom: 6px; font-size: 21px; }
 .settings-card > div:last-child > .el-row,

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -81,6 +81,15 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
 .settings-card.services-view .service-configuration-slot .service-connection-section { margin-top: 0; padding-top: 0; border-top: 0; }
 .settings-card.services-view .service-configuration-slot .subsection-heading { margin-right: 0; margin-left: 0; }
 .settings-card.services-view .service-configuration-slot .el-row { margin-right: 0 !important; margin-left: 0 !important; }
+.settings-card.translation-center-view {
+  display: flex; width: calc(100% + 88px); margin-right: -44px; margin-left: -44px; padding: 0; border-right: 0; border-left: 0; border-radius: 0;
+  flex-direction: column; overflow: hidden;
+}
+.settings-card.translation-center-view > .settings-main-sections { display: none !important; }
+.settings-card.translation-center-view > #settings-translation-center {
+  display: block !important; min-height: 0; height: 100%; flex: 1 1 auto; overflow: hidden;
+}
+.settings-card.translation-center-view .translation-center { height: 100%; overflow-y: auto; }
 .card-intro { margin: 0 16px 25px; padding-bottom: 22px; border-bottom: 1px solid var(--line); }
 .card-intro h2 { margin-bottom: 6px; font-size: 21px; }
 .settings-card > div:last-child > .el-row,
@@ -284,6 +293,7 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .sidebar { flex-basis: 210px; width: 210px; }
   .workspace { width: auto; padding: 28px 28px 20px; }
   .settings-card.services-view { width: calc(100% + 56px); margin-right: -28px; margin-left: -28px; }
+  .settings-card.translation-center-view { width: calc(100% + 56px); margin-right: -28px; margin-left: -28px; }
   .topbar { align-items: stretch; flex-direction: column; }
   .search-box { width: 100%; }
 }
@@ -313,6 +323,7 @@ h1 { margin-bottom: 6px; font-size: 28px; line-height: 1.25; letter-spacing: -.0
   .search-box { height: 44px; }
   .settings-card { padding: 20px 8px 14px; border-radius: 20px; }
   .settings-card.services-view { display: flex; width: 100%; margin-right: 0; margin-left: 0; border-right: 1px solid var(--line); border-left: 1px solid var(--line); border-radius: 20px; overflow: hidden; }
+  .settings-card.translation-center-view { display: flex; width: 100%; margin-right: 0; margin-left: 0; border-right: 1px solid var(--line); border-left: 1px solid var(--line); border-radius: 20px; overflow: hidden; }
   .settings-card.services-view .service-catalog { height: 100% !important; min-height: 0 !important; flex: 1 1 auto; }
   .settings-card.services-view .service-catalog .catalog-layout { display: flex; min-height: 0; flex: 1 1 auto; flex-direction: column; overflow: hidden; }
   .settings-card.services-view .service-catalog .service-rail { min-height: 0; max-height: 190px; flex: 0 0 190px; overflow-y: auto; }

--- a/entrypoints/service/azure-openai.ts
+++ b/entrypoints/service/azure-openai.ts
@@ -29,7 +29,7 @@ async function azureOpenai(message: any) {
         const resp = await fetch(endpoint, {
             method: method.POST,
             headers,
-            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/claude.ts
+++ b/entrypoints/service/claude.ts
@@ -19,7 +19,7 @@ async function claude(message: any) {
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: claudeMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: claudeMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/common.ts
+++ b/entrypoints/service/common.ts
@@ -30,7 +30,7 @@ async function common(message: any) {
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/coze.ts
+++ b/entrypoints/service/coze.ts
@@ -17,7 +17,7 @@ async function coze( message: any) {
     const resp = await fetch(url, {
         method: method.POST,
         headers: headers,
-        body: cozeTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+        body: cozeTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
     });
 
     if (resp.ok) {

--- a/entrypoints/service/custom.ts
+++ b/entrypoints/service/custom.ts
@@ -20,7 +20,7 @@ async function custom(message: any) {
     const resp = await fetch(url, {
         method: method.POST,
         headers: headers,
-        body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+        body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
     });
 
     if (resp.ok) {

--- a/entrypoints/service/deepl.ts
+++ b/entrypoints/service/deepl.ts
@@ -1,11 +1,13 @@
 import {method, urls} from "../utils/constant";
 import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
 
 async function deepl(message: any) {
     const service = message.serviceOverride || config.service;
     // deepl 不支持 zh-Hans，需要转换为 zh
-    let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
+    const {targetLanguage} = getTranslationLanguages(message);
+    let targetLang = targetLanguage === 'zh-Hans' ? 'zh' : targetLanguage;
 
     // 判断是否使用代理
     let url: string = config.proxy[service] ? config.proxy[service] : urls[services.deepL]

--- a/entrypoints/service/deeplx.ts
+++ b/entrypoints/service/deeplx.ts
@@ -1,6 +1,7 @@
 import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
 import {getDeepLXEndpoints} from "@/entrypoints/utils/deeplx";
+import {getTranslationLanguages, type TranslationLanguageOverride} from "@/entrypoints/utils/translationLanguage";
 
 const DEEPLX_TOTAL_TIMEOUT_MS = 20_000;
 const DEEPLX_ATTEMPT_TIMEOUT_MS = 8_000;
@@ -112,6 +113,7 @@ export function getDeepLXRequestLanguages(from: string, to: string): {sourceLang
 export async function translateDeepLXText(
     text: string,
     serviceKey: string = services.deeplx,
+    languageOverride?: TranslationLanguageOverride,
 ): Promise<string> {
     if (typeof text !== "string") {
         throw new Error("DeepLX 翻译仅支持单条文本");
@@ -123,7 +125,8 @@ export async function translateDeepLXText(
         config.proxy[serviceKey],
         token,
     );
-    const {sourceLang, targetLang} = getDeepLXRequestLanguages(config.from, config.to);
+    const {sourceLanguage, targetLanguage} = getTranslationLanguages(languageOverride);
+    const {sourceLang, targetLang} = getDeepLXRequestLanguages(sourceLanguage, targetLanguage);
     const deadline = Date.now() + DEEPLX_TOTAL_TIMEOUT_MS;
     const failures: string[] = [];
 
@@ -151,12 +154,12 @@ export async function translateDeepLXText(
     throw new Error(`DeepLX 所有备用站点均失败：${failureSummary}`);
 }
 
-async function deeplx(message: {origin: string}) {
+async function deeplx(message: {origin: string; sourceLanguage?: string; targetLanguage?: string}) {
     if (typeof message.origin !== "string") {
         throw new Error("DeepLX 翻译仅支持单条文本");
     }
 
-    return translateDeepLXText(message.origin, services.deeplx);
+    return translateDeepLXText(message.origin, services.deeplx, message);
 }
 
 export default deeplx;

--- a/entrypoints/service/deepseek.ts
+++ b/entrypoints/service/deepseek.ts
@@ -26,8 +26,8 @@ async function deepseek(message: any) {
             method: method.POST,
             headers,
             body: isResponses
-                ? deepseekResponsesMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
-                : deepseekMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+                ? deepseekResponsesMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
+                : deepseekMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/free-translation.ts
+++ b/entrypoints/service/free-translation.ts
@@ -1,12 +1,12 @@
 import {translateMicrosoftTexts} from "@/entrypoints/service/microsoft";
 import {translateDeepLXText} from "@/entrypoints/service/deeplx";
 import {translateGoogleText} from "@/entrypoints/service/google";
-import {config} from "@/entrypoints/utils/config";
 import {services} from "@/entrypoints/utils/option";
+import {getTranslationLanguages, type TranslationLanguageOverride} from "@/entrypoints/utils/translationLanguage";
 
 type FreeTranslationProvider = {
     label: string;
-    translate: (text: string) => Promise<string>;
+    translate: (text: string, languages: TranslationLanguageOverride) => Promise<string>;
 };
 
 export const FREE_TRANSLATION_ORDER = [
@@ -25,18 +25,24 @@ function requireTranslation(text: string, label: string): string {
 const providers: FreeTranslationProvider[] = [
     {
         label: FREE_TRANSLATION_ORDER[0],
-        translate: async (text) => {
-            const translations = await translateMicrosoftTexts([text], config.from, config.to);
+        translate: async (text, languages) => {
+            const {sourceLanguage, targetLanguage} = getTranslationLanguages(languages);
+            const translations = await translateMicrosoftTexts([text], sourceLanguage, targetLanguage);
             return requireTranslation(translations[0] || "", FREE_TRANSLATION_ORDER[0]);
         },
     },
     {
         label: FREE_TRANSLATION_ORDER[1],
-        translate: (text) => translateDeepLXText(text, services.deeplx),
+        translate: (text, languages) => languages.sourceLanguage || languages.targetLanguage
+            ? translateDeepLXText(text, services.deeplx, languages)
+            : translateDeepLXText(text, services.deeplx),
     },
     {
         label: FREE_TRANSLATION_ORDER[2],
-        translate: (text) => translateGoogleText(text, config.from, config.to),
+        translate: (text, languages) => {
+            const {sourceLanguage, targetLanguage} = getTranslationLanguages(languages);
+            return translateGoogleText(text, sourceLanguage, targetLanguage);
+        },
     },
 ];
 
@@ -44,7 +50,7 @@ function getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
-export async function translateFreeText(text: string): Promise<string> {
+export async function translateFreeText(text: string, languages: TranslationLanguageOverride = {}): Promise<string> {
     if (typeof text !== "string") {
         throw new Error("免费翻译服务仅支持文本输入");
     }
@@ -52,7 +58,7 @@ export async function translateFreeText(text: string): Promise<string> {
     const failures: string[] = [];
     for (const provider of providers) {
         try {
-            return requireTranslation(await provider.translate(text), provider.label);
+            return requireTranslation(await provider.translate(text, languages), provider.label);
         } catch (error) {
             failures.push(`${provider.label}: ${getErrorMessage(error)}`);
         }
@@ -61,13 +67,13 @@ export async function translateFreeText(text: string): Promise<string> {
     throw new Error(`免费翻译服务均不可用（${FREE_TRANSLATION_ORDER.join(" → ")}）：${failures.join("；")}`);
 }
 
-async function freeTranslation(message: {origin: string | string[]}) {
+async function freeTranslation(message: {origin: string | string[]; sourceLanguage?: string; targetLanguage?: string}) {
     if (typeof message.origin === "string") {
-        return translateFreeText(message.origin);
+        return translateFreeText(message.origin, message);
     }
 
     if (Array.isArray(message.origin)) {
-        return Promise.all(message.origin.map(text => translateFreeText(text)));
+        return Promise.all(message.origin.map(text => translateFreeText(text, message)));
     }
 
     throw new Error("免费翻译服务仅支持文本输入");

--- a/entrypoints/service/gemini.ts
+++ b/entrypoints/service/gemini.ts
@@ -16,7 +16,7 @@ async function gemini(message: any) {
     const resp = await fetch(url, {
         method: method.POST,
         headers: {'Content-Type': 'application/json'},
-        body: geminiMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service),
+        body: geminiMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage),
     });
     if (resp.ok) {
         let result = await resp.json();

--- a/entrypoints/service/google.ts
+++ b/entrypoints/service/google.ts
@@ -1,4 +1,5 @@
-import {config} from "@/entrypoints/utils/config";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
+import type {TranslationLanguageOverride} from "@/entrypoints/utils/translationLanguage";
 
 const GOOGLE_TRANSLATE_RPC_ID = 'MkEWBc';
 const GOOGLE_TRANSLATE_BATCH_URLS = [
@@ -247,11 +248,12 @@ export async function translateGoogleText(
     throw new Error(`谷歌翻译所有匿名接口均失败：${failureSummary}`);
 }
 
-async function google(message: {origin: string}) {
+async function google(message: TranslationLanguageOverride & {origin: string}) {
     if (typeof message.origin !== 'string') {
         throw new Error('谷歌翻译仅支持单条文本');
     }
-    return translateGoogleText(message.origin, config.from, config.to);
+    const {sourceLanguage, targetLanguage} = getTranslationLanguages(message);
+    return translateGoogleText(message.origin, sourceLanguage, targetLanguage);
 }
 
 export default google;

--- a/entrypoints/service/grok.ts
+++ b/entrypoints/service/grok.ts
@@ -20,7 +20,7 @@ async function grok(message: any) {
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/hunyuan-translation.ts
+++ b/entrypoints/service/hunyuan-translation.ts
@@ -3,6 +3,7 @@ import { config } from "@/entrypoints/utils/config";
 import { detectlang } from "../utils/common";
 import { mergeCustomBody } from "../utils/custom-body";
 import { services } from "../utils/option";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
 
 // 混元翻译大模型支持的语言代码映射
 const languageMap: Record<string, string> = {
@@ -131,31 +132,32 @@ async function hunyuanTranslation(message: any) {
         
         // 转换语言代码
         // 对于自动检测，使用FluentRead内置的语言检测
+        const {sourceLanguage, targetLanguage} = getTranslationLanguages(message);
         let sourceLang: string;
-        if (config.from === 'auto') {
+        if (sourceLanguage === 'auto') {
             const detectedLang = detectlang(message.origin.replace(/[\s\u3000]/g, ''));
             sourceLang = languageMap[detectedLang] || detectedLang;
             console.log('🔍 语言检测结果:', { detectedLang, mappedSource: sourceLang });
         } else {
-            sourceLang = languageMap[config.from] || config.from;
+            sourceLang = languageMap[sourceLanguage] || sourceLanguage;
         }
         
-        const targetLang = languageMap[config.to] || config.to;
+        const mappedTargetLang = languageMap[targetLanguage] || targetLanguage;
         
         console.log('🌐 语言映射结果:', { 
-            originalFrom: config.from, 
+            originalFrom: sourceLanguage,
             mappedSource: sourceLang,
-            originalTo: config.to, 
-            mappedTarget: targetLang 
+            originalTo: targetLanguage,
+            mappedTarget: mappedTargetLang
         });
         
         // 如果源语言和目标语言相同，直接返回原文
-        if (sourceLang === targetLang) {
+        if (sourceLang === mappedTargetLang) {
             console.log('⚠️ 源语言与目标语言相同，返回原文');
             return message.origin;
         }
         
-        if (!targetLang) {
+        if (!mappedTargetLang) {
             throw new Error('混元翻译不支持该目标语言');
         }
         
@@ -165,7 +167,7 @@ async function hunyuanTranslation(message: any) {
         // 自定义字段必须在序列化和签名前合并，否则签名内容会与实际请求体不一致。
         const requestBody = buildHunyuanTranslationRequestBody(
             message.origin,
-            targetLang,
+            mappedTargetLang,
             model,
             config.customBody?.[service],
         );

--- a/entrypoints/service/microsoft.ts
+++ b/entrypoints/service/microsoft.ts
@@ -1,4 +1,5 @@
-import {config} from "@/entrypoints/utils/config";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
+import type {TranslationLanguageOverride} from "@/entrypoints/utils/translationLanguage";
 
 const MICROSOFT_TRANSLATE_URL = "https://edge.microsoft.com/translate/translatetext";
 
@@ -64,11 +65,12 @@ export async function translateMicrosoftTexts(
     });
 }
 
-async function microsoft(message: {origin: string | string[]}) {
+async function microsoft(message: TranslationLanguageOverride & {origin: string | string[]}) {
     const origin = message.origin;
     const isSingleText = typeof origin === 'string';
     const texts: string[] = typeof origin === 'string' ? [origin] : origin;
-    const translations = await translateMicrosoftTexts(texts, config.from, config.to);
+    const {sourceLanguage, targetLanguage} = getTranslationLanguages(message);
+    const translations = await translateMicrosoftTexts(texts, sourceLanguage, targetLanguage);
     if (!isSingleText) return translations;
 
     const translatedText = translations[0];

--- a/entrypoints/service/newapi.ts
+++ b/entrypoints/service/newapi.ts
@@ -30,7 +30,7 @@ async function newapi(message: any) {
         const resp = await fetch(url, {
             method: method.POST,
             headers,
-            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
         });
 
         if (!resp.ok) {

--- a/entrypoints/service/tencent.ts
+++ b/entrypoints/service/tencent.ts
@@ -1,5 +1,6 @@
 import { method } from "../utils/constant";
 import { config } from "@/entrypoints/utils/config";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
 
 // 腾讯云机器翻译语言代码映射
 const languageMap: Record<string, string> = {
@@ -101,8 +102,9 @@ async function tencent(message: any) {
         }
         
         // 转换语言代码
-        const sourceLang = languageMap[config.from] || config.from;
-        const targetLang = languageMap[config.to] || config.to;
+        const {sourceLanguage, targetLanguage} = getTranslationLanguages(message);
+        const sourceLang = languageMap[sourceLanguage] || sourceLanguage;
+        const targetLang = languageMap[targetLanguage] || targetLanguage;
         
         if (!targetLang || targetLang === 'auto') {
             throw new Error('腾讯云机器翻译不支持目标语言自动检测');

--- a/entrypoints/service/tongyi.ts
+++ b/entrypoints/service/tongyi.ts
@@ -22,7 +22,7 @@ async function tongyi(message: any) {
     const resp = await fetch(url, {
         method: method.POST,
         headers: headers,
-        body: tongyiMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+        body: tongyiMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
     });
 
     if (resp.ok) {

--- a/entrypoints/service/xiaoniu.ts
+++ b/entrypoints/service/xiaoniu.ts
@@ -1,11 +1,13 @@
 import {method, urls} from "../utils/constant";
 import {services} from "../utils/option";
 import {config} from "@/entrypoints/utils/config";
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
 
 async function xiaoniu(message: any) {
     const service = message.serviceOverride || config.service;
     // 根据需要调整目标语言
-    let targetLang = config.to === 'zh-Hans' ? 'zh' : config.to;
+    const {targetLanguage} = getTranslationLanguages(message);
+    let targetLang = targetLanguage === 'zh-Hans' ? 'zh' : targetLanguage;
 
     // 判断是否使用代理
     let url: string = config.proxy[service] ? config.proxy[service] : urls[services.xiaoniu]

--- a/entrypoints/service/youdao.ts
+++ b/entrypoints/service/youdao.ts
@@ -1,6 +1,7 @@
 import { method } from "../utils/constant";
 import { config } from "@/entrypoints/utils/config";
 import CryptoJS from 'crypto-js';
+import {getTranslationLanguages} from "@/entrypoints/utils/translationLanguage";
 
 interface YoudaoResponse {
   errorCode: string;
@@ -96,8 +97,9 @@ async function youdao(message: any): Promise<string> {
     'yue': 'yue'
   };
 
-  const fromLang = langMap[config.from] || 'auto';
-  const toLang = langMap[config.to] || 'zh-CHS';
+  const {sourceLanguage, targetLanguage} = getTranslationLanguages(message);
+  const fromLang = langMap[sourceLanguage] || 'auto';
+  const toLang = langMap[targetLanguage] || 'zh-CHS';
 
   const sign = generateSign(appKey, query, salt, curtime, appSecret);
 

--- a/entrypoints/service/zhipu.ts
+++ b/entrypoints/service/zhipu.ts
@@ -32,7 +32,7 @@ async function zhipu(message: any) {
     const resp = await fetch(urls[services.zhipu], {
         method: method.POST,
         headers: headers,
-            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service)
+            body: commonMsgTemplate(message.origin, message.pageContext, message.summaryPrompt, message.summarySystemPrompt, service, message.targetLanguage)
     });
 
     if (resp.ok) {

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -103,6 +103,9 @@ export class Config {
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
     deepseekApiType: DeepSeekApiType; // DeepSeek API 格式
     deepseekThinkingMode: DeepSeekThinkingMode; // DeepSeek Chat Completion 思考模式
+    translationCenterServices: string[]; // 翻译中心已选服务及其展示顺序
+    translationCenterSourceLanguage: string; // 翻译中心源语言
+    translationCenterTargetLanguage: string; // 翻译中心目标语言
 
     constructor() {
         this.on = true;
@@ -168,6 +171,9 @@ export class Config {
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
         this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
         this.deepseekThinkingMode = 'disabled'; // 翻译默认关闭思考模式，降低延迟和输出噪音
+        this.translationCenterServices = [];
+        this.translationCenterSourceLanguage = '';
+        this.translationCenterTargetLanguage = '';
     }
 }
 
@@ -353,6 +359,9 @@ export function normalizeConfig(value: unknown): Config {
     if (typeof normalized.contextMenuEnabled !== 'boolean') {
         normalized.contextMenuEnabled = true;
     }
+    normalized.translationCenterServices = normalizeStringList(source.translationCenterServices);
+    normalized.translationCenterSourceLanguage = normalizeConfigLanguage(source.translationCenterSourceLanguage);
+    normalized.translationCenterTargetLanguage = normalizeConfigLanguage(source.translationCenterTargetLanguage);
 
     return normalized;
 }
@@ -391,6 +400,18 @@ function normalizeStringMapping(value: unknown): IMapping {
     return Object.fromEntries(
         Object.entries(value).filter(([, item]) => typeof item === 'string'),
     );
+}
+
+function normalizeStringList(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return [...new Set(value
+        .filter((item): item is string => typeof item === 'string')
+        .map(item => item.trim())
+        .filter(Boolean))];
+}
+
+function normalizeConfigLanguage(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
 }
 
 function isBooleanMapping(value: unknown): value is Record<string, boolean> {

--- a/entrypoints/utils/template.ts
+++ b/entrypoints/utils/template.ts
@@ -11,12 +11,18 @@ function currentCustomBody(service = config.service): string | undefined {
     return config.customBody?.[service];
 }
 
-function buildUserPrompt(origin: string, context?: string, prompt?: string, service = config.service): string {
+function buildUserPrompt(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    service = config.service,
+    targetLanguage = config.to,
+): string {
     const normalizedPrompt = prompt?.trim();
     if (normalizedPrompt) return normalizedPrompt;
 
     const user = (config.user_role[service] || defaultOption.user_role)
-        .replace('{{to}}', config.to).replace('{{origin}}', origin);
+        .replace('{{to}}', targetLanguage).replace('{{origin}}', origin);
     const normalizedContext = context?.trim();
     if (!normalizedContext) return user;
 
@@ -45,7 +51,14 @@ function currentConfiguredModel(service: string): string {
 }
 
 // openai 格式的消息模板（通用模板）
-export function commonMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function commonMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || config.service;
     let model = currentConfiguredModel(service);
 
@@ -53,7 +66,7 @@ export function commonMsgTemplate(origin: string, context?: string, prompt?: str
     model = model.replace(/（.*）/g, "");
 
     let system = systemPrompt?.trim() || config.system_role[service] || defaultOption.system_role;
-    const user = buildUserPrompt(origin, context, prompt, service);
+    const user = buildUserPrompt(origin, context, prompt, service, targetLanguage);
 
     const payload: any = {
         'model': model,
@@ -88,18 +101,32 @@ function getDeepSeekThinkingMode(serviceOverride?: string): 'enabled' | 'disable
     return config.deepseekThinkingMode === 'enabled' ? 'enabled' : 'disabled';
 }
 
-function deepseekPrompt(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+function deepseekPrompt(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || config.service;
     return {
         system: systemPrompt?.trim() || config.system_role[service] || defaultOption.system_role,
-        user: buildUserPrompt(origin, context, prompt, service),
+        user: buildUserPrompt(origin, context, prompt, service, targetLanguage),
     };
 }
 
 // Responses API 格式供明确支持该协议的端点使用。
-export function deepseekResponsesMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function deepseekResponsesMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const model = getCurrentModel(serviceOverride);
-    const {system, user} = deepseekPrompt(origin, context, prompt, systemPrompt, serviceOverride);
+    const {system, user} = deepseekPrompt(origin, context, prompt, systemPrompt, serviceOverride, targetLanguage);
     const payload: any = {
         model,
         instructions: system,
@@ -110,9 +137,16 @@ export function deepseekResponsesMsgTemplate(origin: string, context?: string, p
 }
 
 // DeepSeek 官方 V4 Chat Completion 格式。
-export function deepseekMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function deepseekMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const model = getCurrentModel(serviceOverride);
-    const {system, user} = deepseekPrompt(origin, context, prompt, systemPrompt, serviceOverride);
+    const {system, user} = deepseekPrompt(origin, context, prompt, systemPrompt, serviceOverride, targetLanguage);
     const thinking = getDeepSeekThinkingMode(serviceOverride);
     const payload: any = {
         model,
@@ -127,9 +161,16 @@ export function deepseekMsgTemplate(origin: string, context?: string, prompt?: s
 }
 
 // gemini
-export function geminiMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function geminiMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || config.service;
-    const userPrompt = buildUserPrompt(origin, context, prompt, service);
+    const userPrompt = buildUserPrompt(origin, context, prompt, service, targetLanguage);
     const user = systemPrompt?.trim() ? `${systemPrompt.trim()}\n\n${userPrompt}` : userPrompt;
 
     const payload: any = {
@@ -142,12 +183,19 @@ export function geminiMsgTemplate(origin: string, context?: string, prompt?: str
 }
 
 // claude
-export function claudeMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function claudeMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || services.claude;
     const model = currentConfiguredModel(service);
 
     let system = systemPrompt?.trim() || config.system_role[service] || defaultOption.system_role;
-    const user = buildUserPrompt(origin, context, prompt, service);
+    const user = buildUserPrompt(origin, context, prompt, service, targetLanguage);
 
     const payload: any = {
         model: model,
@@ -163,12 +211,19 @@ export function claudeMsgTemplate(origin: string, context?: string, prompt?: str
 }
 
 // 通义千问
-export function tongyiMsgTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function tongyiMsgTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || config.service;
     const model = currentConfiguredModel(service);
     const normalTemplate = () => {
         let system = systemPrompt?.trim() || config.system_role[service] || defaultOption.system_role;
-        const user = buildUserPrompt(origin, context, prompt, service);
+        const user = buildUserPrompt(origin, context, prompt, service, targetLanguage);
 
         const payload: any = {
             "model": model,
@@ -190,7 +245,7 @@ export function tongyiMsgTemplate(origin: string, context?: string, prompt?: str
             {value: "fr"},
             {value: "ru"},
         ]
-        let targetItem = langMap.find(i => i.value === config.to) || langMap[0]
+        let targetItem = langMap.find(i => i.value === targetLanguage) || langMap[0]
         let targetLang = targetItem.target || targetItem.value
         const payload: any = {
             "model": model,
@@ -208,11 +263,18 @@ export function tongyiMsgTemplate(origin: string, context?: string, prompt?: str
 
 }
 
-export function cozeTemplate(origin: string, context?: string, prompt?: string, systemPrompt?: string, serviceOverride?: string) {
+export function cozeTemplate(
+    origin: string,
+    context?: string,
+    prompt?: string,
+    systemPrompt?: string,
+    serviceOverride?: string,
+    targetLanguage = config.to,
+) {
     const service = serviceOverride || config.service;
 
     let system = systemPrompt?.trim() || config.system_role[service] || defaultOption.system_role;
-    const user = buildUserPrompt(origin, context, prompt, service);
+    const user = buildUserPrompt(origin, context, prompt, service, targetLanguage);
 
     const payload: any = {
         bot_id: config.robot_id[service],

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -144,6 +144,9 @@ export async function translateText(origin: string, context: string = document.t
     timeout = 45000,
     useCache = config.useCache,
     skipLanguageDetection = false,
+    serviceOverride,
+    sourceLanguage,
+    targetLanguage,
     signal,
     queueSession,
   } = options;
@@ -154,14 +157,14 @@ export async function translateText(origin: string, context: string = document.t
     return origin || '';
   }
 
-  assertTranslationCredentials();
+  assertTranslationCredentials(serviceOverride || config.service);
 
   // 如果目标语言与当前文本语言相同，直接返回原文
-  if (!skipLanguageDetection && detectlang(origin.replace(/[\s\u3000]/g, '')) === config.to) {
+  if (!skipLanguageDetection && detectlang(origin.replace(/[\s\u3000]/g, '')) === (targetLanguage || config.to)) {
     return origin;
   }
 
-  const pageContext = await resolvePageContext(options.pageContext);
+  const pageContext = await resolvePageContext(options.pageContext, serviceOverride || config.service);
   throwIfAborted(signal);
 
   // 同一富文本回退可能产生多个短请求；合并持久化写入，避免每个 slot
@@ -176,7 +179,15 @@ export async function translateText(origin: string, context: string = document.t
       try {
         // 发送翻译请求给background脚本处理
         const result = await waitForRequest(
-          browser.runtime.sendMessage({ context, pageContext, origin, useCache }),
+          browser.runtime.sendMessage({
+            context,
+            pageContext,
+            origin,
+            useCache,
+            serviceOverride,
+            sourceLanguage,
+            targetLanguage,
+          }),
           timeout,
           signal,
           lease,
@@ -221,18 +232,20 @@ export async function translateTextBatch(
 ): Promise<string[]> {
   if (origins.length === 0) return [];
 
-  assertTranslationCredentials();
-
   const {
     maxRetries = 3,
     retryDelay = 1000,
     timeout = 45000,
     useCache = config.useCache,
+    serviceOverride,
+    sourceLanguage,
+    targetLanguage,
     signal,
     queueSession,
   } = options;
+  assertTranslationCredentials(serviceOverride || config.service);
   throwIfAborted(signal);
-  const pageContext = await resolvePageContext(options.pageContext);
+  const pageContext = await resolvePageContext(options.pageContext, serviceOverride || config.service);
   throwIfAborted(signal);
 
   scheduleTranslationCountSave();
@@ -242,7 +255,15 @@ export async function translateTextBatch(
       throwIfAborted(signal);
       try {
         const result = await waitForRequest(
-          browser.runtime.sendMessage({ context, pageContext, origin: origins, useCache }),
+          browser.runtime.sendMessage({
+            context,
+            pageContext,
+            origin: origins,
+            useCache,
+            serviceOverride,
+            sourceLanguage,
+            targetLanguage,
+          }),
           timeout,
           signal,
           lease,
@@ -315,6 +336,12 @@ export interface TranslateOptions {
   timeout?: number;
   /** 是否使用缓存 */
   useCache?: boolean;
+  /** 仅对当前请求使用的翻译服务，不改变网页翻译默认服务。 */
+  serviceOverride?: string;
+  /** 仅对当前请求使用的源语言，不改变通用设置。 */
+  sourceLanguage?: string;
+  /** 仅对当前请求使用的目标语言，不改变通用设置。 */
+  targetLanguage?: string;
   /** 发送给 LLM 的网页参考上下文；未提供时按当前页面自动提取。 */
   pageContext?: string;
   /** Internal structured packets contain ASCII sentinels that must not affect source-language detection. */
@@ -325,8 +352,8 @@ export interface TranslateOptions {
   queueSession?: TranslationQueueSession;
 }
 
-function assertTranslationCredentials(): void {
-  const message = getMissingCredentialMessage(config.service, config);
+function assertTranslationCredentials(service = config.service): void {
+  const message = getMissingCredentialMessage(service, config);
   if (message) throw new Error(message);
 }
 

--- a/entrypoints/utils/translationLanguage.ts
+++ b/entrypoints/utils/translationLanguage.ts
@@ -1,0 +1,25 @@
+import { config } from './config';
+
+export interface TranslationLanguageOverride {
+    sourceLanguage?: string;
+    targetLanguage?: string;
+}
+
+function readLanguage(value: unknown, fallback: string): string {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+/**
+ * Resolve the language pair attached to a translation request without mutating
+ * the shared extension configuration. This keeps comparison requests isolated
+ * when several services are translated at the same time.
+ */
+export function getTranslationLanguages(message?: TranslationLanguageOverride | null): {
+    sourceLanguage: string;
+    targetLanguage: string;
+} {
+    return {
+        sourceLanguage: readLanguage(message?.sourceLanguage, config.from),
+        targetLanguage: readLanguage(message?.targetLanguage, config.to),
+    };
+}

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -109,6 +109,33 @@ describe('图片翻译配置', () => {
     });
 });
 
+describe('翻译中心配置', () => {
+    it('默认使用服务列表，保存后保留去重后的服务顺序和语言选择', () => {
+        expect(new Config().translationCenterServices).toEqual([]);
+        expect(normalizeConfig({
+            translationCenterServices: ['google', 'openai', 'google', ' ', 12],
+            translationCenterSourceLanguage: ' en ',
+            translationCenterTargetLanguage: ' ja ',
+        })).toMatchObject({
+            translationCenterServices: ['google', 'openai'],
+            translationCenterSourceLanguage: 'en',
+            translationCenterTargetLanguage: 'ja',
+        });
+    });
+
+    it('旧配置或非法值安全回退为空服务配置', () => {
+        expect(normalizeConfig({
+            translationCenterServices: 'google',
+            translationCenterSourceLanguage: 12,
+            translationCenterTargetLanguage: null,
+        })).toMatchObject({
+            translationCenterServices: [],
+            translationCenterSourceLanguage: '',
+            translationCenterTargetLanguage: '',
+        });
+    });
+});
+
 describe('圈选翻译配置', () => {
     it('默认关闭，并保留用户主动启用的状态', () => {
         expect(new Config().selectionAreaEnabled).toBe(false);

--- a/tests/translateApiPerformance.test.ts
+++ b/tests/translateApiPerformance.test.ts
@@ -88,6 +88,28 @@ describe('translation API request lifecycle performance', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('sends service and language overrides without changing the default request config', async () => {
+    mocks.sendMessage.mockResolvedValue('请求级译文');
+
+    await expect(translateText('Readable source', 'Context', {
+      maxRetries: 0,
+      useCache: false,
+      serviceOverride: 'mock-ai',
+      sourceLanguage: 'en',
+      targetLanguage: 'ja',
+    })).resolves.toBe('请求级译文');
+
+    expect(mocks.config.service).toBe('mock');
+    expect(mocks.config.to).toBe('zh-CN');
+    expect(mocks.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      origin: 'Readable source',
+      serviceOverride: 'mock-ai',
+      sourceLanguage: 'en',
+      targetLanguage: 'ja',
+      useCache: false,
+    }));
+  });
+
   it('aborts a retry delay without sending another runtime request', async () => {
     mocks.sendMessage.mockRejectedValue(new Error('temporary failure'));
     const controller = new AbortController();

--- a/tests/translationLanguage.test.ts
+++ b/tests/translationLanguage.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/entrypoints/utils/config', () => ({
+    config: {
+        from: 'auto',
+        to: 'zh-Hans',
+    },
+}));
+
+import { getTranslationLanguages } from '@/entrypoints/utils/translationLanguage';
+
+describe('翻译请求语言隔离', () => {
+    it('优先使用请求级语言而不需要改写默认配置', () => {
+        expect(getTranslationLanguages({
+            sourceLanguage: 'en',
+            targetLanguage: 'ja',
+        })).toEqual({
+            sourceLanguage: 'en',
+            targetLanguage: 'ja',
+        });
+    });
+
+    it('缺少或为空的请求级语言会回退到默认配置', () => {
+        expect(getTranslationLanguages({
+            sourceLanguage: ' ',
+        })).toEqual({
+            sourceLanguage: 'auto',
+            targetLanguage: 'zh-Hans',
+        });
+    });
+});


### PR DESCRIPTION
## Summary\n- add the translation center comparison page under Settings\n- persist translation center services, order, and language choices without changing the webpage default service\n- improve the more-services picker, add draggable result ordering, and compact the overall layout\n- remove the bottom hint so the translation area has more room\n\n## Validation\n- pnpm compile\n- pnpm test (31 files, 393 tests)\n- pnpm build\n- isolated production Edge translation-center flow: persistence, drag ordering, repeated translation, responsive overflow, and console errors\n\nKnown baseline: the bundled full UI suite still stops at the stale assertion expecting 8 settings categories while the current navigation has 9.