### PR TITLE
feat: restore full-page translation progress panel

### DIFF
--- a/components/Main.vue
+++ b/components/Main.vue
@@ -495,6 +495,31 @@
         </el-col>
       </el-row>
 
+        <!-- 翻译进度面板 -->
+        <el-row class="settings-control-row">
+          <el-col :span="20" class="settings-control-label lightblue rounded-corner">
+            <el-tooltip
+              class="box-item"
+              effect="dark"
+              content="全文翻译时，在网页右下角显示正在翻译和等待中的任务数量；任务结束后自动隐藏。"
+              placement="top-start"
+              :show-after="500"
+            >
+              <span class="popup-text popup-vertical-left">
+                显示翻译进度面板
+                <el-icon class="icon-margin"><InfoFilled /></el-icon>
+              </span>
+            </el-tooltip>
+          </el-col>
+          <el-col :span="4" class="settings-control-field flex-end">
+            <el-switch
+              v-model="config.translationProgressPanelEnabled"
+              class="settings-toggle"
+              aria-label="显示翻译进度面板"
+              @change="handleTranslationProgressPanelChange"
+            />
+          </el-col>
+        </el-row>
 
         <!-- 禁用动画设置 -->
         <el-row class="settings-control-row">
@@ -1051,6 +1076,22 @@ const floatingBallEnabled = computed({
     });
   }
 });
