### PR TITLE
style: refresh custom hotkey dialog

### DIFF
--- a/components/CustomHotkeyInput.vue
+++ b/components/CustomHotkeyInput.vue
@@ -1,110 +1,133 @@
 <template>
-  <div class="custom-hotkey-input">
-    <!-- 自定义快捷键输入对话框 -->
-    <el-dialog
-      v-model="dialogVisible"
-      title="自定义快捷键"
-      width="300px"
-      :close-on-click-modal="false"
-      :modal="false"
-      :append-to-body="true"
-      :destroy-on-close="true"
-      @close="handleCancel"
+  <Teleport to="body">
+    <div
+      v-if="dialogVisible"
+      class="custom-hotkey-overlay"
+      role="presentation"
+      @keydown.esc="handleCancel"
     >
-      <div class="hotkey-input-container">
-        <div class="input-section">
-          <el-text class="input-label">
-            请按下您想要设置的快捷键组合：
-          </el-text>
-          <div 
-            class="hotkey-input-field"
-            :class="{ 
-              'recording': isRecording, 
-              'error': errorMessage,
-              'success': parsedHotkey?.isValid && !errorMessage 
-            }"
-            @click="startRecording"
-            @keydown="handleKeyDown"
-            @keyup="handleKeyUp"
-            tabindex="0"
-            ref="inputField"
-          >
-            <div v-if="!isRecording && !currentHotkey" class="placeholder">
-              点击这里开始录制快捷键...
-            </div>
-            <div v-else-if="isRecording" class="recording-text">
-              <el-icon class="recording-icon"><Loading /></el-icon>
-              正在录制，请按下快捷键...
-            </div>
-            <div v-else-if="currentHotkey" class="hotkey-display">
-              {{ parsedHotkey?.displayName || currentHotkey }}
-            </div>
+      <section
+        ref="dialogRoot"
+        class="custom-hotkey-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="custom-hotkey-title"
+        aria-describedby="custom-hotkey-description"
+        tabindex="-1"
+        @click.stop
+      >
+        <header class="dialog-header">
+          <div class="dialog-heading">
+            <span class="dialog-eyebrow">交互设置</span>
+            <h2 id="custom-hotkey-title">自定义快捷键</h2>
+            <p id="custom-hotkey-description">为当前功能设置一个顺手、易记且不容易冲突的按键组合。</p>
           </div>
-          
-          <!-- 错误提示 -->
-          <div v-if="errorMessage" class="error-message">
-            <el-icon><WarningFilled /></el-icon>
-            {{ errorMessage }}
-          </div>
-          
-          <!-- 冲突警告 -->
-          <div v-if="conflictWarning" class="warning-message">
-            <el-icon><Warning /></el-icon>
-            {{ conflictWarning }}
-          </div>
-          
-          <!-- 成功提示 -->
-          <div v-if="parsedHotkey?.isValid && !errorMessage && !conflictWarning" class="success-message">
-            <el-icon><CircleCheckFilled /></el-icon>
-            快捷键有效，可以使用
-          </div>
-        </div>
+          <button class="dialog-close" type="button" aria-label="关闭自定义快捷键" @click="handleCancel">
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
 
-        <!-- 预设快捷键推荐 -->
-        <div class="preset-section">
-          <el-text class="section-title">或选择推荐的快捷键：</el-text>
-          <div class="preset-buttons">
-            <el-button
-              v-for="preset in recommendedHotkeys"
-              :key="preset.value"
-              size="small"
-              :type="currentHotkey === preset.value ? 'primary' : 'default'"
-              @click="selectPreset(preset.value)"
-              class="preset-button"
+        <div class="dialog-body">
+          <section class="recording-card" :class="{ 'is-recording': isRecording }">
+            <div class="section-heading">
+              <div>
+                <span class="section-eyebrow">录制组合</span>
+                <h3>按下你想使用的快捷键</h3>
+              </div>
+              <span class="state-badge" :class="{ active: isRecording, ready: !!currentHotkey && !isRecording }">
+                {{ isRecording ? '录制中' : currentHotkey ? '已设置' : '待设置' }}
+              </span>
+            </div>
+
+            <button
+              ref="inputField"
+              type="button"
+              class="hotkey-input-field"
+              :class="{
+                recording: isRecording,
+                error: !!errorMessage,
+                warning: !!conflictWarning,
+                success: isValidHotkey
+              }"
+              :aria-label="isRecording ? '正在录制快捷键，请按下组合键' : currentHotkey ? `当前快捷键为 ${displayHotkey}` : '点击开始录制快捷键'"
+              @click="startRecording"
+              @keydown="handleKeyDown"
+              @keyup="handleKeyUp"
             >
