### PR TITLE
fix: keep cancelled full-page segments restored

### DIFF
--- a/entrypoints/main/trans.ts
+++ b/entrypoints/main/trans.ts
@@ -128,6 +128,12 @@ interface FullPageSession {
     lifecycleRetries: WeakMap<Node, FullPageLifecycleRetry>;
     /** Explicit provider/language no-change decisions, scoped to this full-page session. */
     unchangedCandidates: WeakMap<Node, FullPageLifecycleRetry>;
+    /**
+     * Candidate identities explicitly restored by the user during this full-page
+     * session. The source snapshot lets a real host edit clear the tombstone,
+     * while the extension's own restore mutations keep the segment excluded.
+     */
+    userCancelledCandidates: Map<Node, string>;
     /** Candidate keys currently consuming one of the full-page concurrency slots. */
     inFlightCandidates: Map<Node, TranslationCandidate>;
     /**
@@ -810,6 +816,51 @@ function unregisterSessionStatefulTarget(session: FullPageSession | undefined, t
     }
 }
 
+function rememberUserCancelledCandidate(
+    session: FullPageSession,
+    candidate: TranslationCandidate,
+    target: HTMLElement,
+    state: TranslationState,
+): void {
+    const source = normalizeComparableText(state.sourceText || candidateLifecycleSource(candidate));
+    const remember = (node: Node | null | undefined) => {
+        if (node) session.userCancelledCandidates.set(node, source);
+    };
+
+    // Exact candidates use their element as the key. Synthetic inline runs use
+    // the first source node as the key, so retain every captured source node to
+    // survive the segment unwrap performed by restoreTranslation().
+    remember(getTranslationCandidateKey(candidate));
+    if (!candidate.nodes?.length) remember(candidate.element);
+    state.sourceTextNodes?.forEach((node) => remember(node));
+    state.syntheticSourceNodes?.forEach((node) => remember(node));
+    remember(target);
+}
+
+function isUserCancelledCandidate(
+    session: FullPageSession,
+    candidate: TranslationCandidate,
+): boolean {
+    const source = candidateLifecycleSource(candidate);
+    const identities = [
+        getTranslationCandidateKey(candidate),
+        ...(candidate.nodes ?? []),
+    ];
+    let cancelled = false;
+    identities.forEach((identity) => {
+        const cancelledSource = session.userCancelledCandidates.get(identity);
+        if (cancelledSource === undefined) return;
+        if (cancelledSource === source) {
+            cancelled = true;
+        } else {
+            // The host reused the same DOM node for different content. A
+            // previous user cancellation must not suppress the new source.
+            session.userCancelledCandidates.delete(identity);
+        }
+    });
+    return cancelled;
+}
+
 function registerSessionStatefulTarget(
     session: FullPageSession | undefined,
     candidateOwner: HTMLElement,
@@ -903,12 +954,26 @@ async function translateTarget(
     const statefulSession = owner?.active
         ? owner
         : fullPageSession?.active ? fullPageSession : undefined;
-    const existingNode = candidate.nodes?.length ? null : candidate.element;
+    const existingNode = candidate.nodes?.length
+        ? (() => {
+            const firstSourceNode = candidate.nodes?.[0];
+            let current = firstSourceNode?.parentElement ?? null;
+            while (current) {
+                if (current.matches('[data-fr-translation-segment="true"]') &&
+                    getTranslationState(current)) return current;
+                current = current.parentElement;
+            }
+            return null;
+        })()
+        : candidate.element;
     const current = existingNode ? getTranslationState(existingNode) : undefined;
     if (current?.phase === "loading") return {status: "owned"};
     if (current?.phase === "translated") {
         // 滑动触发只对当前鼠标下的新目标翻译，不在移动过程中反复恢复原文。
         if (!slide && existingNode) {
+            if (statefulSession?.active && fullPageSession === statefulSession) {
+                rememberUserCancelledCandidate(statefulSession, candidate, existingNode, current);
+            }
             unregisterSessionStatefulTarget(statefulSession, existingNode);
             restoreTranslation(existingNode);
         }
@@ -1218,6 +1283,22 @@ function drainFullPage(session: FullPageSession): void {
 function scheduleDiscoveredCandidate(session: FullPageSession, candidate: TranslationCandidate): void {
     const target = asHTMLElement(candidate.element);
     if (!session.active || !target || !target.isConnected) return;
+    const key = getTranslationCandidateKey(candidate);
+    if (isUserCancelledCandidate(session, candidate)) {
+        // The restore mutation that follows an explicit user cancellation is
+        // still observed by the full-page session. Remove any stale queue entry
+        // before dropping the rediscovered candidate, otherwise it can be
+        // reintroduced by a delayed visibility callback.
+        const queuedCandidate = session.scheduled.get(key);
+        if (queuedCandidate) {
+            forgetCandidate(session, queuedCandidate);
+        } else if (session.pending.get(key) === candidate) {
+            session.pending.delete(key);
+            removeCandidateObservation(session, key);
+            scheduleFullPageProgressPublish(session);
+        }
+        return;
+    }
     const targetState = getTranslationState(target);
     if (targetState) {
         // Hover can commit this state before the full-page session exists. Add
@@ -1234,8 +1315,6 @@ function scheduleDiscoveredCandidate(session: FullPageSession, candidate: Transl
         // Explicit source/structure mutations restart them through the observer.
         return;
     }
-    const key = getTranslationCandidateKey(candidate);
-
     const unchanged = session.unchangedCandidates.get(key);
     const cappedRetry = session.lifecycleRetries.get(key);
     if (unchanged || (cappedRetry && cappedRetry.attempts > FULL_PAGE_LIFECYCLE_RETRY_LIMIT)) {
@@ -1938,6 +2017,7 @@ function createFullPageSession(root: HTMLElement): FullPageSession {
         statefulAncestorsByTarget: new WeakMap(),
         lifecycleRetries: new WeakMap(),
         unchangedCandidates: new WeakMap(),
+        userCancelledCandidates: new Map(),
         inFlightCandidates: new Map(),
         translationSlotCache: new Map(),
         draining: false,
@@ -1975,6 +2055,7 @@ function disposeFullPageSession(session: FullPageSession): void {
     session.statefulTargetsByAncestor.clear();
     session.statefulAncestorsByTarget = new WeakMap();
     session.inFlightCandidates.clear();
+    session.userCancelledCandidates.clear();
     session.translationSlotCache.clear();
     session.dirtyRoots.clear();
     session.dirtyRootsBroadMode = false;

--- a/entrypoints/utils/model.ts
+++ b/entrypoints/utils/model.ts
@@ -201,7 +201,7 @@ export class Config {
         this.tencentSecretKey = ''; // 腾讯云 Secret Key
         this.azureOpenaiEndpoint = ''; // Azure OpenAI 端点地址
         this.animations = true; // 默认启用动画
-        this.translationProgressPanelEnabled = true; // 默认显示全文翻译进度面板
+        this.translationProgressPanelEnabled = false; // 默认关闭全文翻译进度面板
         this.inputBoxTranslationTrigger = 'disabled'; // 默认关闭输入框翻译
         this.inputBoxTranslationTarget = 'en'; // 默认翻译成英文
         this.deepseekApiType = 'auto'; // DeepSeek 默认自动选择 API 格式
@@ -294,7 +294,7 @@ export function normalizeConfig(value: unknown): Config {
     if (typeof source.translationProgressPanelEnabled !== 'boolean') {
         normalized.translationProgressPanelEnabled = typeof legacyTranslationStatus === 'boolean'
             ? legacyTranslationStatus
-            : true;
+            : false;
     }
     delete (normalized as unknown as Record<string, unknown>).translationStatus;
     // __fluentConfigRevision 只用于 storage 的写入顺序判断，不能进入运行时

--- a/tests/fullPageVisibilityScheduling.test.ts
+++ b/tests/fullPageVisibilityScheduling.test.ts
@@ -9,6 +9,13 @@ const runtime = vi.hoisted(() => ({
         nodes?: readonly Node[];
         adapterId?: string;
     }>,
+    pointCandidate: null as {
+        element: HTMLElement;
+        kind: "content";
+        reason: string;
+        nodes?: readonly Node[];
+        adapterId?: string;
+    } | null,
     requests: vi.fn<(origins: readonly string[]) => Promise<string[]>>(async (origins) =>
         origins.map((origin) => `译:${origin}`),
     ),
@@ -136,7 +143,7 @@ vi.mock("@/entrypoints/translation-core/public", () => {
         parseTranslationSlots: () => null,
         resolveTranslationCandidate: (start: Node | null | undefined) =>
             [...runtime.candidates].reverse().find((candidate) => candidate.element === start),
-        resolveTranslationCandidateAtPoint: () => null,
+        resolveTranslationCandidateAtPoint: () => runtime.pointCandidate,
         selectPreferredTranslationCandidate: (
             existing: {element: HTMLElement; adapterId?: string},
             candidate: {element: HTMLElement; adapterId?: string},
@@ -148,6 +155,7 @@ vi.mock("@/entrypoints/translation-core/public", () => {
 import {
     autoTranslateEnglishPage,
     handleBilingualTranslation,
+    handleTranslation,
     isFullPageTranslationActive,
     restoreOriginalContent,
 } from "@/entrypoints/main/trans";
@@ -228,6 +236,7 @@ describe("全文翻译可见性锚点", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         runtime.candidates = [];
+        runtime.pointCandidate = null;
         runtime.requests.mockReset();
         runtime.requests.mockImplementation(async (origins) => origins.map((origin) => `译:${origin}`));
         runtime.retryCallbacks = [];
@@ -275,6 +284,55 @@ describe("全文翻译可见性锚点", () => {
         restoreOriginalContent();
         expect(isFullPageTranslationActive()).toBe(false);
         expect(states).toEqual(["started", "ended"]);
+    });
+
+    it("全文翻译后按 Ctrl 恢复的单段不会被当前全文会话重新排队", async () => {
+        runtime.config.display = 1;
+        document.body.innerHTML = '<p id="prose">Restore only this paragraph.</p>';
+        const paragraph = document.querySelector<HTMLElement>("#prose")!;
+        const candidate = {element: paragraph, kind: "content" as const, reason: "paragraph"};
+        setLayoutBox(paragraph, 640, 90);
+        runtime.candidates = [candidate];
+        runtime.pointCandidate = candidate;
+
+        autoTranslateEnglishPage();
+        await vi.advanceTimersByTimeAsync(50);
+        TestIntersectionObserver.instances[0]!.emit(paragraph, true);
+        await finishScheduledWork();
+
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+        expect(paragraph.querySelectorAll(".fluent-read-bilingual-content")).toHaveLength(1);
+
+        // This is the same path used by the real Control hover trigger. It
+        // restores the current target while leaving the full-page session alive.
+        handleTranslation(20, 20);
+        await finishScheduledWork();
+
+        expect(isFullPageTranslationActive()).toBe(true);
+        expect(getTranslationState(paragraph)).toBeUndefined();
+        expect(paragraph.textContent).toBe("Restore only this paragraph.");
+        expect(paragraph.querySelectorAll(".fluent-read-bilingual-content")).toHaveLength(0);
+
+        // The browser delivers the extension restore as a mutation. A rescan
+        // must remember the explicit cancellation instead of translating again.
+        TestMutationObserver.instances.at(-1)!.emit([{
+            type: "childList",
+            target: paragraph,
+            addedNodes: [] as unknown as NodeList,
+            removedNodes: [] as unknown as NodeList,
+        } as unknown as MutationRecord]);
+        await finishScheduledWork();
+        expect(runtime.requests).toHaveBeenCalledTimes(1);
+        expect(paragraph.querySelectorAll(".fluent-read-bilingual-content")).toHaveLength(0);
+
+        // The cancellation is scoped to this session; starting a new full-page
+        // session is still allowed to translate the paragraph again.
+        restoreOriginalContent();
+        autoTranslateEnglishPage();
+        await vi.advanceTimersByTimeAsync(50);
+        TestIntersectionObserver.instances.at(-1)!.emit(paragraph, true);
+        await finishScheduledWork();
+        expect(runtime.requests).toHaveBeenCalledTimes(2);
     });
 
     it("候选自身有布局盒时直接观察候选，不改用内部标签", async () => {

--- a/tests/model.test.ts
+++ b/tests/model.test.ts
@@ -174,12 +174,12 @@ describe('全文翻译范围配置', () => {
 });
 
 describe('翻译进度面板配置', () => {
-    it('默认开启，并严格保留布尔设置', () => {
-        expect(new Config().translationProgressPanelEnabled).toBe(true);
-        expect(normalizeConfig({}).translationProgressPanelEnabled).toBe(true);
+    it('默认关闭，并保留用户主动启用的状态', () => {
+        expect(new Config().translationProgressPanelEnabled).toBe(false);
+        expect(normalizeConfig({}).translationProgressPanelEnabled).toBe(false);
         expect(normalizeConfig({translationProgressPanelEnabled: true}).translationProgressPanelEnabled).toBe(true);
         expect(normalizeConfig({translationProgressPanelEnabled: false}).translationProgressPanelEnabled).toBe(false);
-        expect(normalizeConfig({translationProgressPanelEnabled: 'false'}).translationProgressPanelEnabled).toBe(true);
+        expect(normalizeConfig({translationProgressPanelEnabled: 'false'}).translationProgressPanelEnabled).toBe(false);
     });
 
     it('迁移旧 translationStatus 布尔值并移除旧字段', () => {


### PR DESCRIPTION
## 变更\n- 将翻译进度面板默认设为关闭，同时保留用户已有配置\n- 记录当前全文翻译会话中由用户取消的段落，避免 MutationObserver 立即重新识别并翻译\n- 页面原文变化或重新启动全文翻译后，允许该段落再次翻译\n\n## 验证\n- pnpm test -- tests/model.test.ts tests/fullPageVisibilityScheduling.test.ts（93 tests）\n- pnpm compile\n- pnpm build\n- git diff --check\n- 隔离 Edge：默认无进度面板；全文翻译后按 Control 可恢复单段且不会立即重译；新会话可再次翻译