### PR TITLE
fix: move image translation button to bottom-left

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -417,11 +417,11 @@
           <div class="image-translation-preview-art"><span>文字</span><b>文</b></div>
           <div>
             <span class="feature-title"><strong>悬停图片显示翻译入口</strong><em class="beta-badge">Beta 测试</em></span>
-            <small>点击图片右上角的小图标即可识别并翻译图片文字</small>
+            <small>点击图片左下角的小图标即可识别并翻译图片文字</small>
           </div>
         </div>
         <div class="setting-row">
-          <span><strong>启用图片翻译</strong><small>在网页图片右上角显示“文”按钮</small></span>
+          <span><strong>启用图片翻译</strong><small>在网页图片左下角显示“文”按钮</small></span>
           <button class="switch compact" type="button" role="switch" :aria-checked="!config.disableImageTranslator" aria-label="启用或关闭图片翻译" @click="setImageTranslatorEnabled(config.disableImageTranslator)"><i /></button>
         </div>
       </div>
@@ -594,7 +594,7 @@ const drawerDescription = computed(() => ({
   selection: '选中文字或圈选页面区域，按你的偏好获取译文。',
   floating: '把全文翻译入口固定在最顺手的位置。',
   appearance: '调整双语布局、译文样式与界面主题。',
-  image: '把鼠标移到图片上，从图片右上角打开翻译入口。',
+  image: '把鼠标移到图片上，从图片左下角打开翻译入口。',
   video: '在 YouTube 播放器中显示实时字幕译文。',
 }[activeDrawer.value]));
 const hoverChoices = [

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -425,7 +425,7 @@ footer > button { justify-self: end; }
   font-size: 10px; font-weight: 750;
 }
 .image-translation-preview-art b {
-  position: absolute; right: 5px; bottom: 5px; display: grid; place-items: center; width: 20px; height: 20px;
+  position: absolute; left: 5px; bottom: 5px; display: grid; place-items: center; width: 20px; height: 20px;
   border: 1px solid rgba(255, 255, 255, .8); border-radius: 999px; color: #fff; background: rgba(20, 20, 20, .7); font-size: 11px;
 }
 .image-translation-preview > div:last-child { display: flex; flex-direction: column; gap: 4px; }

--- a/entrypoints/style.css
+++ b/entrypoints/style.css
@@ -66,8 +66,8 @@
 
 .fluent-read-image-translation-button {
     position: absolute;
-    right: 8px;
-    top: 8px;
+    left: 8px;
+    bottom: 8px;
     width: 26px;
     height: 26px;
     padding: 0;

--- a/entrypoints/utils/imageTranslation.ts
+++ b/entrypoints/utils/imageTranslation.ts
@@ -60,7 +60,7 @@ function ensureImageOverlayRoot(): HTMLDivElement {
       .${IMAGE_TRANSLATION_OVERLAY} { position: fixed !important; overflow: hidden !important; pointer-events: none !important; box-sizing: border-box !important; }
       .${IMAGE_TRANSLATION_OVERLAY} canvas { position: absolute !important; inset: 0 !important; display: none; width: 100%; height: 100%; pointer-events: none; }
       .${IMAGE_TRANSLATION_BUTTON} {
-        position: absolute !important; right: 8px !important; top: 8px !important; z-index: 1 !important;
+        position: absolute !important; left: 8px !important; bottom: 8px !important; z-index: 1 !important;
         width: 26px !important; height: 26px !important; padding: 0 !important;
         border: 1px solid rgba(255,255,255,.7) !important; border-radius: 999px !important;
         background: rgba(20,20,20,.68) !important; color: rgba(255,255,255,.95) !important;


### PR DESCRIPTION
Move the image translation entry button from the top-right to the bottom-left of each image, and synchronize popup preview and guidance text. Validation: pnpm compile; pnpm test -- tests/imageTranslation.test.ts tests/contentTrustBoundary.test.ts (12 passed); pnpm build; isolated production Edge verification confirmed 8px left/bottom offsets and clean console.