+
+const handleTranslationProgressPanelChange = (isEnabled: boolean) => {
+  browser.tabs.query({}).then(tabs => {
+    tabs.forEach(tab => {
+      if (!tab.id) return;
+      browser.tabs.sendMessage(tab.id, {
+        type: 'toggleTranslationProgressPanel',
+        isEnabled,
+      }).catch(() => {
+        // 忽略发送失败的错误（可能是页面未加载内容脚本）
+      });
+    });
+  }).catch(() => {
+    // 忽略无法查询标签页的错误，配置仍会通过统一存储链路保存
+  });
+};
 
 // 监听划词翻译模式变化
 watch(() => config.value.selectionTranslatorMode, (newMode) => {

--- a/components/TranslationProgressPanel.vue
+++ b/components/TranslationProgressPanel.vue
@@ -1,0 +1,320 @@
+<template>
+  <Transition name="fr-progress-panel">
+    <aside
+      v-if="isVisible"
+      class="fr-translation-progress"
+      :class="{ 'fr-dark': isDark, 'fr-static': !animationsEnabled }"
+      :data-session-id="progress.sessionId"
+      :data-running="progress.running"
+      :data-remaining="progress.remaining"
+      :data-queued="progress.queued"
+      :data-offscreen="progress.offscreen"
+    >
+      <span class="fr-progress-indicator" aria-hidden="true">
+        <i />
+        <i />
+        <i />
+      </span>
+
+      <span
+        class="fr-progress-copy"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        :aria-label="statusLabel"
+      >
+        <strong>翻译进度</strong>
+        <span class="fr-progress-counts">
+          <span>进行中 <b>{{ progress.running }}</b></span>
+          <span class="fr-progress-divider" aria-hidden="true" />
+          <span>剩余 <b>{{ progress.remaining }}</b></span>
+        </span>
+        <small v-if="progress.offscreen > 0">
+          {{ progress.offscreen }} 项将在滚动到附近时翻译
+        </small>
+      </span>
+
+      <button type="button" aria-label="本次全文翻译不再显示进度面板" title="本次隐藏" @click="dismiss">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="m4 4 8 8m0-8-8 8" />
+        </svg>
+      </button>
+    </aside>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import {
+  getFullPageTranslationProgress,
+  subscribeFullPageTranslationProgress,
+} from '@/entrypoints/utils/fullPageTranslationProgress';
+import { config, subscribeConfig } from '@/entrypoints/utils/config';
+
+const progress = ref(getFullPageTranslationProgress());
+const dismissedSessionId = ref<number | null>(null);
+const animationsEnabled = ref(config.animations !== false);
+const configuredTheme = ref(config.theme || 'auto');
+const prefersDark = ref(false);
+const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+let unsubscribeProgress: (() => void) | null = null;
+let unsubscribeConfig: (() => void) | null = null;
+
+const isDark = computed(() => configuredTheme.value === 'dark' || (
+  configuredTheme.value === 'auto' && prefersDark.value
+));
+
+const isVisible = computed(() => progress.value.active &&
+  progress.value.sessionId !== dismissedSessionId.value &&
+  (progress.value.running > 0 || progress.value.remaining > 0));
+
+const statusLabel = computed(() => {
+  const offscreen = progress.value.offscreen > 0
+    ? `，其中 ${progress.value.offscreen} 个任务将在滚动到附近时翻译`
+    : '';
+  return `翻译进度：正在进行 ${progress.value.running} 个任务，剩余 ${progress.value.remaining} 个任务${offscreen}`;
+});
+
+function updatePreferredTheme(event?: MediaQueryListEvent): void {
+  prefersDark.value = event?.matches ?? darkModeMediaQuery.matches;
+}
+
+function dismiss(): void {
+  dismissedSessionId.value = progress.value.sessionId;
+}
+
+onMounted(() => {
+  updatePreferredTheme();
+  darkModeMediaQuery.addEventListener('change', updatePreferredTheme);
+  unsubscribeProgress = subscribeFullPageTranslationProgress((nextProgress) => {
+    progress.value = nextProgress;
+  });
+  unsubscribeConfig = subscribeConfig((nextConfig) => {
+    animationsEnabled.value = nextConfig.animations !== false;
+    configuredTheme.value = nextConfig.theme || 'auto';
+  });
+});
+
+onBeforeUnmount(() => {
+  darkModeMediaQuery.removeEventListener('change', updatePreferredTheme);
+  unsubscribeProgress?.();
+  unsubscribeProgress = null;
+  unsubscribeConfig?.();
+  unsubscribeConfig = null;
+});
+</script>
+
+<style scoped>
+.fr-translation-progress {
+  position: fixed;
+  right: max(16px, env(safe-area-inset-right));
+  bottom: max(16px, env(safe-area-inset-bottom));
+  z-index: 2147483645;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 28px;
+  gap: 10px;
+  align-items: center;
+  width: min(286px, calc(100vw - 32px));
+  padding: 11px 10px 11px 12px;
+  border: 1px solid rgba(229, 88, 139, 0.24);
+  border-radius: 14px;
+  background: rgba(255, 252, 253, 0.96);
+  box-shadow: 0 12px 32px rgba(68, 38, 52, 0.18), 0 2px 8px rgba(68, 38, 52, 0.08);
+  color: #3f3540;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-size: 12px;
+  line-height: 1.35;
+  pointer-events: auto;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.fr-progress-indicator {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 3px;
+  width: 34px;
+  height: 34px;
+  padding: 8px 7px;
+  border-radius: 10px;
+  background: linear-gradient(145deg, #fff0f5, #ffe0eb);
+  color: #e84f87;
+}
+
+.fr-progress-indicator i {
+  display: block;
+  width: 4px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+  animation: fr-progress-pulse 0.72s ease-in-out infinite alternate;
+}
+
+.fr-progress-indicator i:nth-child(2) {
+  height: 14px;
+  animation-delay: 0.16s;
+}
+
+.fr-progress-indicator i:nth-child(3) {
+  height: 11px;
+  animation-delay: 0.32s;
+}
+
+.fr-progress-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fr-progress-copy strong {
+  color: #342b35;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.fr-progress-counts {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #746875;
+  white-space: nowrap;
+}
+
+.fr-progress-counts b {
+  color: #bd2f62;
+  font-variant-numeric: tabular-nums;
+  font-weight: 750;
+}
+
+.fr-progress-divider {
+  width: 1px;
+  height: 10px;
+  background: #e7dce1;
+}
+
+.fr-progress-copy small {
+  overflow: hidden;
+  color: #70636e;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+button {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #988b95;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus-visible {
+  background: #f8e9ef;
+  color: #cf3e73;
+  outline: none;
+}
+
+button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(232, 79, 135, 0.28);
+}
+
+button svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.6;
+}
+
+.fr-dark {
+  border-color: rgba(242, 116, 162, 0.3);
+  background: rgba(38, 31, 39, 0.96);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.34), 0 2px 8px rgba(0, 0, 0, 0.2);
+  color: #f7edf1;
+}
+
+.fr-dark .fr-progress-indicator {
+  background: linear-gradient(145deg, #593043, #442635);
+  color: #ff80ae;
+}
+
+.fr-dark .fr-progress-copy strong {
+  color: #fff7fa;
+}
+
+.fr-dark .fr-progress-counts {
+  color: #d1c2c9;
+}
+
+.fr-dark .fr-progress-counts b {
+  color: #ff80ae;
+}
+
+.fr-dark .fr-progress-divider {
+  background: #5d4c55;
+}
+
+.fr-dark .fr-progress-copy small,
+.fr-dark button {
+  color: #bfaeb7;
+}
+
+.fr-dark button:hover,
+.fr-dark button:focus-visible {
+  background: #523242;
+  color: #ff91b8;
+}
+
+.fr-progress-panel-enter-active,
+.fr-progress-panel-leave-active {
+  transition: opacity 0.18s ease, transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.fr-progress-panel-enter-from,
+.fr-progress-panel-leave-to {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+}
+
+.fr-static .fr-progress-indicator i {
+  animation: none;
+}
+
+.fr-static.fr-progress-panel-enter-active,
+.fr-static.fr-progress-panel-leave-active {
+  transition: none;
+}
+
+@keyframes fr-progress-pulse {
+  from { transform: scaleY(0.5); opacity: 0.5; }
+  to { transform: scaleY(1); opacity: 1; }
+}
+
+@media (max-width: 420px) {
+  .fr-translation-progress {
+    right: max(10px, env(safe-area-inset-right));
+    bottom: max(10px, env(safe-area-inset-bottom));
+    width: min(270px, calc(100vw - 20px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fr-translation-progress,
+  .fr-progress-indicator i {
+    animation: none;
+    transition: none;
+  }
+}
+</style>

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -8,13 +8,17 @@ import {
 import { constants } from "@/entrypoints/utils/constant";
 import { getCenterPoint } from "@/entrypoints/utils/common";
 import pageStyles from './style.css?inline';
-import { config, configReady } from "@/entrypoints/utils/config";
+import { config, configReady, subscribeConfig } from "@/entrypoints/utils/config";
 import { mountFloatingBall, unmountFloatingBall } from "@/entrypoints/utils/floatingBall";
 import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoints/utils/selectionTranslator";
 import { mountAreaTranslator, unmountAreaTranslator } from "@/entrypoints/utils/areaTranslator";
 import { cancelAllTranslations } from "@/entrypoints/utils/translateApi";
 import { mountNewApiComponent, unmountNewApiComponent } from "@/entrypoints/utils/newApi";
 import { mountImageTranslator, unmountImageTranslator } from "@/entrypoints/utils/imageTranslation";
+import {
+    mountTranslationProgressPanel,
+    unmountTranslationProgressPanel,
+} from "@/entrypoints/utils/translationProgressPanel";
 import {
     getDeepActiveElement,
     getInputBoxText,
@@ -31,6 +35,7 @@ import {resetPageTranslationContextCache} from '@/entrypoints/utils/pageContext'
 let contentScriptContext: ContentScriptContext | null = null;
 let inputTooltipUi: ShadowRootContentScriptUi<HTMLElement> | null = null;
 let unmountVideoSubtitleTranslation: (() => void) | null = null;
+let unsubscribeTranslationProgressConfig: (() => void) | null = null;
 
 function installPageStyles(ctx: ContentScriptContext) {
     const existing = document.getElementById('fluent-read-page-styles');
@@ -109,6 +114,18 @@ function handleRuntimeMessage(
         return true;
     }
 
+    if (payload.type === 'toggleTranslationProgressPanel') {
+        const isEnabled = payload.isEnabled === true;
+        config.translationProgressPanelEnabled = isEnabled;
+        if (isEnabled) {
+            void mountTranslationProgressPanel(ctx);
+        } else {
+            unmountTranslationProgressPanel();
+        }
+        sendResponse();
+        return true;
+    }
+
     if (payload.type === 'contextMenuTranslate') {
         if (config.on === false) {
             sendResponse({ status: 'disabled' });
@@ -158,6 +175,9 @@ export default defineContentScript({
             unmountSelectionTranslator();
             unmountAreaTranslator();
             unmountImageTranslator();
+            unsubscribeTranslationProgressConfig?.();
+            unsubscribeTranslationProgressConfig = null;
+            unmountTranslationProgressPanel();
             unmountVideoSubtitleTranslation?.();
             unmountVideoSubtitleTranslation = null;
             unmountNewApiComponent();
@@ -176,6 +196,13 @@ export default defineContentScript({
             sendResponse: (response?: unknown) => void,
         ) => handleRuntimeMessage(message, ctx, sendResponse);
         browser.runtime.onMessage.addListener(runtimeMessageListener);
+        unsubscribeTranslationProgressConfig = subscribeConfig((nextConfig) => {
+            if (nextConfig.translationProgressPanelEnabled === true) {
+                void mountTranslationProgressPanel(ctx);
+            } else {
+                unmountTranslationProgressPanel();
+            }
+        });
         // 监听器始终注册并在触发时读取实时配置。这样扩展在当前页面由关闭
         // 切换为开启后，无需刷新页面就能恢复 Control/Alt+T。
         setupManualTranslationTriggers(pageEventController.signal);

--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -32,6 +32,11 @@ import {
     type TranslationQueueSession,
 } from "@/entrypoints/utils/translateQueue";
 import {
+    finishFullPageTranslationProgress,
+    startFullPageTranslationProgress,
+    updateFullPageTranslationProgress,
+} from "@/entrypoints/utils/fullPageTranslationProgress";
+import {
     appendBilingualTranslation,
 } from "@/entrypoints/main/translationRenderer";
 import {
@@ -99,6 +104,8 @@ interface LiveTextTranslationResult {
 interface FullPageSession {
     active: boolean;
     translationMode: FullPageTranslationMode;
+    progressSessionId: number;
+    progressPublishScheduled: boolean;
     observer: IntersectionObserver;
     mutationObserver: MutationObserver;
     shadowEventController: AbortController;
@@ -150,6 +157,30 @@ const FULL_PAGE_TRANSLATION_CACHE_LIMIT = 512;
 
 let hoverTimer: ReturnType<typeof setTimeout> | undefined;
 let fullPageSession: FullPageSession | null = null;
+
+function scheduleFullPageProgressPublish(session: FullPageSession): void {
+    if (!session.active || session.progressPublishScheduled) return;
+    session.progressPublishScheduled = true;
+    queueMicrotask(() => {
+        session.progressPublishScheduled = false;
+        if (!session.active || fullPageSession !== session) return;
+
+        const running = session.inFlightCandidates.size;
+        let runningScheduled = 0;
+        for (const [key, candidate] of session.inFlightCandidates) {
+            if (session.scheduled.get(key) === candidate) runningScheduled += 1;
+        }
+        // 同一个 key 的新候选可以在旧请求 settle 前替换 scheduled 所有权。
+        // 旧请求仍算进行中，但不能把新的待处理候选从 remaining 中扣掉。
+        const remaining = Math.max(0, session.scheduled.size - runningScheduled);
+        const queued = Math.min(session.pending.size, remaining);
+        updateFullPageTranslationProgress(session.progressSessionId, {
+            running,
+            queued,
+            offscreen: Math.max(0, remaining - queued),
+        });
+    });
+}
 
 function isElementNode(node: Node | null | undefined): node is Element {
     return Boolean(node && node.nodeType === 1 && typeof (node as Element).matches === "function");
@@ -818,6 +849,7 @@ function refreshCandidateVisibilityBinding(
         // subtree is being rebuilt. If it was still waiting on the old anchor,
         // direct scheduling is the only visibility-safe fallback.
         if (!session.pending.has(key)) session.pending.set(key, candidate);
+        scheduleFullPageProgressPublish(session);
         scheduleFullPageDrain(session);
         return;
     }
@@ -830,16 +862,21 @@ function refreshCandidateVisibilityBinding(
     observed.set(key, candidate);
     session.candidateAnchors.set(key, nextAnchor);
     session.observer.observe(nextAnchor);
+    scheduleFullPageProgressPublish(session);
 }
 
 function forgetCandidate(session: FullPageSession | undefined, candidate: TranslationCandidate): void {
     if (!session) return;
     const key = getTranslationCandidateKey(candidate);
-    if (session.pending.get(key) === candidate) session.pending.delete(key);
-    if (session.scheduled.get(key) !== candidate) return;
+    const removedPending = session.pending.get(key) === candidate && session.pending.delete(key);
+    if (session.scheduled.get(key) !== candidate) {
+        if (removedPending) scheduleFullPageProgressPublish(session);
+        return;
+    }
     session.scheduled.delete(key);
     removeCandidateObservation(session, key);
     removeCandidateOwnerKey(session, candidate.element, key);
+    scheduleFullPageProgressPublish(session);
 }
 
 async function translateTarget(
@@ -1157,10 +1194,14 @@ function drainFullPage(session: FullPageSession): void {
                 if (session.inFlightCandidates.get(key) === candidate) {
                     session.inFlightCandidates.delete(key);
                 }
-                if (session.active) scheduleFullPageDrain(session);
+                if (session.active) {
+                    scheduleFullPageProgressPublish(session);
+                    scheduleFullPageDrain(session);
+                }
             });
     }
     session.draining = false;
+    scheduleFullPageProgressPublish(session);
 }
 
 function scheduleDiscoveredCandidate(session: FullPageSession, candidate: TranslationCandidate): void {
@@ -1225,6 +1266,7 @@ function scheduleDiscoveredCandidate(session: FullPageSession, candidate: Transl
     session.scheduled.set(key, candidate);
     addCandidateOwnerKey(session, target, key);
     refreshCandidateVisibilityBinding(session, key, candidate);
+    scheduleFullPageProgressPublish(session);
 }
 
 function nodeContains(ancestor: Node, descendant: Node): boolean {
@@ -1844,6 +1886,7 @@ function createFullPageSession(root: HTMLElement): FullPageSession {
             const candidates = session.observedCandidates.get(node);
             candidates?.forEach((candidate, key) => session.pending.set(key, candidate));
         }
+        scheduleFullPageProgressPublish(session);
         scheduleFullPageDrain(session);
     }, {
         root: null,
@@ -1855,6 +1898,8 @@ function createFullPageSession(root: HTMLElement): FullPageSession {
     session = {
         active: true,
         translationMode: config.fullPageTranslationMode,
+        progressSessionId: startFullPageTranslationProgress(),
+        progressPublishScheduled: false,
         observer,
         mutationObserver,
         shadowEventController: new AbortController(),
@@ -1913,6 +1958,7 @@ function disposeFullPageSession(session: FullPageSession): void {
     session.pruneRequested = false;
     session.statefulAttributeTimers.clear();
     session.statefulAttributeRescanTargets = new WeakSet();
+    finishFullPageTranslationProgress(session.progressSessionId);
 }
 
 function stopFullPageSession(): void {

--- a/entrypoints/options/navigation.ts
+++ b/entrypoints/options/navigation.ts
@@ -76,7 +76,7 @@ export const navigationGroups: NavigationGroup[] = [
         id: 'settings-advanced', icon: '◇', label: '高级选项', description: '性能与模板', group: '系统与数据',
         heading: '精细控制运行方式', summary: '管理缓存、动画、并发、悬浮工具、代理和 AI 提示词。',
         kicker: '运行策略', title: '高级选项', detail: '这些设置更偏向性能、兼容性和高级翻译行为。',
-        searchDescription: '缓存、动画、并发、悬浮球、输入框、代理与提示词',
+        searchDescription: '缓存、动画、并发、显示翻译进度面板、悬浮球、输入框、代理与提示词',
       },
       {
         id: 'settings-data', icon: '⇅', label: '配置管理', description: '导入与导出', group: '系统与数据',

--- a/entrypoints/utils/fullPageTranslationProgress.ts
+++ b/entrypoints/utils/fullPageTranslationProgress.ts
@@ -1,0 +1,94 @@
+export interface FullPageTranslationProgress {
+  sessionId: number;
+  active: boolean;
+  running: number;
+  remaining: number;
+  queued: number;
+  offscreen: number;
+}
+
+type FullPageTranslationProgressListener = (progress: FullPageTranslationProgress) => void;
+
+const listeners = new Set<FullPageTranslationProgressListener>();
+let nextSessionId = 0;
+let progress: FullPageTranslationProgress = {
+  sessionId: 0,
+  active: false,
+  running: 0,
+  remaining: 0,
+  queued: 0,
+  offscreen: 0,
+};
+
+function cloneProgress(): FullPageTranslationProgress {
+  return {...progress};
+}
+
+function notifyProgressListeners(): void {
+  const snapshot = cloneProgress();
+  listeners.forEach((listener) => listener(snapshot));
+}
+
+function normalizeCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+export function startFullPageTranslationProgress(): number {
+  const sessionId = ++nextSessionId;
+  progress = {
+    sessionId,
+    active: true,
+    running: 0,
+    remaining: 0,
+    queued: 0,
+    offscreen: 0,
+  };
+  notifyProgressListeners();
+  return sessionId;
+}
+
+export function updateFullPageTranslationProgress(
+  sessionId: number,
+  value: Pick<FullPageTranslationProgress, 'running' | 'queued' | 'offscreen'>,
+): void {
+  if (!progress.active || progress.sessionId !== sessionId) return;
+
+  const running = normalizeCount(value.running);
+  const queued = normalizeCount(value.queued);
+  const offscreen = normalizeCount(value.offscreen);
+  const remaining = queued + offscreen;
+  if (
+    progress.running === running &&
+    progress.remaining === remaining &&
+    progress.queued === queued &&
+    progress.offscreen === offscreen
+  ) return;
+
+  progress = {...progress, running, remaining, queued, offscreen};
+  notifyProgressListeners();
+}
+
+export function finishFullPageTranslationProgress(sessionId: number): void {
+  if (!progress.active || progress.sessionId !== sessionId) return;
+  progress = {
+    sessionId,
+    active: false,
+    running: 0,
+    remaining: 0,
+    queued: 0,
+    offscreen: 0,
+  };
+  notifyProgressListeners();
+}
+
+export function getFullPageTranslationProgress(): FullPageTranslationProgress {
+  return cloneProgress();
+}
+
+export function subscribeFullPageTranslationProgress(
+  listener: FullPageTranslationProgressListener,
+): () => void {
+  listeners.add(listener);
+  listener(cloneProgress());
+  return () => listeners.delete(listener);
+}

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -101,6 +101,7 @@ export class Config {
     tencentSecretKey: string; // 腾讯云 Secret Key
     azureOpenaiEndpoint: string; // Azure OpenAI 端点地址
     animations: boolean; // 是否启用动画效果
+    translationProgressPanelEnabled: boolean; // 是否显示全文翻译进度面板
     inputBoxTranslationTrigger: string; // 输入框翻译触发方式
     inputBoxTranslationTarget: string; // 输入框翻译目标语言
     deepseekApiType: DeepSeekApiType; // DeepSeek API 格式
@@ -170,6 +171,7 @@ export class Config {
         this.tencentSecretKey = ''; // 腾讯云 Secret Key
         this.azureOpenaiEndpoint = ''; // Azure OpenAI 端点地址
         this.animations = true; // 默认启用动画
+        this.translationProgressPanelEnabled = true; // 默认显示全文翻译进度面板
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
         this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
@@ -257,6 +259,12 @@ export function normalizeConfig(value: unknown): Config {
         ? cloneConfigValue(value) as Partial<Config>
         : {};
     Object.assign(normalized, source);
+    const legacyTranslationStatus = (source as unknown as Record<string, unknown>).translationStatus;
+    if (typeof source.translationProgressPanelEnabled !== 'boolean') {
+        normalized.translationProgressPanelEnabled = typeof legacyTranslationStatus === 'boolean'
+            ? legacyTranslationStatus
+            : true;
+    }
     delete (normalized as unknown as Record<string, unknown>).translationStatus;
     // __fluentConfigRevision 只用于 storage 的写入顺序判断，不能进入运行时
     // 配置或历史快照，否则默认配置与同值的页面快照会因内部字段不同而无法去重。

--- a/entrypoints/utils/translationProgressPanel.ts
+++ b/entrypoints/utils/translationProgressPanel.ts
@@ -1,0 +1,60 @@
+import TranslationProgressPanel from '@/components/TranslationProgressPanel.vue';
+import { config } from '@/entrypoints/utils/config';
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
+import { createVueShadowUi, type VueShadowMount } from '@/entrypoints/utils/shadowUi';
+
+let progressPanelInstance: any = null;
+let progressPanelUi: ShadowRootContentScriptUi<VueShadowMount> | null = null;
+let mountingPromise: Promise<any> | null = null;
+let mountRequestId = 0;
+let contentScriptContext: ContentScriptContext | null = null;
+let mountRequested = false;
+
+export function mountTranslationProgressPanel(ctx?: ContentScriptContext) {
+  if (ctx) contentScriptContext = ctx;
+  mountRequested = config.translationProgressPanelEnabled === true;
+  if (progressPanelInstance || mountingPromise || !mountRequested) {
+    return mountingPromise;
+  }
+  if (!contentScriptContext) return;
+
+  const requestId = ++mountRequestId;
+  let retryAfterStaleMount = false;
+  mountingPromise = createVueShadowUi(contentScriptContext, {
+    name: 'fluent-read-translation-progress-ui',
+    // 保留旧版 host id，继续兼容既有 DOM 排除规则和自动化定位。
+    hostId: 'fluent-read-translation-status-container',
+    component: TranslationProgressPanel,
+    zIndex: 2_147_483_645,
+  }).then((ui) => {
+    if (requestId !== mountRequestId || config.translationProgressPanelEnabled !== true) {
+      retryAfterStaleMount = requestId !== mountRequestId;
+      ui.remove();
+      return null;
+    }
+    progressPanelUi = ui;
+    progressPanelInstance = ui.mounted?.instance ?? null;
+    return progressPanelInstance;
+  }).catch((error) => {
+    console.error('[FluentRead] 翻译进度面板挂载失败', error);
+    return null;
+  }).finally(() => {
+    mountingPromise = null;
+    // 设置页可能在 Shadow UI 首次挂载完成前快速关闭再开启。旧请求会按
+    // requestId 自行移除，这里补发用户最后一次明确保留的挂载请求。
+    if (retryAfterStaleMount && mountRequested && !progressPanelInstance) {
+      void mountTranslationProgressPanel();
+    }
+  });
+
+  return mountingPromise;
+}
+
+export function unmountTranslationProgressPanel(): void {
+  mountRequested = false;
+  mountRequestId += 1;
+  progressPanelUi?.remove();
+  progressPanelUi = null;
+  progressPanelInstance = null;
+}

--- a/tests/fullPageTranslationProgress.test.ts
+++ b/tests/fullPageTranslationProgress.test.ts
@@ -1,0 +1,94 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  finishFullPageTranslationProgress,
+  getFullPageTranslationProgress,
+  startFullPageTranslationProgress,
+  subscribeFullPageTranslationProgress,
+  updateFullPageTranslationProgress,
+} from '@/entrypoints/utils/fullPageTranslationProgress';
+
+afterEach(() => {
+  const current = getFullPageTranslationProgress();
+  if (current.active) finishFullPageTranslationProgress(current.sessionId);
+});
+
+describe('全文翻译进度', () => {
+  it('立即提供快照，并发布进行中、队列与离屏任务数量', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFullPageTranslationProgress(listener);
+    const sessionId = startFullPageTranslationProgress();
+
+    updateFullPageTranslationProgress(sessionId, {
+      running: 3,
+      queued: 4,
+      offscreen: 7,
+    });
+
+    expect(listener).toHaveBeenLastCalledWith({
+      sessionId,
+      active: true,
+      running: 3,
+      remaining: 11,
+      queued: 4,
+      offscreen: 7,
+    });
+    expect(getFullPageTranslationProgress()).toEqual(listener.mock.lastCall?.[0]);
+    unsubscribe();
+  });
+
+  it('忽略旧会话的迟到更新和结束通知', () => {
+    const staleSessionId = startFullPageTranslationProgress();
+    const currentSessionId = startFullPageTranslationProgress();
+
+    updateFullPageTranslationProgress(staleSessionId, {running: 99, queued: 99, offscreen: 99});
+    finishFullPageTranslationProgress(staleSessionId);
+
+    expect(getFullPageTranslationProgress()).toEqual({
+      sessionId: currentSessionId,
+      active: true,
+      running: 0,
+      remaining: 0,
+      queued: 0,
+      offscreen: 0,
+    });
+  });
+
+  it('结束当前会话时清零计数并通知订阅者', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFullPageTranslationProgress(listener);
+    const sessionId = startFullPageTranslationProgress();
+    updateFullPageTranslationProgress(sessionId, {running: 2, queued: 1, offscreen: 5});
+
+    finishFullPageTranslationProgress(sessionId);
+
+    expect(listener).toHaveBeenLastCalledWith({
+      sessionId,
+      active: false,
+      running: 0,
+      remaining: 0,
+      queued: 0,
+      offscreen: 0,
+    });
+    unsubscribe();
+  });
+
+  it('规范化异常计数，并对相同快照去重', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeFullPageTranslationProgress(listener);
+    const sessionId = startFullPageTranslationProgress();
+    listener.mockClear();
+
+    updateFullPageTranslationProgress(sessionId, {running: 2.9, queued: -1, offscreen: Number.NaN});
+    updateFullPageTranslationProgress(sessionId, {running: 2, queued: 0, offscreen: 0});
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+      running: 2,
+      remaining: 0,
+      queued: 0,
+      offscreen: 0,
+    }));
+    unsubscribe();
+  });
+});

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -148,6 +148,11 @@ import {
     restoreOriginalContent,
 } from "@/entrypoints/main/trans";
 import {getTranslationState} from "@/entrypoints/main/translationState";
+import {
+    getFullPageTranslationProgress,
+    subscribeFullPageTranslationProgress,
+    type FullPageTranslationProgress,
+} from "@/entrypoints/utils/fullPageTranslationProgress";
 
 class TestIntersectionObserver {
     static instances: TestIntersectionObserver[] = [];
@@ -593,6 +598,160 @@ describe("全文翻译可见性锚点", () => {
         expect(candidates.map((candidate) => candidate.textContent)).toEqual([
             "译:One", "译:Two", "译:Three", "译:Four",
         ]);
+    });
+
+    it("全文进度只把预取窗口内的等待候选计入 queued，并保留离屏 remaining", async () => {
+        document.body.innerHTML = ["One", "Two", "Three", "Four", "Five"]
+            .map((label, index) => `<p id="progress-candidate-${index}">${label}</p>`)
+            .join("");
+        const candidates = Array.from(document.querySelectorAll<HTMLElement>("p"));
+        candidates.forEach((candidate) => setLayoutBox(candidate, 400, 40));
+        runtime.candidates = candidates.map((element) => ({
+            element,
+            kind: "content" as const,
+            reason: "paragraph",
+        }));
+        const requests = candidates.map(() => deferred<string[]>());
+        let nextRequest = 0;
+        runtime.requests.mockImplementation(() => requests[nextRequest++]!.promise);
+
+        const snapshots: FullPageTranslationProgress[] = [];
+        const unsubscribe = subscribeFullPageTranslationProgress((progress) => {
+            snapshots.push(progress);
+        });
+        const expectCurrentProgress = (expected: Pick<
+            FullPageTranslationProgress,
+            "active" | "running" | "remaining" | "queued" | "offscreen"
+        >) => {
+            expect(getFullPageTranslationProgress()).toMatchObject(expected);
+            expect(snapshots.at(-1)).toMatchObject(expected);
+        };
+
+        try {
+            autoTranslateEnglishPage();
+            await vi.advanceTimersByTimeAsync(50);
+            await Promise.resolve();
+
+            expectCurrentProgress({
+                active: true,
+                running: 0,
+                remaining: 5,
+                queued: 0,
+                offscreen: 5,
+            });
+
+            const observer = TestIntersectionObserver.instances[0]!;
+            candidates.slice(0, 4).forEach((candidate) => observer.emit(candidate, true));
+            await vi.advanceTimersByTimeAsync(1);
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(runtime.requests).toHaveBeenCalledTimes(3);
+            expectCurrentProgress({
+                active: true,
+                running: 3,
+                remaining: 2,
+                queued: 1,
+                offscreen: 1,
+            });
+
+            requests[0]!.resolve(["译:One"]);
+            await vi.advanceTimersByTimeAsync(1);
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(runtime.requests).toHaveBeenCalledTimes(4);
+            expectCurrentProgress({
+                active: true,
+                running: 3,
+                remaining: 1,
+                queued: 0,
+                offscreen: 1,
+            });
+
+            observer.emit(candidates[4]!, true);
+            await vi.advanceTimersByTimeAsync(1);
+            await Promise.resolve();
+
+            expect(runtime.requests).toHaveBeenCalledTimes(4);
+            expectCurrentProgress({
+                active: true,
+                running: 3,
+                remaining: 1,
+                queued: 1,
+                offscreen: 0,
+            });
+
+            requests[1]!.resolve(["译:Two"]);
+            await vi.advanceTimersByTimeAsync(1);
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(runtime.requests).toHaveBeenCalledTimes(5);
+
+            requests[2]!.resolve(["译:Three"]);
+            requests[3]!.resolve(["译:Four"]);
+            requests[4]!.resolve(["译:Five"]);
+            await finishScheduledWork();
+
+            expect(candidates.map((candidate) => candidate.textContent)).toEqual([
+                "译:One", "译:Two", "译:Three", "译:Four", "译:Five",
+            ]);
+            expectCurrentProgress({
+                active: true,
+                running: 0,
+                remaining: 0,
+                queued: 0,
+                offscreen: 0,
+            });
+
+            restoreOriginalContent();
+            expectCurrentProgress({
+                active: false,
+                running: 0,
+                remaining: 0,
+                queued: 0,
+                offscreen: 0,
+            });
+        } finally {
+            unsubscribe();
+        }
+    });
+
+    it("立即翻译整页时把所有未启动候选计入 queued，不产生离屏计数", async () => {
+        runtime.config.fullPageTranslationMode = "all";
+        document.body.innerHTML = ["One", "Two", "Three", "Four", "Five"]
+            .map((label, index) => `<p id="all-progress-candidate-${index}">${label}</p>`)
+            .join("");
+        const candidates = Array.from(document.querySelectorAll<HTMLElement>("p"));
+        candidates.forEach((candidate) => setLayoutBox(candidate, 400, 40));
+        runtime.candidates = candidates.map((element) => ({
+            element,
+            kind: "content" as const,
+            reason: "paragraph",
+        }));
+        const requests = candidates.map(() => deferred<string[]>());
+        let nextRequest = 0;
+        runtime.requests.mockImplementation(() => requests[nextRequest++]!.promise);
+
+        autoTranslateEnglishPage();
+        await vi.advanceTimersByTimeAsync(51);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(3);
+        expect(TestIntersectionObserver.instances[0]!.observe).not.toHaveBeenCalled();
+        expect(getFullPageTranslationProgress()).toMatchObject({
+            active: true,
+            running: 3,
+            remaining: 2,
+            queued: 2,
+            offscreen: 0,
+        });
+
+        restoreOriginalContent();
+        requests.slice(0, 3).forEach((request, index) => request.resolve([`译:${candidates[index]!.textContent}`]));
+        await finishScheduledWork();
+        expect(getFullPageTranslationProgress()).toMatchObject({active: false});
     });
 
     it("不会把扩展生成的布局节点当成候选可见性锚点", async () => {

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -163,6 +163,26 @@ describe('全文翻译范围配置', () => {
     });
 });
 
+describe('翻译进度面板配置', () => {
+    it('默认开启，并严格保留布尔设置', () => {
+        expect(new Config().translationProgressPanelEnabled).toBe(true);
+        expect(normalizeConfig({}).translationProgressPanelEnabled).toBe(true);
+        expect(normalizeConfig({translationProgressPanelEnabled: true}).translationProgressPanelEnabled).toBe(true);
+        expect(normalizeConfig({translationProgressPanelEnabled: false}).translationProgressPanelEnabled).toBe(false);
+        expect(normalizeConfig({translationProgressPanelEnabled: 'false'}).translationProgressPanelEnabled).toBe(true);
+    });
+
+    it('迁移旧 translationStatus 布尔值并移除旧字段', () => {
+        const enabled = normalizeConfig({translationStatus: true});
+        const disabled = normalizeConfig({translationStatus: false});
+
+        expect(enabled.translationProgressPanelEnabled).toBe(true);
+        expect(disabled.translationProgressPanelEnabled).toBe(false);
+        expect((enabled as unknown as Record<string, unknown>).translationStatus).toBeUndefined();
+        expect((disabled as unknown as Record<string, unknown>).translationStatus).toBeUndefined();
+    });
+});
+
 describe('鼠标悬浮翻译延迟配置', () => {
     it('默认保留现有 50ms 行为，并归一化用户设置', () => {
         expect(new Config().mouseHoverTranslationDelay).toBe(DEFAULT_MOUSE_HOVER_TRANSLATION_DELAY);


### PR DESCRIPTION
## Summary

- restore a compact full-page translation progress panel backed by the active FullPageSession
- show running, remaining, queued, and offscreen counts for viewport and translate-all modes
- add a persisted advanced setting, legacy migration, current-session dismissal, automatic completion hiding, ARIA status, theme, and reduced-motion behavior
- cover progress state and scheduler integration with regression tests

## Validation

- pnpm test: 33 files, 421 tests passed
- pnpm compile
- pnpm build
- pnpm build:firefox
- git diff --check
- isolated screen-off Edge production fixture: viewport 3/2/1/1, translate-all 3/2/2/0, setting persistence, remount, auto-hide, animation toggle, ARIA, and zero console errors

## Known baseline

The standard extension UI full suite stops before feature assertions because its navigation assertion still requires 8 categories while the current options page has 9. The focused production Edge fixture passes.

Closes #322