-              {{ preset.label }}
-            </el-button>
-          </div>
-        </div>
+              <span v-if="!isRecording && !currentHotkey" class="placeholder">
+                点击后按下快捷键组合
+              </span>
+              <span v-else-if="isRecording" class="recording-text">
+                <el-icon class="recording-icon"><Loading /></el-icon>
+                正在录制，请按下快捷键…
+              </span>
+              <span v-else class="hotkey-display">
+                <kbd>{{ displayHotkey }}</kbd>
+              </span>
+            </button>
 
-        <!-- 简化说明 -->
-        <div class="help-section">
-          <el-text size="small" type="info">
-            提示：建议使用修饰键组合（如 Ctrl+字母），避免与系统快捷键冲突。注意：不能使用 CMD 充当快捷键
-          </el-text>
-        </div>
-      </div>
+            <p class="field-hint">支持 Ctrl、Alt、Shift 与字母或功能键组合；不支持使用 CMD/Meta 键。</p>
+          </section>
 
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button @click="handleCancel">取消</el-button>
-          <el-button @click="clearHotkey" v-if="currentHotkey">清除</el-button>
-          <el-button 
-            type="primary" 
-            @click="handleConfirm"
-            :disabled="!canConfirm"
+          <div
+            v-if="errorMessage || conflictWarning || isValidHotkey"
+            class="hotkey-status"
+            :class="{ error: !!errorMessage, warning: !!conflictWarning && !errorMessage, success: isValidHotkey }"
+            :role="errorMessage ? 'alert' : 'status'"
+            aria-live="polite"
           >
-            确认
-          </el-button>
+            <el-icon v-if="errorMessage"><WarningFilled /></el-icon>
+            <el-icon v-else-if="conflictWarning"><Warning /></el-icon>
+            <el-icon v-else><CircleCheckFilled /></el-icon>
+            <span>{{ errorMessage || conflictWarning || '快捷键有效，可以使用' }}</span>
+          </div>
+
+          <section class="preset-section">
+            <div class="section-heading preset-heading">
+              <div>
+                <span class="section-eyebrow">快速选择</span>
+                <h3>推荐快捷键</h3>
+              </div>
+              <span class="section-note">也可以直接录制</span>
+            </div>
+            <div class="preset-buttons">
+              <button
+                v-for="preset in recommendedHotkeys"
+                :key="preset.value"
+                type="button"
+                class="preset-button"
+                :class="{ selected: currentHotkey === preset.value }"
+                :aria-label="preset.label"
+                :aria-pressed="currentHotkey === preset.value"
+                @click="selectPreset(preset.value)"
+              >
+                <span class="preset-label">{{ currentHotkey === preset.value ? '当前选择' : '使用' }}</span>
+                <kbd>{{ preset.label }}</kbd>
+              </button>
+            </div>
+          </section>
+
+          <aside class="help-section">
+            <span class="help-icon" aria-hidden="true">i</span>
+            <p>建议使用修饰键组合，避免与浏览器、系统或网页已有快捷键冲突。设置完成后，快捷键会立即应用。</p>
+          </aside>
         </div>
-      </template>
-    </el-dialog>
-  </div>
+
+        <footer class="dialog-footer">
+          <button v-if="currentHotkey" class="clear-button" type="button" @click="clearHotkey">清除快捷键</button>
+          <div class="dialog-actions">
+            <button class="secondary-button" type="button" @click="handleCancel">取消</button>
+            <button class="primary-button" type="button" :disabled="!canConfirm" @click="handleConfirm">确认</button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts" name="CustomHotkeyInput">
 import { ref, computed, nextTick, watch } from 'vue';
-import { ElDialog, ElButton, ElText, ElIcon } from 'element-plus';
+import { ElIcon } from 'element-plus';
 import { Loading, WarningFilled, Warning, CircleCheckFilled } from '@element-plus/icons-vue';
 import { parseHotkey, validateHotkeyConflicts, type ParsedHotkey } from '@/entrypoints/utils/hotkey';
 
