### PR TITLE
fix: reveal translations inside line-clamped containers

### DIFF
--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -39,6 +39,7 @@ import {
 import {
     appendBilingualTranslation,
 } from "@/entrypoints/main/translationRenderer";
+import {ensureTranslationTruncationLayout} from "@/entrypoints/main/translationLayout";
 import {
     beginTranslation,
     detachFailedTranslationUi,
@@ -54,6 +55,7 @@ import {
     setRetryWrapper,
     setSpinner,
     setTextSlotsApplied,
+    isTranslationLayoutOverrideMutation,
     type TranslationState,
 } from "@/entrypoints/main/translationState";
 
@@ -1492,6 +1494,11 @@ function isOwnMutation(
     mutation: MutationRecord,
     loadingSyntheticChecks: WeakMap<TranslationState, boolean>,
 ): boolean {
+    const exactMutationElement = mutationTargetElement(mutation.target);
+    if (mutation.type === "attributes" && mutation.attributeName === "style" &&
+        exactMutationElement && isTranslationLayoutOverrideMutation(exactMutationElement as HTMLElement)) {
+        return true;
+    }
     // 不能用“位于任意插件节点内”作为判断：站点可能直接改写双语 wrapper
     // 的文本，必须让这类 mutation 进入 stale/retranslate 分支。加载/错误节点
     // 没有宿主正文，才可以直接视为插件自身变化。
@@ -1747,6 +1754,15 @@ function scheduleStatefulAttributeReevaluation(
         // pure class/style churn cheap while still detecting same-text label or
         // inline-link replacement. Live single/control slots are compared with
         // the values written by this generation rather than their old source.
+        const shouldReconcileBilingualLayout =
+            state.phase === "translated" &&
+            state.mode === "bilingual" &&
+            state.kind === "content" &&
+            state.bilingualContent?.isConnected;
+        if (shouldReconcileBilingualLayout && !ensureTranslationTruncationLayout(target)) {
+            restartStatefulTarget(session, target);
+            return;
+        }
         if (statefulSourceAndTextSlotsAreCurrent(target, state)) return;
         restartStatefulTarget(session, target);
     }, STATEFUL_ATTRIBUTE_DEBOUNCE_MS);

--- a/entrypoints/main/translationLayout.ts
+++ b/entrypoints/main/translationLayout.ts
@@ -1,0 +1,1 @@
+export {ensureTranslationTruncationLayout} from "@/entrypoints/main/translationState";

--- a/entrypoints/main/translationRenderer.ts
+++ b/entrypoints/main/translationRenderer.ts
@@ -1,6 +1,6 @@
 import { options } from "@/entrypoints/utils/option";
 import { config } from "@/entrypoints/utils/config";
-import {removeTranslationTruncation} from "@/entrypoints/translation-core/public";
+import {ensureTranslationTruncationLayout} from "@/entrypoints/main/translationLayout";
 
 /**
  * 译文允许保留的内联元素。
@@ -92,7 +92,7 @@ export function appendBilingualTranslation(node: HTMLElement, text: string): HTM
     // 当作可信 HTML 直接写回网页。
     const fragment = createSafeTranslationFragment(text);
     content.appendChild(fragment);
-    removeTranslationTruncation(node);
+    ensureTranslationTruncationLayout(node);
     node.appendChild(content);
     return content;
 }

--- a/entrypoints/main/translationState.ts
+++ b/entrypoints/main/translationState.ts
@@ -1,3 +1,9 @@
+import {
+    getComposedParent,
+    hasActiveTranslationLineClamp,
+    translationTruncationStyleOverrides,
+} from "@/entrypoints/translation-core/public";
+
 /**
  * 指定节点翻译的生命周期状态。
  *
@@ -8,6 +14,37 @@
 type TranslationDisplayMode = "bilingual" | "single";
 type TranslationPhase = "loading" | "translated" | "error";
 type TranslationTargetKind = "content" | "control";
+
+export interface TranslationLayoutStyleOverride {
+    property: string;
+    value: string;
+    priority: string;
+}
+
+interface TranslationLayoutPropertySnapshot {
+    property: string;
+    overrideValue: string;
+    overridePriority: string;
+    originalValue: string;
+    originalPriority: string;
+    appliedValue: string;
+    appliedPriority: string;
+}
+
+interface SharedTranslationLayoutOverride {
+    originalStyleAttribute: string | null;
+    renderedStyleAttribute: string | null;
+    properties: TranslationLayoutPropertySnapshot[];
+    owners: Set<WeakRef<HTMLElement>>;
+    canRestoreExactStyleAttribute: boolean;
+}
+
+type TranslationLayoutObserverRoot = Document | ShadowRoot;
+
+interface TranslationLayoutRootObserver {
+    observer: MutationObserver;
+    owners: Set<WeakRef<HTMLElement>>;
+}
 
 export interface TranslationState {
     mode: TranslationDisplayMode;
@@ -46,6 +83,12 @@ export interface TranslationState {
     retryWrapper?: HTMLElement;
     /** 双语 wrapper 最后一次由插件写入的 HTML，用于区分宿主重绘和插件自身 mutation。 */
     bilingualHTML?: string;
+    /** Candidate/ancestor nodes whose clipping styles are leased by this translation. */
+    layoutOverrideElements?: Set<HTMLElement>;
+    /** Bounded composed ancestors watched for newly activated line clamps or reparenting. */
+    layoutWatchElements?: Set<HTMLElement>;
+    /** Document/ShadowRoot observers retained while the bilingual layout lease is active. */
+    layoutObserverRoots?: Set<TranslationLayoutObserverRoot>;
 }
 
 interface TranslationAttempt {
@@ -56,8 +99,16 @@ interface TranslationAttempt {
 const states = new WeakMap<HTMLElement, TranslationState>();
 const activeNodeRefs = new Set<WeakRef<HTMLElement>>();
 const activeRefsByNode = new WeakMap<HTMLElement, WeakRef<HTMLElement>>();
-const ownersByIndexedNode = new WeakMap<Node, Set<HTMLElement>>();
+const ownersByIndexedNode = new WeakMap<Node, Set<WeakRef<HTMLElement>>>();
 const indexedNodesByOwner = new WeakMap<HTMLElement, Set<Node>>();
+const sharedLayoutOverrides = new WeakMap<HTMLElement, SharedTranslationLayoutOverride>();
+const layoutObserversByRoot = new WeakMap<TranslationLayoutObserverRoot, TranslationLayoutRootObserver>();
+const pendingLayoutRefreshes = new WeakMap<HTMLElement, {removedNodes: Set<Node>}>();
+const maxTranslationLayoutAncestorDepth = 16;
+
+function getStylePropertyPriority(style: CSSStyleDeclaration, property: string): string {
+    return typeof style.getPropertyPriority === "function" ? style.getPropertyPriority(property) : "";
+}
 
 function forEachActiveNode(callback: (node: HTMLElement, state: TranslationState) => void): void {
     for (const ref of activeNodeRefs) {
@@ -75,11 +126,13 @@ function forEachActiveNode(callback: (node: HTMLElement, state: TranslationState
     }
 }
 
-function trackActiveNode(node: HTMLElement): void {
-    if (activeRefsByNode.has(node)) return;
+function trackActiveNode(node: HTMLElement): WeakRef<HTMLElement> {
+    const existing = activeRefsByNode.get(node);
+    if (existing) return existing;
     const ref = new WeakRef(node);
     activeRefsByNode.set(node, ref);
     activeNodeRefs.add(ref);
+    return ref;
 }
 
 function clearOwnershipIndex(owner: HTMLElement): void {
@@ -88,7 +141,10 @@ function clearOwnershipIndex(owner: HTMLElement): void {
 
     indexedNodes.forEach((indexedNode) => {
         const owners = ownersByIndexedNode.get(indexedNode);
-        owners?.delete(owner);
+        owners?.forEach((ref) => {
+            const candidate = ref.deref();
+            if (!candidate || candidate === owner) owners.delete(ref);
+        });
         if (owners?.size === 0) ownersByIndexedNode.delete(indexedNode);
     });
     indexedNodesByOwner.delete(owner);
@@ -101,16 +157,19 @@ function refreshOwnershipIndex(owner: HTMLElement, state: TranslationState): voi
         ...(state.spinner ? [state.spinner] : []),
         ...(state.bilingualContent ? [state.bilingualContent] : []),
         ...(state.retryWrapper ? [state.retryWrapper] : []),
+        ...(state.layoutOverrideElements ?? []),
+        ...(state.layoutWatchElements ?? []),
     ]);
     indexedNodesByOwner.set(owner, indexedNodes);
+    const ownerRef = trackActiveNode(owner);
 
     indexedNodes.forEach((indexedNode) => {
         let owners = ownersByIndexedNode.get(indexedNode);
         if (!owners) {
-            owners = new Set<HTMLElement>();
+            owners = new Set<WeakRef<HTMLElement>>();
             ownersByIndexedNode.set(indexedNode, owners);
         }
-        owners.add(owner);
+        owners.add(ownerRef);
     });
 }
 
@@ -281,6 +340,359 @@ export function setRenderedStyleAttribute(node: HTMLElement): void {
     }
 }
 
+function getStylePropertyValue(style: CSSStyleDeclaration, property: string): string {
+    return style.getPropertyValue(property) ?? "";
+}
+
+function scheduleTranslationLayoutRefresh(owner: HTMLElement, removedNodes: readonly Node[] = []): void {
+    let pending = pendingLayoutRefreshes.get(owner);
+    if (pending) {
+        removedNodes.forEach((node) => pending?.removedNodes.add(node));
+        return;
+    }
+
+    pending = {removedNodes: new Set(removedNodes)};
+    pendingLayoutRefreshes.set(owner, pending);
+    const flush = () => {
+        if (pendingLayoutRefreshes.get(owner) !== pending) return;
+        pendingLayoutRefreshes.delete(owner);
+        const state = states.get(owner);
+        if (!state) return;
+
+        // Run after every MutationObserver callback from this checkpoint. The
+        // full-page observer can therefore unregister its own indexes before a
+        // standalone hover translation tears down shared state.
+        if (!owner.isConnected) {
+            discardTranslation(owner, state);
+            return;
+        }
+
+        const expectedArtifact = state.phase === "translated" && state.mode === "bilingual"
+            ? state.bilingualContent
+            : state.phase === "loading"
+                ? state.spinner
+                : state.phase === "error"
+                    ? state.retryWrapper
+                    : undefined;
+        if (expectedArtifact && expectedArtifact.parentNode !== owner) {
+            restoreTranslation(owner);
+            return;
+        }
+
+        if (state.phase === "translated" && state.mode === "bilingual" &&
+            state.kind === "content" && state.bilingualContent?.parentNode === owner &&
+            !ensureTranslationTruncationLayout(owner)) {
+            restoreTranslation(owner);
+        }
+    };
+    const enqueue = globalThis.queueMicrotask ?? ((callback: VoidFunction) => Promise.resolve().then(callback));
+    enqueue(flush);
+}
+
+function createTranslationLayoutRootObserver(root: TranslationLayoutObserverRoot): TranslationLayoutRootObserver | undefined {
+    const document = root.nodeType === 9 ? root as Document : (root as ShadowRoot).ownerDocument;
+    const Observer = document.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+    const target = root.nodeType === 9 ? (root as Document).documentElement : root;
+    if (typeof Observer !== "function" || !target) return undefined;
+
+    const observer = new Observer((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.type === "childList") {
+                mutation.removedNodes.forEach((removed) => {
+                    getTranslationOwnersForRemovedNode(removed)
+                        .forEach((owner) => scheduleTranslationLayoutRefresh(owner, [removed]));
+                });
+                return;
+            }
+            if (mutation.type !== "attributes" ||
+                (mutation.attributeName !== "style" && mutation.attributeName !== "class") ||
+                mutation.target.nodeType !== 1) return;
+
+            const element = mutation.target as HTMLElement;
+            const override = sharedLayoutOverrides.get(element);
+            if (mutation.attributeName === "style" && override &&
+                element.getAttribute("style") === override.renderedStyleAttribute) return;
+
+            getTranslationOwnersForIndexedNode(element).forEach((owner) => {
+                const state = states.get(owner);
+                if (state && (element === owner || state.layoutWatchElements?.has(element))) {
+                    scheduleTranslationLayoutRefresh(owner);
+                }
+            });
+        });
+    });
+    observer.observe(target, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["style", "class"],
+    });
+    return {observer, owners: new Set()};
+}
+
+function retainTranslationLayoutRoot(owner: HTMLElement, root: TranslationLayoutObserverRoot): void {
+    let observerState = layoutObserversByRoot.get(root);
+    if (!observerState) {
+        observerState = createTranslationLayoutRootObserver(root);
+        if (!observerState) return;
+        layoutObserversByRoot.set(root, observerState);
+    }
+    observerState.owners.add(trackActiveNode(owner));
+}
+
+function releaseTranslationLayoutRoot(owner: HTMLElement, root: TranslationLayoutObserverRoot): void {
+    const observerState = layoutObserversByRoot.get(root);
+    if (!observerState) return;
+    observerState.owners.forEach((ref) => {
+        const candidate = ref.deref();
+        if (!candidate || candidate === owner || !states.has(candidate)) observerState?.owners.delete(ref);
+    });
+    if (observerState.owners.size > 0) return;
+    observerState.observer.disconnect();
+    layoutObserversByRoot.delete(root);
+}
+
+function restoreSharedTranslationLayoutOverride(
+    element: HTMLElement,
+    override: SharedTranslationLayoutOverride,
+): void {
+    if (override.canRestoreExactStyleAttribute &&
+        element.getAttribute("style") === override.renderedStyleAttribute) {
+        if (override.originalStyleAttribute === null) element.removeAttribute("style");
+        else element.setAttribute("style", override.originalStyleAttribute);
+    } else {
+        override.properties.forEach((property) => {
+            const currentValue = getStylePropertyValue(element.style, property.property);
+            const currentPriority = getStylePropertyPriority(element.style, property.property);
+            if (currentValue !== property.appliedValue || currentPriority !== property.appliedPriority) return;
+            if (property.originalValue) {
+                element.style.setProperty(
+                    property.property,
+                    property.originalValue,
+                    property.originalPriority,
+                );
+            } else {
+                element.style.removeProperty(property.property);
+            }
+        });
+        if (override.originalStyleAttribute === null && element.getAttribute("style") === "") {
+            element.removeAttribute("style");
+        }
+    }
+    sharedLayoutOverrides.delete(element);
+}
+
+function liveSharedTranslationLayoutOverride(
+    element: HTMLElement,
+): SharedTranslationLayoutOverride | undefined {
+    let override = sharedLayoutOverrides.get(element);
+    if (!override) return undefined;
+    const disconnectedOwners: HTMLElement[] = [];
+    override.owners.forEach((ref) => {
+        const owner = ref.deref();
+        if (!owner || !states.has(owner)) override?.owners.delete(ref);
+        else if (!owner.isConnected) disconnectedOwners.push(owner);
+    });
+    disconnectedOwners.forEach((owner) => {
+        const state = states.get(owner);
+        if (state) discardTranslation(owner, state);
+    });
+    override = sharedLayoutOverrides.get(element);
+    if (!override) return undefined;
+    if (override.owners.size > 0) return override;
+    restoreSharedTranslationLayoutOverride(element, override);
+    return undefined;
+}
+
+export function hasTranslationLayoutOverride(element: HTMLElement): boolean {
+    return liveSharedTranslationLayoutOverride(element) !== undefined;
+}
+
+function translationLayoutAncestorChain(owner: HTMLElement): HTMLElement[] {
+    const ancestors: HTMLElement[] = [];
+    let current = getComposedParent(owner);
+    let depth = 0;
+    while (current && current !== owner.ownerDocument.body && depth < maxTranslationLayoutAncestorDepth) {
+        depth += 1;
+        const HTMLElementConstructor = current.ownerDocument.defaultView?.HTMLElement;
+        if (HTMLElementConstructor && current instanceof HTMLElementConstructor) {
+            ancestors.push(current as HTMLElement);
+        }
+        current = getComposedParent(current);
+    }
+    return ancestors;
+}
+
+function translationLayoutObserverRoots(
+    owner: HTMLElement,
+    watchElements: ReadonlySet<HTMLElement>,
+): Set<TranslationLayoutObserverRoot> {
+    const roots = new Set<TranslationLayoutObserverRoot>();
+    for (const element of [owner, ...watchElements]) {
+        const root = element.getRootNode();
+        if (root.nodeType === 9) roots.add(root as Document);
+        else if (root.nodeType === 11 && "host" in root) roots.add(root as ShadowRoot);
+    }
+    return roots;
+}
+
+function updateTranslationLayoutObservers(
+    owner: HTMLElement,
+    state: TranslationState,
+    watchElements: ReadonlySet<HTMLElement>,
+): void {
+    const previousRoots = state.layoutObserverRoots ?? new Set<TranslationLayoutObserverRoot>();
+    const nextRoots = translationLayoutObserverRoots(owner, watchElements);
+    previousRoots.forEach((root) => {
+        if (!nextRoots.has(root)) releaseTranslationLayoutRoot(owner, root);
+    });
+    nextRoots.forEach((root) => {
+        if (!previousRoots.has(root)) retainTranslationLayoutRoot(owner, root);
+    });
+    state.layoutObserverRoots = nextRoots;
+}
+
+function releaseTranslationLayoutOverride(
+    owner: HTMLElement,
+    state: TranslationState,
+    element: HTMLElement,
+): void {
+    const override = sharedLayoutOverrides.get(element);
+    const ownerRef = activeRefsByNode.get(owner);
+    if (override && ownerRef) override.owners.delete(ownerRef);
+    override?.owners.forEach((ref) => {
+        const candidate = ref.deref();
+        if (!candidate || !states.has(candidate)) override.owners.delete(ref);
+    });
+    if (override?.owners.size === 0) restoreSharedTranslationLayoutOverride(element, override);
+    state.layoutOverrideElements?.delete(element);
+}
+
+/**
+ * Lease one host element's truncation properties. The first owner records and
+ * applies the override; later owners share it so restoring one paragraph
+ * cannot hide a translated sibling that uses the same clamp container.
+ */
+export function acquireTranslationLayoutOverride(
+    owner: HTMLElement,
+    element: HTMLElement,
+    overrides: readonly TranslationLayoutStyleOverride[],
+): boolean {
+    const state = states.get(owner);
+    if (!state) return false;
+    const ownerRef = trackActiveNode(owner);
+
+    const existing = liveSharedTranslationLayoutOverride(element);
+    if (existing) {
+        existing.owners.add(ownerRef);
+        (state.layoutOverrideElements ??= new Set()).add(element);
+        refreshOwnershipIndex(owner, state);
+        return true;
+    }
+
+    const originalStyleAttribute = element.getAttribute("style");
+    const properties = overrides.map(({property, value, priority}) => {
+        const originalValue = getStylePropertyValue(element.style, property);
+        const originalPriority = getStylePropertyPriority(element.style, property);
+        element.style.setProperty(property, value, priority);
+        return {
+            property,
+            overrideValue: value,
+            overridePriority: priority,
+            originalValue,
+            originalPriority,
+            appliedValue: getStylePropertyValue(element.style, property),
+            appliedPriority: getStylePropertyPriority(element.style, property),
+        };
+    });
+    const override: SharedTranslationLayoutOverride = {
+        originalStyleAttribute,
+        renderedStyleAttribute: element.getAttribute("style"),
+        properties,
+        owners: new Set([ownerRef]),
+        canRestoreExactStyleAttribute: true,
+    };
+    sharedLayoutOverrides.set(element, override);
+    (state.layoutOverrideElements ??= new Set()).add(element);
+    refreshOwnershipIndex(owner, state);
+    return true;
+}
+
+/** Exact style-attribute equality keeps a host write in the same microtask authoritative. */
+export function isTranslationLayoutOverrideMutation(element: HTMLElement): boolean {
+    const override = sharedLayoutOverrides.get(element);
+    return Boolean(override && element.getAttribute("style") === override.renderedStyleAttribute);
+}
+
+/** Rebase host style writes, then keep every active bilingual wrapper unclamped. */
+export function reconcileTranslationLayoutOverrides(owner: HTMLElement): boolean {
+    const state = states.get(owner);
+    if (!state) return false;
+    for (const element of state.layoutOverrideElements ?? []) {
+        const override = liveSharedTranslationLayoutOverride(element);
+        if (!override) continue;
+        if (!element.isConnected || (element !== owner &&
+            !state.layoutWatchElements?.has(element) && !element.contains(owner))) return false;
+
+        if (element.getAttribute("style") !== override.renderedStyleAttribute) {
+            override.canRestoreExactStyleAttribute = false;
+        }
+        override.properties.forEach((property) => {
+            const currentValue = getStylePropertyValue(element.style, property.property);
+            const currentPriority = getStylePropertyPriority(element.style, property.property);
+            if (currentValue === property.appliedValue && currentPriority === property.appliedPriority) return;
+            property.originalValue = currentValue;
+            property.originalPriority = currentPriority;
+            element.style.setProperty(
+                property.property,
+                property.overrideValue,
+                property.overridePriority,
+            );
+            property.appliedValue = getStylePropertyValue(element.style, property.property);
+            property.appliedPriority = getStylePropertyPriority(element.style, property.property);
+        });
+        override.renderedStyleAttribute = element.getAttribute("style");
+    }
+    return true;
+}
+
+/** Discover new clamp ancestors, drop stale reparented leases, and reapply host-overwritten values. */
+export function ensureTranslationTruncationLayout(owner: HTMLElement): boolean {
+    const state = states.get(owner);
+    if (!state || !owner.isConnected) return false;
+
+    const ancestors = translationLayoutAncestorChain(owner);
+    const watchElements = new Set(ancestors);
+    state.layoutWatchElements = watchElements;
+    refreshOwnershipIndex(owner, state);
+    updateTranslationLayoutObservers(owner, state, watchElements);
+
+    const desiredElements = new Set<HTMLElement>([owner]);
+    ancestors.forEach((ancestor) => {
+        if (sharedLayoutOverrides.has(ancestor) || hasActiveTranslationLineClamp(ancestor)) {
+            desiredElements.add(ancestor);
+        }
+    });
+
+    for (const element of Array.from(state.layoutOverrideElements ?? [])) {
+        if (!desiredElements.has(element)) releaseTranslationLayoutOverride(owner, state, element);
+    }
+    desiredElements.forEach((element) => {
+        acquireTranslationLayoutOverride(owner, element, translationTruncationStyleOverrides);
+    });
+    refreshOwnershipIndex(owner, state);
+    return reconcileTranslationLayoutOverrides(owner);
+}
+
+function releaseTranslationLayoutOverrides(owner: HTMLElement, state: TranslationState): void {
+    state.layoutObserverRoots?.forEach((root) => releaseTranslationLayoutRoot(owner, root));
+    state.layoutObserverRoots?.clear();
+    Array.from(state.layoutOverrideElements ?? [])
+        .forEach((element) => releaseTranslationLayoutOverride(owner, state, element));
+    state.layoutOverrideElements?.clear();
+    state.layoutWatchElements?.clear();
+}
+
 function removeExtensionNode(node: Node | undefined): void {
     if (node?.parentNode) node.parentNode.removeChild(node);
 }
