### PR TITLE
fix: keep userscript config saves safe after main merge

### DIFF
--- a/entrypoints/utils/config.ts
+++ b/entrypoints/utils/config.ts
@@ -328,7 +328,15 @@ function queueStorageWrite(nextConfig: Config, serialized: string, revision: num
             if (revision !== writeRevision || lastPersistedSerialized !== serialized) return;
             try {
                 if (!trustedCredentialStorageContext) {
-                    throw new Error('当前上下文不能安全访问 session 凭据存储');
+                    // Userscripts and extension content scripts can persist the
+                    // public configuration, but they cannot access the
+                    // extension-only session credential store. Credentials are
+                    // stripped by toPublicConfig before this fallback write.
+                    await storage.setItem(CONFIG_STORAGE_KEY, {
+                        ...toPublicConfig(nextConfig),
+                        [CONFIG_REVISION_FIELD]: storedRevision,
+                    });
+                    return;
                 }
 
                 const credentials = extractConfigCredentials(nextConfig);

--- a/scripts/run-userscript-smoke-test.cjs
+++ b/scripts/run-userscript-smoke-test.cjs
@@ -332,22 +332,36 @@ async function main() {
     await page.waitForTimeout(80);
     await hoverToggle(page, 0, args.timeout);
     const message = page.locator('body > .el-message.fluent-read-message').last();
-    await message.waitFor({state: 'visible', timeout: args.timeout});
-    const messageStyle = await message.evaluate((element) => {
-      const style = getComputedStyle(element);
-      const rect = element.getBoundingClientRect();
-      return {
+    let messageStyle;
+    if (await message.count() > 0 && await message.isVisible().catch(() => false)) {
+      messageStyle = await message.evaluate((element) => {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return {
+          kind: 'light-dom-message',
+          lightDom: element.getRootNode() === document,
+          position: style.position,
+          display: style.display,
+          zIndex: style.zIndex,
+          top: rect.top,
+          width: rect.width,
+        };
+      });
+      if (!messageStyle.lightDom || messageStyle.position !== 'fixed' || messageStyle.display !== 'flex'
+        || Number(messageStyle.zIndex) < 2_147_483_000 || messageStyle.top < 0 || messageStyle.width < 100) {
+        throw new Error(`light-DOM 错误提示样式断言失败：${JSON.stringify(messageStyle)}`);
+      }
+    } else {
+      const retry = page.locator('#target .fluent-read-retry-wrapper').last();
+      await retry.waitFor({state: 'visible', timeout: args.timeout});
+      messageStyle = await retry.evaluate((element) => ({
+        kind: 'inline-retry-wrapper',
         lightDom: element.getRootNode() === document,
-        position: style.position,
-        display: style.display,
-        zIndex: style.zIndex,
-        top: rect.top,
-        width: rect.width,
-      };
-    });
-    if (!messageStyle.lightDom || messageStyle.position !== 'fixed' || messageStyle.display !== 'flex'
-      || Number(messageStyle.zIndex) < 2_147_483_000 || messageStyle.top < 0 || messageStyle.width < 100) {
-      throw new Error(`light-DOM 错误提示样式断言失败：${JSON.stringify(messageStyle)}`);
+        text: element.textContent?.trim() || '',
+      }));
+      if (!messageStyle.lightDom || !messageStyle.text) {
+        throw new Error(`inline 错误提示断言失败：${JSON.stringify(messageStyle)}`);
+      }
     }
 
     const bridgeCleanup = await page.evaluate(async () => {


### PR DESCRIPTION
Follow-up to #335

## Summary

- Let userscript/content contexts persist sanitized public configuration without attempting the extension-only session credential store.
- Keep credential writes restricted to trusted extension contexts.
- Update the userscript smoke test to accept both the legacy light-DOM Element Plus error message and the current inline retry wrapper.

## Validation

- `pnpm compile`
- `pnpm test` (53 files / 569 tests)
- `pnpm test:userscript`
- Final isolated Edge userscript smoke: `[1, 0, 1]`, full-page translate/restore/retranslate, dynamic ShadowRoot, settings isolation, config save, page globals preserved, and zero console errors.
