### PR TITLE
style(popup): remove video subtitle card highlight

### DIFF
--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -284,11 +284,6 @@ footer button {
 .video-beta-banner > span:last-child { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
 .video-beta-banner small { color: var(--muted); font-size: 9px; }
 .video-feature-card .feature-icon.teal { font-size: 12px; letter-spacing: -.04em; }
-.video-feature-card.needs-enable {
-  border-color: rgba(239, 71, 118, .38);
-  background: linear-gradient(135deg, var(--surface), rgba(239, 71, 118, .06));
-  box-shadow: 0 6px 18px rgba(239, 71, 118, .08);
-}
 .video-feature-card.needs-enable small { color: var(--brand-strong); font-weight: 700; }
 .feature-card > i { width: 6px; height: 6px; }
 .feature-card > b { color: var(--muted); font-size: 18px; font-weight: 400; }


### PR DESCRIPTION
## Summary

- remove the pink border, gradient, and shadow from the disabled video subtitle shortcut card
- keep the red click-to-enable hint and existing behavior unchanged

## Validation

- pnpm compile
- pnpm test: 33 files, 421 tests passed
- pnpm build
- production Edge focused UI check: video card border/background/shadow match the standard shortcut card; 0 console errors
- full UI suite attempted; the harness stopped while activating its background popup message target after popup and persistence screenshots, before later assertions