@@ -365,6 +777,7 @@ function teardownAttempt(
     removeExtensionNode(state.spinner);
     removeExtensionNode(state.bilingualContent);
     removeRetryArtifacts(node);
+    releaseTranslationLayoutOverrides(node, state);
 
     if (restoreTextSlots && state.textSlotsApplied) {
         state.originalTextValues.forEach(({node: textNode, value}) => {
@@ -413,9 +826,7 @@ export function getTranslationOwnersForRemovedNode(removed: Node): HTMLElement[]
         const current = stack.pop();
         if (!current) continue;
 
-        ownersByIndexedNode.get(current)?.forEach((owner) => {
-            if (states.has(owner)) owners.add(owner);
-        });
+        getTranslationOwnersForIndexedNode(current).forEach((owner) => owners.add(owner));
 
         if (current.nodeType === 1) {
             const shadowRoot = (current as Element).shadowRoot;
@@ -428,6 +839,20 @@ export function getTranslationOwnersForRemovedNode(removed: Node): HTMLElement[]
         }
     }
 
+    return [...owners];
+}
+
+/** Resolve only owners indexed directly on this node; dead weak references are pruned lazily. */
+export function getTranslationOwnersForIndexedNode(indexedNode: Node): HTMLElement[] {
+    const refs = ownersByIndexedNode.get(indexedNode);
+    if (!refs) return [];
+    const owners = new Set<HTMLElement>();
+    refs.forEach((ref) => {
+        const owner = ref.deref();
+        if (!owner || !states.has(owner)) refs.delete(ref);
+        else owners.add(owner);
+    });
+    if (refs.size === 0) ownersByIndexedNode.delete(indexedNode);
     return [...owners];
 }
 

--- a/entrypoints/translation-core/public.ts
+++ b/entrypoints/translation-core/public.ts
@@ -31,13 +31,17 @@ export {
     applyTranslationsToSnapshot,
     collectLiveTranslationTextSlots,
     createTranslationSourceSnapshot,
+    findTranslationTruncationAncestors,
+    hasActiveTranslationLineClamp,
     parseTranslationSlots,
     removeTranslationTruncation,
     serializeTranslationSlots,
+    translationTruncationStyleOverrides,
 } from './serialization';
 export type {
     SerializedTranslationSlots,
     TranslationSourceSnapshot,
+    TranslationStyleOverride,
     TranslationTextSlot,
 } from './serialization';
 export {createDeclarativeAdapter} from './adapters/declarative';

--- a/entrypoints/translation-core/serialization.ts
+++ b/entrypoints/translation-core/serialization.ts
@@ -25,6 +25,20 @@ export interface SerializedTranslationSlots {
     ends: readonly string[];
 }
 
+export interface TranslationStyleOverride {
+    property: string;
+    value: string;
+    priority: string;
+}
+
+export const translationTruncationStyleOverrides: readonly TranslationStyleOverride[] = [
+    {property: '-webkit-line-clamp', value: 'unset', priority: 'important'},
+    {property: 'line-clamp', value: 'unset', priority: 'important'},
+    {property: 'max-height', value: 'unset', priority: 'important'},
+];
+
+const maxTranslationTruncationAncestorDepth = 16;
+
 function hashSlotSources(sources: readonly string[]): string {
     let hash = 2166136261;
     for (const source of sources) {
@@ -188,13 +202,51 @@ export function applyTranslationsToSnapshot(
     return snapshot.clone.innerHTML;
 }
 
-function clearStyleProperty(node: HTMLElement, property: string): void {
-    const style = node.style as unknown as Record<string, string | undefined>;
-    if (style[property] !== undefined) style[property] = '';
+function isActiveLineClampValue(value: string): boolean {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || ['none', 'normal', 'auto', 'unset', 'initial'].includes(normalized)) return false;
+    const lineCount = Number.parseFloat(normalized);
+    return Number.isFinite(lineCount) && lineCount > 0;
+}
+
+export function hasActiveTranslationLineClamp(element: HTMLElement): boolean {
+    try {
+        const style = element.ownerDocument?.defaultView?.getComputedStyle(element);
+        if (!style) return false;
+        return [
+            style.webkitLineClamp,
+            style.getPropertyValue('-webkit-line-clamp'),
+            style.getPropertyValue('line-clamp'),
+        ].some(isActiveLineClampValue);
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * A translated paragraph can sit inside a separate line-clamp wrapper. Walk a
+ * small, bounded ancestor chain so rendering can temporarily lease every
+ * active clipping container without turning candidate discovery into a style
+ * mutation. Existing leases are included for sibling candidates that share
+ * one clamp container after the first translation has already unset it.
+ */
+export function findTranslationTruncationAncestors(
+    node: HTMLElement,
+    hasExistingOverride: (element: HTMLElement) => boolean = () => false,
+): HTMLElement[] {
+    const result: HTMLElement[] = [];
+    let current = node.parentElement;
+    let depth = 0;
+    while (current && current !== node.ownerDocument?.body && depth < maxTranslationTruncationAncestorDepth) {
+        depth += 1;
+        if (hasExistingOverride(current) || hasActiveTranslationLineClamp(current)) result.push(current);
+        current = current.parentElement;
+    }
+    return result;
 }
 
 export function removeTranslationTruncation(node: HTMLElement): void {
-    clearStyleProperty(node, 'webkitLineClamp');
-    node.style.webkitLineClamp = 'unset';
-    node.style.maxHeight = 'unset';
+    translationTruncationStyleOverrides.forEach(({property, value, priority}) => {
+        node.style.setProperty(property, value, priority);
+    });
 }

--- a/scripts/run-full-page-translation-test.cjs
+++ b/scripts/run-full-page-translation-test.cjs
@@ -137,7 +137,7 @@ async function readShortcutDiagnostics(page) {
       save: document.querySelector('#save-button')?.textContent?.trim() || '',
       cancel: document.querySelector('#cancel-button')?.textContent?.trim() || '',
     },
-    targetStates: ['#paragraph-one', '#paragraph-two', '#save-button', '#cancel-button']
+    targetStates: ['#paragraph-one', '#paragraph-two', '#model-description', '#save-button', '#cancel-button']
       .map((selector) => ({
         selector,
         bilingual: document.querySelector(selector)?.querySelectorAll('.fluent-read-bilingual-content').length || 0,
@@ -154,6 +154,24 @@ async function pageState(page) {
   return page.evaluate(() => {
     const get = (selector) => document.querySelector(selector);
     const count = (selector) => get(selector)?.querySelectorAll('.fluent-read-bilingual-content').length || 0;
+    const clampState = (clampSelector, targetSelector) => {
+      const clamp = get(clampSelector);
+      const target = get(targetSelector);
+      const wrapper = target?.querySelector('.fluent-read-bilingual-content');
+      if (!clamp || !target) return null;
+      const clampRect = clamp.getBoundingClientRect();
+      const wrapperRect = wrapper?.getBoundingClientRect();
+      return {
+        bilingual: target.querySelectorAll('.fluent-read-bilingual-content').length,
+        lineClamp: getComputedStyle(clamp).webkitLineClamp,
+        inlineStyle: clamp.getAttribute('style'),
+        clientHeight: clamp.clientHeight,
+        scrollHeight: clamp.scrollHeight,
+        wrapperVisible: Boolean(wrapperRect && wrapperRect.width > 0 && wrapperRect.height > 0 &&
+          wrapperRect.top >= clampRect.top - 1 && wrapperRect.bottom <= clampRect.bottom + 1),
+        translationText: wrapper?.textContent?.trim() || '',
+      };
+    };
     const shadowParagraph = get('#shadow-host')?.shadowRoot?.querySelector('#shadow-paragraph');
     const button = get('#save-button');
     const cancelButton = get('#cancel-button');
@@ -163,6 +181,8 @@ async function pageState(page) {
       paragraphTwoText: get('#paragraph-two')?.textContent?.trim() || '',
       heading: count('h1'),
       dynamic: count('#dynamic-paragraph'),
+      staticClamp: clampState('#model-description-clamp', '#model-description'),
+      dynamicClamp: clampState('#dynamic-model-description-clamp', '#dynamic-paragraph'),
       shadow: shadowParagraph?.querySelectorAll('.fluent-read-bilingual-content').length || 0,
       header: count('header'),
       nav: count('nav'),
@@ -185,6 +205,13 @@ function assertTranslated(state, label) {
   if (!state.paragraphTwoText.includes('changed after full-page translation')) {
     throw new Error(`${label} 没有响应宿主页面的动态文本更新：${JSON.stringify(state)}`);
   }
+  for (const [name, clamp] of [['static', state.staticClamp], ['dynamic', state.dynamicClamp]]) {
+    if (!clamp || clamp.bilingual !== 1 || !clamp.wrapperVisible ||
+        !/[\u3400-\u9fff]/u.test(clamp.translationText) ||
+        !['none', 'unset'].includes(clamp.lineClamp)) {
+      throw new Error(`${label} ${name} line-clamp 译文仍被裁剪：${JSON.stringify(clamp)}`);
+    }
+  }
   if (state.header !== 0 || state.nav !== 0 || state.footer !== 0) throw new Error(`${label} 导航/页脚被误翻译`);
   if (state.buttonBilingualCount !== 0 || state.cancelButtonBilingualCount !== 0 ||
       !/[\u3400-\u9fff]/u.test(state.buttonText) || !/[\u3400-\u9fff]/u.test(state.cancelButtonText) ||
@@ -202,6 +229,11 @@ function assertRestored(state) {
   }
   if (!state.paragraphTwoText.includes('changed after full-page translation')) {
     throw new Error(`全文恢复覆盖了宿主页面更新：${JSON.stringify(state)}`);
+  }
+  for (const [name, clamp] of [['static', state.staticClamp], ['dynamic', state.dynamicClamp]]) {
+    if (!clamp || clamp.bilingual !== 0 || clamp.lineClamp !== '2' || clamp.inlineStyle !== null) {
+      throw new Error(`全文恢复后 ${name} line-clamp 样式没有精确还原：${JSON.stringify(clamp)}`);
+    }
   }
   if (state.buttonText !== '★Save changes' || state.cancelButtonText !== 'Cancel' ||
       !state.buttonIconPresent || state.buttonBilingualCount !== 0 || state.cancelButtonBilingualCount !== 0) {
@@ -271,10 +303,25 @@ async function main() {
     if (configResult.config?.service !== args.service) throw new Error(`翻译服务不符：预期 ${args.service}，实际 ${configResult.config?.service}`);
     await page.bringToFront();
 
+    const initialClamp = await page.evaluate(() => {
+      const clamp = document.querySelector('#model-description-clamp');
+      return clamp ? {
+        lineClamp: getComputedStyle(clamp).webkitLineClamp,
+        clientHeight: clamp.clientHeight,
+        scrollHeight: clamp.scrollHeight,
+        inlineStyle: clamp.getAttribute('style'),
+      } : null;
+    });
+    if (!initialClamp || initialClamp.lineClamp !== '2' || initialClamp.inlineStyle !== null ||
+        initialClamp.scrollHeight <= initialClamp.clientHeight) {
+      throw new Error(`line-clamp fixture 初始状态无效：${JSON.stringify(initialClamp)}`);
+    }
+
     await installShortcutDiagnostics(page);
     await toggleFullPage(page);
     try {
       await waitFor(page, () => document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
+        document.querySelector('#model-description .fluent-read-bilingual-content') &&
         document.querySelector('#shadow-host')?.shadowRoot?.querySelector('#shadow-paragraph .fluent-read-bilingual-content') &&
         /[\u3400-\u9fff]/u.test(document.querySelector('#save-button')?.textContent || '') &&
         /[\u3400-\u9fff]/u.test(document.querySelector('#cancel-button')?.textContent || ''), args.timeout);
@@ -286,10 +333,14 @@ async function main() {
     // 在会话已经启动后再插入节点，确认 MutationObserver 能把新内容纳入全文队列。
     await page.evaluate(() => {
       const container = document.querySelector('#dynamic-container');
+      const clamp = document.createElement('div');
+      clamp.id = 'dynamic-model-description-clamp';
+      clamp.className = 'model-description-clamp';
       const paragraph = document.createElement('p');
       paragraph.id = 'dynamic-paragraph';
-      paragraph.textContent = 'This paragraph is inserted after the full page session starts.';
-      container.appendChild(paragraph);
+      paragraph.textContent = 'This virtualized model description is inserted after the full page session starts. Its translated text must expand the newly mounted two-line clamp instead of remaining hidden beneath the source content.';
+      clamp.appendChild(paragraph);
+      container.appendChild(clamp);
     });
     await waitFor(page, () => document.querySelector('#dynamic-paragraph .fluent-read-bilingual-content'), args.timeout);
 
@@ -315,6 +366,7 @@ async function main() {
 
     await toggleFullPage(page);
     await waitFor(page, () => document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
+      document.querySelector('#model-description .fluent-read-bilingual-content') &&
       document.querySelector('#dynamic-paragraph .fluent-read-bilingual-content') &&
       document.querySelector('#shadow-host')?.shadowRoot?.querySelector('#shadow-paragraph .fluent-read-bilingual-content') &&
       /[\u3400-\u9fff]/u.test(document.querySelector('#save-button')?.textContent || '') &&

--- a/tests/fixtures/unified-translation-fixture.html
+++ b/tests/fixtures/unified-translation-fixture.html
@@ -9,6 +9,14 @@
     .toolbar { display: flex; gap: 8px; }
     button { padding: 6px 12px; }
     code { font-family: monospace; }
+    .model-description-clamp {
+      display: -webkit-box;
+      width: 320px;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
+    .model-description-clamp p { margin: 0; }
   </style>
 </head>
 <body>
@@ -21,6 +29,13 @@
       and <code>const value = 42</code> that should remain inside the translated block.
     </p>
     <p id="paragraph-two">The second paragraph is a neighbor and must be translated exactly once.</p>
+    <div id="model-description-clamp" class="model-description-clamp">
+      <div class="model-description-prose">
+        <p id="model-description">
+          This model description reproduces a card whose outer wrapper shows only two lines of source text. The bilingual translation is appended after the complete description and must remain geometrically visible instead of being clipped below the original text.
+        </p>
+      </div>
+    </div>
     <div class="toolbar">
       <button id="save-button"><span aria-hidden="true">★</span><span>Save changes</span></button>
       <button id="cancel-button">Cancel</button>

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -14,6 +14,7 @@ const runtime = vi.hoisted(() => ({
     ),
     retryCallbacks: [] as Array<() => void>,
     config: {service: "microsoft", display: 0, to: "zh", fullPageTranslationMode: "viewport" as "viewport" | "all"},
+    ensureTranslationTruncationLayout: vi.fn(() => true),
 }));
 
 vi.mock("@/entrypoints/utils/check", () => ({checkConfig: () => true}));
@@ -56,6 +57,9 @@ vi.mock("@/entrypoints/main/translationRenderer", () => ({
         node.appendChild(wrapper);
         return wrapper;
     },
+}));
+vi.mock("@/entrypoints/main/translationLayout", () => ({
+    ensureTranslationTruncationLayout: runtime.ensureTranslationTruncationLayout,
 }));
 vi.mock("@/entrypoints/translation-core/public", () => {
     const protectedSelector = [
@@ -229,6 +233,7 @@ describe("全文翻译可见性锚点", () => {
         runtime.retryCallbacks = [];
         runtime.config.display = 0;
         runtime.config.fullPageTranslationMode = "viewport";
+        runtime.ensureTranslationTruncationLayout.mockClear();
         TestIntersectionObserver.instances = [];
         TestMutationObserver.instances = [];
 
@@ -1420,6 +1425,40 @@ describe("全文翻译可见性锚点", () => {
 
         expect(runtime.requests).toHaveBeenCalledTimes(1);
     });
+
+    it.each([
+        {display: 0, expectedLayoutChecks: 0, label: "single"},
+        {display: 1, expectedLayoutChecks: 1, label: "bilingual"},
+    ] as const)(
+        "$label 已译内容发生纯布局 mutation 时只为双语 wrapper 续租 unclamp",
+        async ({display, expectedLayoutChecks}) => {
+            runtime.config.display = display;
+            document.body.innerHTML = '<p id="prose">Stable source under a layout-only mutation.</p>';
+            const paragraph = document.querySelector<HTMLElement>("#prose")!;
+            setLayoutBox(paragraph, 620, 90);
+            runtime.candidates = [{element: paragraph, kind: "content", reason: "paragraph"}];
+
+            autoTranslateEnglishPage();
+            await vi.advanceTimersByTimeAsync(50);
+            TestIntersectionObserver.instances[0]!.emit(paragraph, true);
+            await finishScheduledWork();
+            expect(getTranslationState(paragraph)?.phase).toBe("translated");
+
+            paragraph.classList.add("host-layout-update");
+            TestMutationObserver.instances.at(-1)!.emit([{
+                type: "attributes",
+                target: paragraph,
+                attributeName: "class",
+                addedNodes: [] as unknown as NodeList,
+                removedNodes: [] as unknown as NodeList,
+            } as unknown as MutationRecord]);
+            await finishScheduledWork();
+
+            expect(runtime.ensureTranslationTruncationLayout)
+                .toHaveBeenCalledTimes(expectedLayoutChecks);
+            expect(runtime.requests).toHaveBeenCalledTimes(1);
+        },
+    );
 
     it("已译 prose 忽略 MathJax/code 等保护后代 churn，但外层 source mutation 会重启", async () => {
         runtime.config.display = 1;

--- a/tests/translationTruncation.test.ts
+++ b/tests/translationTruncation.test.ts
@@ -1,0 +1,509 @@
+import {parseHTML} from 'linkedom';
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/entrypoints/utils/config', () => ({
+    config: {style: 1, to: 'zh-Hans'},
+}));
+vi.mock('@/entrypoints/utils/option', () => ({
+    options: {styles: []},
+}));
+
+import {
+    findTranslationTruncationAncestors,
+    hasActiveTranslationLineClamp,
+    translationTruncationStyleOverrides,
+} from '@/entrypoints/translation-core/public';
+import {
+    acquireTranslationLayoutOverride,
+    beginTranslation,
+    getTranslationState,
+    hasTranslationLayoutOverride,
+    isTranslationLayoutOverrideMutation,
+    reconcileTranslationLayoutOverrides,
+    restoreTranslation,
+    setBilingualContent,
+} from '@/entrypoints/main/translationState';
+import {ensureTranslationTruncationLayout} from '@/entrypoints/main/translationLayout';
+import {appendBilingualTranslation} from '@/entrypoints/main/translationRenderer';
+
+function openRouterFixture() {
+    const {document} = parseHTML(`
+        <html><body>
+            <div id="ordinary-overflow">
+                <div id="clamp">
+                    <div class="prose"><p id="first">A long model description for the first card.</p></div>
+                    <p id="second">A second translated paragraph sharing the same clamp.</p>
+                </div>
+            </div>
+        </body></html>
+    `);
+    const clamp = document.querySelector<HTMLElement>('#clamp')!;
+    const ordinary = document.querySelector<HTMLElement>('#ordinary-overflow')!;
+    const first = document.querySelector<HTMLElement>('#first')!;
+    const second = document.querySelector<HTMLElement>('#second')!;
+    const getComputedStyle = (element: Element) => {
+        const lineClamp = element === clamp ? '2' : 'none';
+        return {
+            webkitLineClamp: lineClamp,
+            getPropertyValue: (property: string) =>
+                property === '-webkit-line-clamp' || property === 'line-clamp' ? lineClamp : '',
+        } as unknown as CSSStyleDeclaration;
+    };
+    Object.defineProperty(document.defaultView, 'getComputedStyle', {
+        configurable: true,
+        value: getComputedStyle,
+    });
+    return {document, clamp, ordinary, first, second};
+}
+
+/** linkedom omits CSS priority APIs, so record the real setProperty calls explicitly. */
+function trackStylePriorities(element: HTMLElement) {
+    const style = element.style;
+    const priorities = new Map<string, string>();
+    const calls: Array<{property: string; value: string; priority: string}> = [];
+    const initialStyle = element.getAttribute('style') ?? '';
+    initialStyle.split(';').forEach((declaration) => {
+        const separator = declaration.indexOf(':');
+        if (separator < 0 || !/!important\s*$/iu.test(declaration)) return;
+        priorities.set(declaration.slice(0, separator).trim().toLowerCase(), 'important');
+    });
+    const originalSetProperty = style.setProperty.bind(style);
+    const originalRemoveProperty = style.removeProperty.bind(style);
+
+    Object.defineProperties(style, {
+        getPropertyPriority: {
+            configurable: true,
+            value: (property: string) => priorities.get(property.toLowerCase()) ?? '',
+        },
+        setProperty: {
+            configurable: true,
+            value: (property: string, value: string, priority = '') => {
+                const normalizedPriority = priority.toLowerCase();
+                calls.push({property, value, priority: normalizedPriority});
+                originalSetProperty(property, value);
+                if (normalizedPriority) priorities.set(property.toLowerCase(), normalizedPriority);
+                else priorities.delete(property.toLowerCase());
+            },
+        },
+        removeProperty: {
+            configurable: true,
+            value: (property: string) => {
+                priorities.delete(property.toLowerCase());
+                return originalRemoveProperty(property);
+            },
+        },
+    });
+
+    return {
+        calls,
+        getPriority: (property: string) => priorities.get(property.toLowerCase()) ?? '',
+    };
+}
+
+async function flushMutationObservers(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+}
+
+async function withDocumentRealm<T>(
+    document: Document,
+    callback: () => Promise<T>,
+): Promise<T> {
+    const realm = document.defaultView as unknown as Record<string, unknown>;
+    const globalRecord = globalThis as unknown as Record<string, unknown>;
+    const realmBindings: Record<string, unknown> = {
+        document,
+        window: document.defaultView,
+        DOMParser: class FixtureDOMParser {
+            parseFromString(source: string): Document {
+                return parseHTML(`<html><head></head><body>${source}</body></html>`).document;
+            }
+        },
+        Element: realm.Element,
+        HTMLElement: realm.HTMLElement,
+        MutationObserver: realm.MutationObserver,
+        Node: realm.Node,
+        ShadowRoot: realm.ShadowRoot,
+    };
+    const previousDescriptors = new Map<string, PropertyDescriptor | undefined>();
+
+    Object.entries(realmBindings).forEach(([name, value]) => {
+        previousDescriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+        if (value !== undefined) {
+            Object.defineProperty(globalRecord, name, {
+                configurable: true,
+                writable: true,
+                value,
+            });
+        }
+    });
+
+    try {
+        return await callback();
+    } finally {
+        Object.keys(realmBindings).forEach((name) => {
+            const descriptor = previousDescriptors.get(name);
+            if (descriptor) Object.defineProperty(globalRecord, name, descriptor);
+            else delete globalRecord[name];
+        });
+    }
+}
+
+function commitBilingualTranslation(owner: HTMLElement): HTMLElement {
+    const attempt = beginTranslation(owner, 'bilingual')!;
+    attempt.state.phase = 'translated';
+    expect(ensureTranslationTruncationLayout(owner)).toBe(true);
+
+    const wrapper = owner.ownerDocument.createElement('span');
+    wrapper.className = 'fluent-read-bilingual-content';
+    wrapper.setAttribute('data-fr-translation-owned', 'true');
+    wrapper.textContent = 'Translated text.';
+    owner.appendChild(wrapper);
+    setBilingualContent(owner, wrapper);
+    return wrapper;
+}
+
+function dynamicClampFixture() {
+    const {document} = parseHTML(`
+        <html><body>
+            <div id="late-clamp"><p id="owner">A translated paragraph.</p></div>
+        </body></html>
+    `);
+    const clamp = document.querySelector<HTMLElement>('#late-clamp')!;
+    const owner = document.querySelector<HTMLElement>('#owner')!;
+    Object.defineProperty(document.defaultView, 'getComputedStyle', {
+        configurable: true,
+        value: (element: Element) => {
+            const inlineClamp = (element as HTMLElement).style?.getPropertyValue('-webkit-line-clamp') ?? '';
+            const lineClamp = inlineClamp === 'unset'
+                ? 'none'
+                : inlineClamp || (element === clamp && clamp.classList.contains('line-clamp-2') ? '2' : 'none');
+            return {
+                webkitLineClamp: lineClamp,
+                getPropertyValue: (property: string) =>
+                    property === '-webkit-line-clamp' || property === 'line-clamp' ? lineClamp : '',
+            } as unknown as CSSStyleDeclaration;
+        },
+    });
+    return {document, clamp, owner};
+}
+
+describe('translation truncation layout', () => {
+    it('finds the active OpenRouter-style ancestor but ignores ordinary overflow clipping', () => {
+        const {clamp, ordinary, first} = openRouterFixture();
+
+        expect(hasActiveTranslationLineClamp(clamp)).toBe(true);
+        expect(hasActiveTranslationLineClamp(ordinary)).toBe(false);
+        expect(findTranslationTruncationAncestors(first)).toEqual([clamp]);
+    });
+
+    it('includes a shared ancestor whose first lease has already removed its computed clamp', () => {
+        const {clamp, first} = openRouterFixture();
+        Object.defineProperty(first.ownerDocument.defaultView, 'getComputedStyle', {
+            configurable: true,
+            value: () => ({
+                webkitLineClamp: 'none',
+                getPropertyValue: () => '',
+            } as unknown as CSSStyleDeclaration),
+        });
+
+        expect(findTranslationTruncationAncestors(first, (element) => element === clamp)).toEqual([clamp]);
+    });
+
+    it('wires OpenRouter ancestor unclamping through the real bilingual renderer', async () => {
+        const {document, clamp, first} = openRouterFixture();
+        const originalClampStyle = '-webkit-line-clamp: 2 !important; max-height: 40px; color: red;';
+        clamp.setAttribute('style', originalClampStyle);
+        const priorityTracking = trackStylePriorities(clamp);
+
+        await withDocumentRealm(document, async () => {
+            const attempt = beginTranslation(first, 'bilingual')!;
+            attempt.state.phase = 'translated';
+            const wrapper = appendBilingualTranslation(first, '模型介绍已翻译。');
+            setBilingualContent(first, wrapper);
+
+            expect(wrapper.parentElement).toBe(first);
+            expect(wrapper.textContent).toBe('模型介绍已翻译。');
+            expect(wrapper.getAttribute('translate')).toBe('no');
+            expect(hasTranslationLayoutOverride(first)).toBe(true);
+            expect(hasTranslationLayoutOverride(clamp)).toBe(true);
+            expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+            expect(priorityTracking.calls).toContainEqual({
+                property: '-webkit-line-clamp',
+                value: 'unset',
+                priority: 'important',
+            });
+
+            expect(restoreTranslation(first)).toBe(true);
+            expect(wrapper.isConnected).toBe(false);
+            expect(hasTranslationLayoutOverride(clamp)).toBe(false);
+            expect(clamp.getAttribute('style')).toBe(originalClampStyle);
+        });
+    });
+
+    it('shares one clamp lease and restores its properties only after the last owner exits', () => {
+        const {clamp, first, second} = openRouterFixture();
+        clamp.setAttribute(
+            'style',
+            '-webkit-line-clamp: 2 !important; max-height: 40px; color: red;',
+        );
+        const firstAttempt = beginTranslation(first, 'bilingual')!;
+        const secondAttempt = beginTranslation(second, 'bilingual')!;
+
+        expect(acquireTranslationLayoutOverride(
+            first,
+            clamp,
+            translationTruncationStyleOverrides,
+        )).toBe(true);
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+        expect(isTranslationLayoutOverrideMutation(clamp)).toBe(true);
+
+        expect(acquireTranslationLayoutOverride(
+            second,
+            clamp,
+            translationTruncationStyleOverrides,
+        )).toBe(true);
+        expect(hasTranslationLayoutOverride(clamp)).toBe(true);
+
+        firstAttempt.state.phase = 'translated';
+        expect(restoreTranslation(first)).toBe(true);
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+        expect(hasTranslationLayoutOverride(clamp)).toBe(true);
+
+        clamp.style.setProperty('background-color', 'blue');
+        secondAttempt.state.phase = 'translated';
+        expect(restoreTranslation(second)).toBe(true);
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toMatch(/^2(?: !important)?$/u);
+        expect(clamp.style.getPropertyValue('max-height')).toBe('40px');
+        expect(clamp.style.getPropertyValue('color')).toBe('red');
+        expect(clamp.style.getPropertyValue('background-color')).toBe('blue');
+        expect(clamp.style.getPropertyValue('line-clamp') ?? '').toBe('');
+        expect(hasTranslationLayoutOverride(clamp)).toBe(false);
+    });
+
+    it('preserves a host clamp rewrite instead of restoring the stale pre-translation value', () => {
+        const {clamp, first} = openRouterFixture();
+        clamp.style.setProperty('-webkit-line-clamp', '2');
+        const attempt = beginTranslation(first, 'bilingual')!;
+        acquireTranslationLayoutOverride(first, clamp, translationTruncationStyleOverrides);
+
+        clamp.style.setProperty('-webkit-line-clamp', '4', 'important');
+        expect(isTranslationLayoutOverrideMutation(clamp)).toBe(false);
+        attempt.state.phase = 'translated';
+        expect(restoreTranslation(first)).toBe(true);
+
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('4');
+    });
+
+    it('reapplies an overridden host clamp and restores the host rewrite as the new baseline', () => {
+        const {clamp, first} = openRouterFixture();
+        clamp.style.setProperty('-webkit-line-clamp', '2');
+        commitBilingualTranslation(first);
+
+        clamp.setAttribute('style', '-webkit-line-clamp: 4; background-color: blue;');
+        expect(reconcileTranslationLayoutOverrides(first)).toBe(true);
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+        expect(clamp.style.getPropertyValue('background-color')).toBe('blue');
+
+        expect(restoreTranslation(first)).toBe(true);
+        expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('4');
+        expect(clamp.style.getPropertyValue('background-color')).toBe('blue');
+    });
+
+    it('releases a hover-style lease when its translated owner is detached', async () => {
+        const {document, clamp, first} = openRouterFixture();
+        await withDocumentRealm(document, async () => {
+            clamp.style.setProperty('-webkit-line-clamp', '2');
+            commitBilingualTranslation(first);
+            await flushMutationObservers();
+            first.remove();
+            await flushMutationObservers();
+
+            try {
+                expect(getTranslationState(first)).toBeUndefined();
+                expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+                expect(hasTranslationLayoutOverride(clamp)).toBe(false);
+            } finally {
+                if (getTranslationState(first)) restoreTranslation(first);
+            }
+        });
+    });
+
+    it('automatically clears a connected hover owner when the host removes its bilingual wrapper', async () => {
+        const {document, clamp, first} = openRouterFixture();
+        await withDocumentRealm(document, async () => {
+            clamp.style.setProperty('-webkit-line-clamp', '2');
+            const wrapper = commitBilingualTranslation(first);
+            await flushMutationObservers();
+
+            wrapper.remove();
+            await flushMutationObservers();
+
+            try {
+                expect(getTranslationState(first)).toBeUndefined();
+                expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+            } finally {
+                if (getTranslationState(first)) restoreTranslation(first);
+            }
+        });
+    });
+
+    it('moves a connected hover owner lease from clamp A to clamp B', async () => {
+        const {document} = parseHTML(`
+            <html><body>
+                <div id="clamp-a" style="-webkit-line-clamp: 2"><p id="owner">Moved prose.</p></div>
+                <div id="clamp-b" style="-webkit-line-clamp: 3"></div>
+            </body></html>
+        `);
+        const clampA = document.querySelector<HTMLElement>('#clamp-a')!;
+        const clampB = document.querySelector<HTMLElement>('#clamp-b')!;
+        const owner = document.querySelector<HTMLElement>('#owner')!;
+        Object.defineProperty(document.defaultView, 'getComputedStyle', {
+            configurable: true,
+            value: (element: Element) => {
+                const inlineClamp = (element as HTMLElement).style?.getPropertyValue('-webkit-line-clamp') ?? '';
+                const lineClamp = inlineClamp === 'unset' ? 'none' : inlineClamp || 'none';
+                return {
+                    webkitLineClamp: lineClamp,
+                    getPropertyValue: (property: string) =>
+                        property === '-webkit-line-clamp' || property === 'line-clamp' ? lineClamp : '',
+                } as unknown as CSSStyleDeclaration;
+            },
+        });
+
+        await withDocumentRealm(document, async () => {
+            const wrapper = commitBilingualTranslation(owner);
+            await flushMutationObservers();
+            expect(clampA.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+
+            clampB.appendChild(owner);
+            await flushMutationObservers();
+
+            try {
+                expect(getTranslationState(owner)?.phase).toBe('translated');
+                expect(wrapper.isConnected).toBe(true);
+                expect(clampA.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+                expect(clampB.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+            } finally {
+                if (getTranslationState(owner)) restoreTranslation(owner);
+            }
+        });
+    });
+
+    it.each([
+        {
+            trigger: 'class',
+            activate: (clamp: HTMLElement) => clamp.classList.add('line-clamp-2'),
+            restoredClamp: '',
+        },
+        {
+            trigger: 'inline style',
+            activate: (clamp: HTMLElement) => clamp.style.setProperty('-webkit-line-clamp', '2'),
+            restoredClamp: '2',
+        },
+    ])('automatically acquires an ancestor clamp activated through $trigger', async ({activate, restoredClamp}) => {
+        const {document, clamp, owner} = dynamicClampFixture();
+        await withDocumentRealm(document, async () => {
+            commitBilingualTranslation(owner);
+            await flushMutationObservers();
+            expect(clamp.style.getPropertyValue('-webkit-line-clamp') ?? '').toBe('');
+
+            activate(clamp);
+            await flushMutationObservers();
+
+            try {
+                expect(getTranslationState(owner)?.phase).toBe('translated');
+                expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+            } finally {
+                if (getTranslationState(owner)) restoreTranslation(owner);
+            }
+            expect(clamp.style.getPropertyValue('-webkit-line-clamp') ?? '').toBe(restoredClamp);
+        });
+    });
+
+    it('reapplies a hover owner override after the host rewrites its inline clamp', async () => {
+        const {document, first} = openRouterFixture();
+        await withDocumentRealm(document, async () => {
+            commitBilingualTranslation(first);
+            await flushMutationObservers();
+
+            first.setAttribute('style', '-webkit-line-clamp: 2; color: blue;');
+            await flushMutationObservers();
+
+            try {
+                expect(first.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+                expect(first.style.getPropertyValue('color')).toBe('blue');
+            } finally {
+                if (getTranslationState(first)) restoreTranslation(first);
+            }
+            expect(first.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+            expect(first.style.getPropertyValue('color')).toBe('blue');
+        });
+    });
+
+    it('automatically releases a hover lease when its owner is removed inside an open ShadowRoot', async () => {
+        const {document} = parseHTML('<html><body><div id="host"></div></body></html>');
+        const host = document.querySelector<HTMLElement>('#host')!;
+        const shadowRoot = host.attachShadow({mode: 'open'});
+        const clamp = document.createElement('div');
+        const owner = document.createElement('p');
+        clamp.style.setProperty('-webkit-line-clamp', '2');
+        owner.textContent = 'Shadow-root model description.';
+        clamp.appendChild(owner);
+        shadowRoot.appendChild(clamp);
+        Object.defineProperty(document.defaultView, 'getComputedStyle', {
+            configurable: true,
+            value: (element: Element) => {
+                const inlineClamp = (element as HTMLElement).style?.getPropertyValue('-webkit-line-clamp') ?? '';
+                const lineClamp = inlineClamp === 'unset' ? 'none' : inlineClamp || 'none';
+                return {
+                    webkitLineClamp: lineClamp,
+                    getPropertyValue: (property: string) =>
+                        property === '-webkit-line-clamp' || property === 'line-clamp' ? lineClamp : '',
+                } as unknown as CSSStyleDeclaration;
+            },
+        });
+
+        await withDocumentRealm(document, async () => {
+            commitBilingualTranslation(owner);
+            await flushMutationObservers();
+            expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('unset');
+
+            owner.remove();
+            await flushMutationObservers();
+
+            try {
+                expect(getTranslationState(owner)).toBeUndefined();
+                expect(clamp.style.getPropertyValue('-webkit-line-clamp')).toBe('2');
+            } finally {
+                if (getTranslationState(owner)) restoreTranslation(owner);
+            }
+        });
+    });
+
+    it('restores the exact original style attribute when the host did not mutate it', () => {
+        const {clamp, first} = openRouterFixture();
+        const originalStyle = 'COLOR: red; -webkit-line-clamp: 2; max-height: 40px';
+        clamp.setAttribute('style', originalStyle);
+        const attempt = beginTranslation(first, 'bilingual')!;
+        acquireTranslationLayoutOverride(first, clamp, translationTruncationStyleOverrides);
+        attempt.state.phase = 'translated';
+
+        expect(restoreTranslation(first)).toBe(true);
+        expect(clamp.getAttribute('style')).toBe(originalStyle);
+    });
+
+    it('removes a temporary style attribute when the unclamped ancestor originally had none', () => {
+        const {clamp, first} = openRouterFixture();
+        expect(clamp.getAttribute('style')).toBeNull();
+        const attempt = beginTranslation(first, 'bilingual')!;
+        acquireTranslationLayoutOverride(first, clamp, translationTruncationStyleOverrides);
+        expect(clamp.getAttribute('style')).not.toBeNull();
+
+        attempt.state.phase = 'translated';
+        expect(restoreTranslation(first)).toBe(true);
+        expect(clamp.getAttribute('style')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- reveal bilingual translations hidden by active line-clamp/max-height ancestors
- preserve shared leases, host style updates, reparenting, and Shadow DOM lifecycle
- add OpenRouter-shaped regression coverage and real-browser fixture assertions

## Validation
- pnpm test (34 files, 438 tests)
- pnpm compile
- pnpm build
- isolated hidden Edge verification on OpenRouter models and FLUX detail pages

Fixes the case where the translation wrapper exists in the DOM but is clipped by the host card layout.