@@ -128,10 +151,7 @@ interface Emits {
 const emit = defineEmits<Emits>();
 
 // 响应式数据
-const dialogVisible = computed({
-  get: () => props.modelValue,
-  set: (value) => emit('update:modelValue', value)
-});
+const dialogVisible = computed(() => props.modelValue);
 
 const currentHotkey = ref(props.currentValue || '');
 const isRecording = ref(false);
@@ -139,6 +159,7 @@ const pressedKeys = ref(new Set<string>());
 const errorMessage = ref('');
 const conflictWarning = ref('');
 const inputField = ref<HTMLElement>();
+const dialogRoot = ref<HTMLElement>();
 
 // 解析当前快捷键
 const parsedHotkey = computed<ParsedHotkey | null>(() => {
@@ -146,10 +167,19 @@ const parsedHotkey = computed<ParsedHotkey | null>(() => {
   return parseHotkey(currentHotkey.value);
 });
 
+const isValidHotkey = computed(() => Boolean(
+  parsedHotkey.value?.isValid && !errorMessage.value && !conflictWarning.value,
+));
+
+const displayHotkey = computed(() => {
+  if (currentHotkey.value === 'none') return '已禁用';
+  return parsedHotkey.value?.displayName || currentHotkey.value;
+});
+
 // 检查是否可以确认
 const canConfirm = computed(() => {
   return currentHotkey.value === 'none' || 
-         (parsedHotkey.value?.isValid && !errorMessage.value);
+         Boolean(parsedHotkey.value?.isValid && !errorMessage.value);
 });
 
 // 推荐的快捷键
@@ -164,6 +194,12 @@ const recommendedHotkeys = [
 // 监听当前值变化
 watch(() => props.currentValue, (newValue) => {
   currentHotkey.value = newValue || '';
+});
+
+watch(dialogVisible, (visible) => {
+  if (visible) {
+    nextTick(() => dialogRoot.value?.focus({ preventScroll: true }));
+  }
 });
 
 // 监听快捷键变化，进行验证
@@ -318,7 +354,7 @@ function handleConfirm() {
   if (!canConfirm.value) return;
   
   emit('confirm', currentHotkey.value);
-  dialogVisible.value = false;
+  emit('update:modelValue', false);
 }
 
 // 取消
@@ -329,202 +365,566 @@ function handleCancel() {
   errorMessage.value = '';
   conflictWarning.value = '';
   emit('cancel');
-  dialogVisible.value = false;
+  emit('update:modelValue', false);
 }
 </script>
 
 <style scoped>
-.custom-hotkey-input {
-  width: 100%;
-}
-
-.hotkey-input-container {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.input-section {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.input-label {
-  font-weight: 500;
-  color: var(--el-text-color-primary);
-}
-
-.hotkey-input-field {
-  min-height: 50px;
-  border: 2px solid var(--el-border-color);
-  border-radius: 6px;
-  padding: 12px;
-  cursor: pointer;
-  transition: all 0.3s ease;
+.custom-hotkey-overlay {
+  --hotkey-brand: var(--brand, #ef4776);
+  --hotkey-brand-strong: var(--brand-strong, #dc315f);
+  --hotkey-brand-soft: var(--brand-soft, #fff0f4);
+  --hotkey-ink: var(--ink, #172033);
+  --hotkey-muted: var(--muted, #737c8f);
+  --hotkey-line: var(--line, #e5e8ef);
+  --hotkey-surface: var(--surface, #fff);
+  --hotkey-surface-soft: var(--surface-soft, #f7f8fb);
+  position: fixed;
+  z-index: 3000;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--el-bg-color);
-  position: relative;
+  overflow-y: auto;
+  padding: 24px;
+  background: rgba(23, 32, 51, .3);
+  backdrop-filter: blur(8px);
+  font-family: inherit;
+}
+
+.custom-hotkey-dialog {
+  display: flex;
+  width: min(560px, 100%);
+  max-height: min(760px, calc(100vh - 32px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, .8);
+  border-radius: 26px;
+  outline: none;
+  background: var(--hotkey-surface);
+  box-shadow: 0 28px 80px rgba(23, 32, 51, .2), 0 8px 24px rgba(23, 32, 51, .08);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px 30px 22px;
+  border-bottom: 1px solid var(--hotkey-line);
+  background: linear-gradient(135deg, #fff7f9 0%, var(--hotkey-surface) 68%);
+}
+
+.dialog-heading,
+.section-heading {
+  min-width: 0;
+}
+
+.dialog-eyebrow,
+.section-eyebrow {
+  display: block;
+  color: var(--hotkey-brand-strong);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .12em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.dialog-heading h2,
+.section-heading h3 {
+  margin: 5px 0 0;
+  color: var(--hotkey-ink);
+  letter-spacing: -.03em;
+}
+
+.dialog-heading h2 {
+  font-size: 25px;
+  line-height: 1.25;
+}
+
+.dialog-heading p {
+  max-width: 410px;
+  margin: 8px 0 0;
+  color: var(--hotkey-muted);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.dialog-close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  place-items: center;
+  margin: -4px -6px 0 0;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  color: #8c94a3;
+  background: transparent;
+  cursor: pointer;
+  font-size: 26px;
+  font-weight: 300;
+  line-height: 1;
+  transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.dialog-close:hover,
+.dialog-close:focus-visible {
+  border-color: #f4ced9;
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+}
+
+.dialog-body {
+  display: grid;
+  gap: 18px;
+  min-height: 0;
+  padding: 24px 30px 26px;
+  overflow-y: auto;
+}
+
+.recording-card {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid #f1d6de;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #fff8fa 0%, var(--hotkey-surface-soft) 100%);
+}
+
+.recording-card.is-recording {
+  border-color: #f0b4c5;
+  box-shadow: 0 0 0 4px rgba(239, 71, 118, .08);
+}
+
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.section-heading h3 {
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.state-badge {
+  flex: 0 0 auto;
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #8b93a4;
+  background: #eef1f6;
+  font-size: 10px;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.state-badge.active,
+.state-badge.ready {
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+}
+
+.hotkey-input-field {
+  display: flex;
+  min-height: 78px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 14px 18px;
+  border: 1px dashed #d4dae5;
+  border-radius: 16px;
+  color: var(--hotkey-muted);
+  background: rgba(255, 255, 255, .86);
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease, color 160ms ease;
 }
 
 .hotkey-input-field:hover {
-  border-color: var(--el-color-primary);
+  border-color: #ef9ab1;
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-surface);
 }
 
-.hotkey-input-field:focus {
-  outline: none;
-  border-color: var(--el-color-primary);
-  box-shadow: 0 0 0 2px var(--el-color-primary-light-8);
+.hotkey-input-field:focus-visible {
+  border-color: var(--hotkey-brand);
+  outline: 3px solid rgba(239, 71, 118, .16);
+  outline-offset: 2px;
 }
 
 .hotkey-input-field.recording {
-  border-color: var(--el-color-warning);
-  background: var(--el-color-warning-light-9);
-  animation: pulse 2s infinite;
+  border-style: solid;
+  border-color: var(--hotkey-brand);
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+  box-shadow: 0 0 0 4px rgba(239, 71, 118, .1);
 }
 
 .hotkey-input-field.error {
-  border-color: var(--el-color-danger);
-  background: var(--el-color-danger-light-9);
+  border-style: solid;
+  border-color: #e46b6b;
+  color: #bd4545;
+  background: #fff6f6;
+}
+
+.hotkey-input-field.warning {
+  border-style: solid;
+  border-color: #e7b24f;
+  color: #9c6b12;
+  background: #fffaf0;
 }
 
 .hotkey-input-field.success {
-  border-color: var(--el-color-success);
-  background: var(--el-color-success-light-9);
-}
-
-@keyframes pulse {
-  0% { box-shadow: 0 0 0 0 var(--el-color-warning-light-5); }
-  70% { box-shadow: 0 0 0 8px transparent; }
-  100% { box-shadow: 0 0 0 0 transparent; }
+  border-style: solid;
+  border-color: #8bcaa4;
+  color: #2c8050;
+  background: #f4fbf6;
 }
 
 .placeholder {
-  color: var(--el-text-color-placeholder);
-  font-style: italic;
+  font-size: 13px;
 }
 
 .recording-text {
-  color: var(--el-color-warning);
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: 650;
 }
 
 .recording-icon {
-  animation: spin 1s linear infinite;
+  animation: hotkey-spin 1s linear infinite;
 }
 
-@keyframes spin {
+@keyframes hotkey-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
 
-.hotkey-display {
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--el-color-primary);
-  padding: 8px 16px;
-  background: var(--el-color-primary-light-9);
-  border-radius: 6px;
-  border: 1px solid var(--el-color-primary-light-7);
-}
-
-.error-message {
-  display: flex;
+.hotkey-display kbd,
+.preset-button kbd {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  color: var(--el-color-danger);
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid #dfe4ed;
+  border-bottom-width: 2px;
+  border-radius: 9px;
+  color: var(--hotkey-ink);
+  background: var(--hotkey-surface);
+  box-shadow: 0 2px 3px rgba(23, 32, 51, .06);
+  font-family: 'SFMono-Regular', 'SF Mono', 'Cascadia Code', 'Roboto Mono', monospace;
   font-size: 14px;
-  padding: 8px 12px;
-  background: var(--el-color-danger-light-9);
-  border-radius: 6px;
-  border: 1px solid var(--el-color-danger-light-7);
+  font-weight: 700;
+  letter-spacing: .02em;
 }
 
-.warning-message {
+.hotkey-display kbd {
+  padding: 8px 15px;
+  border-color: #f0b4c5;
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+  font-size: 17px;
+}
+
+.field-hint,
+.section-note {
+  color: var(--hotkey-muted);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.field-hint {
+  margin: -4px 0 0;
+}
+
+.section-note {
+  padding-top: 2px;
+  white-space: nowrap;
+}
+
+.hotkey-status {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
-  color: var(--el-color-warning);
-  font-size: 14px;
-  padding: 8px 12px;
-  background: var(--el-color-warning-light-9);
-  border-radius: 6px;
-  border: 1px solid var(--el-color-warning-light-7);
-}
-
-.success-message {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--el-color-success);
-  font-size: 14px;
-  padding: 8px 12px;
-  background: var(--el-color-success-light-9);
-  border-radius: 6px;
-  border: 1px solid var(--el-color-success-light-7);
-}
-
-.preset-section {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.section-title {
-  font-weight: 500;
-  color: var(--el-text-color-primary);
-}
-
-.preset-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.preset-button {
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-}
-
-.help-section {
-  margin-top: 4px;
-}
-
-.help-content {
-  padding: 0 4px;
-}
-
-.help-content h4 {
-  margin: 16px 0 8px 0;
-  color: var(--el-text-color-primary);
-  font-size: 14px;
-}
-
-.help-content ul {
-  margin: 8px 0;
-  padding-left: 20px;
-}
-
-.help-content li {
-  margin: 4px 0;
-  font-size: 13px;
-  color: var(--el-text-color-regular);
+  padding: 10px 12px;
+  border: 1px solid;
+  border-radius: 13px;
+  font-size: 12px;
   line-height: 1.5;
 }
 
-.help-content strong {
-  color: var(--el-text-color-primary);
-  font-weight: 600;
+.hotkey-status.error {
+  border-color: #f1c2c2;
+  color: #b84d4d;
+  background: #fff6f6;
+}
+
+.hotkey-status.warning {
+  border-color: #f0d49a;
+  color: #956713;
+  background: #fffaf0;
+}
+
+.hotkey-status.success {
+  border-color: #b9e0c5;
+  color: #2d7d4d;
+  background: #f4fbf6;
+}
+
+.preset-section {
+  display: grid;
+  gap: 13px;
+}
+
+.preset-buttons {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.preset-button {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 9px 10px 9px 12px;
+  border: 1px solid var(--hotkey-line);
+  border-radius: 14px;
+  color: var(--hotkey-muted);
+  background: var(--hotkey-surface);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.preset-button:hover,
+.preset-button:focus-visible {
+  border-color: #ef9ab1;
+  color: var(--hotkey-brand-strong);
+  background: #fffafb;
+  box-shadow: 0 7px 18px rgba(239, 71, 118, .08);
+  transform: translateY(-1px);
+}
+
+.preset-button.selected {
+  border-color: #f0b4c5;
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+  box-shadow: 0 6px 16px rgba(239, 71, 118, .08);
+}
+
+.preset-button kbd {
+  flex: 0 0 auto;
+  color: var(--hotkey-ink);
+  font-size: 12px;
+}
+
+.preset-button.selected kbd {
+  border-color: #f0b4c5;
+  color: var(--hotkey-brand-strong);
+}
+
+.preset-label {
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.help-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 13px 14px;
+  border: 1px solid var(--hotkey-line);
+  border-radius: 14px;
+  background: var(--hotkey-surface-soft);
+}
+
+.help-icon {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  place-items: center;
+  margin-top: 1px;
+  border-radius: 50%;
+  color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-soft);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.help-section p {
+  margin: 0;
+  color: var(--hotkey-muted);
+  font-size: 11px;
+  line-height: 1.65;
 }
 
 .dialog-footer {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 30px 24px;
+  border-top: 1px solid var(--hotkey-line);
+  background: var(--hotkey-surface);
+}
+
+.dialog-actions {
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.clear-button,
+.secondary-button,
+.primary-button {
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  transition: border-color 160ms ease, color 160ms ease, background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.clear-button {
+  padding: 0;
+  border: 0;
+  color: #bd656d;
+  background: transparent;
+}
+
+.clear-button:hover,
+.clear-button:focus-visible {
+  color: #a64852;
+  text-decoration: underline;
+}
+
+.secondary-button {
+  border: 1px solid var(--hotkey-line);
+  color: var(--hotkey-ink);
+  background: var(--hotkey-surface);
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  border-color: #ccd3df;
+  background: var(--hotkey-surface-soft);
+}
+
+.primary-button {
+  border: 1px solid var(--hotkey-brand);
+  color: #fff;
+  background: var(--hotkey-brand);
+  box-shadow: 0 7px 16px rgba(239, 71, 118, .2);
+}
+
+.primary-button:hover:not(:disabled),
+.primary-button:focus-visible:not(:disabled) {
+  border-color: var(--hotkey-brand-strong);
+  background: var(--hotkey-brand-strong);
+  box-shadow: 0 9px 20px rgba(239, 71, 118, .25);
+  transform: translateY(-1px);
+}
+
+.primary-button:disabled {
+  border-color: #dfe4ed;
+  color: #aeb5c1;
+  background: #eef1f5;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .custom-hotkey-overlay {
+    align-items: flex-start;
+    padding: 14px;
+  }
+
+  .custom-hotkey-dialog {
+    max-height: calc(100vh - 28px);
+    border-radius: 21px;
+  }
+
+  .dialog-header {
+    padding: 22px 20px 18px;
+  }
+
+  .dialog-heading h2 {
+    font-size: 22px;
+  }
+
+  .dialog-body {
+    padding: 18px 20px 20px;
+  }
+
+  .recording-card {
+    padding: 16px;
+  }
+
+  .preset-buttons {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dialog-footer {
+    padding: 15px 20px 19px;
+  }
+}
+
+@media (max-width: 380px) {
+  .custom-hotkey-overlay {
+    padding: 8px;
+  }
+
+  .custom-hotkey-dialog {
+    max-height: calc(100vh - 16px);
+  }
+
+  .dialog-header,
+  .dialog-body,
+  .dialog-footer {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+
+  .recording-card {
+    padding: 13px;
+  }
+
+  .section-note {
+    display: none;
+  }
+
+  .dialog-footer {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
+
+  .dialog-actions {
+    width: 100%;
+  }
+
+  .secondary-button,
+  .primary-button {
+    flex: 1 1 0;
+  }
+
+  .clear-button {
+    align-self: flex-start;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- 重做自定义快捷键弹层，使其与当前设置页的品牌色、卡片、圆角和间距体系一致
- 保留预设选择、键盘录制、确认、取消回退、清除草稿和状态校验
- 增加响应式布局、基础无障碍名称和高于抽屉遮罩的弹层层级

## Validation
- `pnpm compile`
- `pnpm test`（45 个测试文件，541 个测试通过）
- `pnpm build`
- 屏幕外隔离 Edge 真实交互：预设 Alt+Q、键盘录制 Control+Option+T、确认、取消、清除草稿；consoleErrors=0
- 已知基线：完整 UI runner 在未修改的 popup “更多服务默认没有收起”断言处停止，快捷键专项已绕过该断言直接验证。