### PR TITLE
fix: remove floating ball settings from popup

### DIFF
--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -230,11 +230,6 @@
           <span><strong>划词翻译</strong><small>{{ selectionSummary }}</small></span>
           <i :class="{ active: config.selectionTranslatorMode !== 'disabled' || config.selectionAreaEnabled }" />
         </button>
-        <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('floating')">
-          <span class="feature-icon blue">◉</span>
-          <span><strong>全文悬浮球</strong><small>{{ config.disableFloatingBall ? '已关闭' : floatingSummary }}</small></span>
-          <i :class="{ active: !config.disableFloatingBall }" />
-        </button>
         <button class="feature-card" type="button" :disabled="!config.on" @click="openDrawer('appearance')">
           <span class="feature-icon amber">Aa</span>
           <span><strong>译文显示</strong><small>{{ displaySummary }}</small></span>
@@ -427,29 +422,6 @@
         </div>
       </div>
 
-      <div v-else-if="activeDrawer === 'floating'" class="drawer-content">
-        <div class="setting-row">
-          <span><strong>启用全文翻译悬浮球</strong><small>在页面边缘快速翻译或恢复全文</small></span>
-          <button class="switch compact" type="button" role="switch" :aria-checked="!config.disableFloatingBall" aria-label="启用或关闭全文翻译悬浮球" @click="setFloatingEnabled(config.disableFloatingBall)"><i /></button>
-        </div>
-        <div class="choice-block">
-          <label>悬浮位置</label>
-          <div class="chips two">
-            <button type="button" :class="{ selected: config.floatingBallPosition === 'left' }" @click="config.floatingBallPosition = 'left'">页面左侧</button>
-            <button type="button" :class="{ selected: config.floatingBallPosition === 'right' }" @click="config.floatingBallPosition = 'right'">页面右侧</button>
-          </div>
-        </div>
-        <label class="select-row">
-          <span><strong>全文翻译快捷键</strong><small>无需点击悬浮球即可切换</small></span>
-          <select v-model="config.floatingBallHotkey" @change="handleFloatingHotkeyChange">
-            <option v-for="item in options.floatingBallHotkeys" :key="item.value" :value="item.value">{{ item.label }}</option>
-          </select>
-        </label>
-        <button v-if="config.floatingBallHotkey === 'custom'" class="secondary-action" type="button" @click="showCustomHotkeyDialog = true">
-          {{ config.customFloatingBallHotkey ? `当前：${config.customFloatingBallHotkey}` : '录制自定义快捷键' }}
-        </button>
-      </div>
-
       <div v-else-if="activeDrawer === 'image'" class="drawer-content">
         <div class="image-translation-preview">
           <div class="image-translation-preview-art"><span>文字</span><b>文</b></div>
@@ -505,7 +477,6 @@
       <button v-if="activeDrawer !== 'image'" class="drawer-settings-link" type="button" @click="openOptions(drawerSettingsSection[activeDrawer])">在完整设置中查看全部选项 ↗</button>
     </el-drawer>
 
-    <CustomHotkeyInput v-model="showCustomHotkeyDialog" :current-value="config.customFloatingBallHotkey" @confirm="confirmFloatingHotkey" @cancel="cancelFloatingHotkey" />
     <CustomHotkeyInput v-model="showCustomMouseHotkeyDialog" :current-value="config.customHotkey" @confirm="confirmMouseHotkey" @cancel="cancelMouseHotkey" />
     <CustomHotkeyInput v-model="showCustomSelectionHotkeyDialog" :current-value="config.customSelectionTranslatorHotkey" @confirm="confirmSelectionHotkey" @cancel="cancelSelectionHotkey" />
   </main>
@@ -537,7 +508,7 @@ import { SELECTION_TTS_VOICE_OPTIONS } from '@/entrypoints/utils/selectionTtsCon
 import { getSiteBaseDomain } from '@/entrypoints/utils/siteRules';
 import ServiceIcon from '@/components/ServiceIcon.vue';
 
-type DrawerName = 'hover' | 'selection' | 'floating' | 'appearance' | 'image' | 'video';
+type DrawerName = 'hover' | 'selection' | 'appearance' | 'image' | 'video';
 type SettingsSection = 'settings-general' | 'settings-shortcuts' | 'settings-services' | 'settings-sites' | 'settings-video' | 'settings-vocabulary';
 const CustomHotkeyInput = defineAsyncComponent(() => import('@/components/CustomHotkeyInput.vue'));
 const version = process.env.VUE_APP_VERSION;
@@ -553,7 +524,6 @@ const clearingCache = ref(false);
 const donationVisible = ref(false);
 const notice = ref('');
 const noticeType = ref<'success' | 'error'>('success');
-const showCustomHotkeyDialog = ref(false);
 const showCustomMouseHotkeyDialog = ref(false);
 const showCustomSelectionHotkeyDialog = ref(false);
 const servicePicker = ref<HTMLElement | null>(null);
@@ -568,7 +538,6 @@ const darkMode = window.matchMedia('(prefers-color-scheme: dark)');
 const drawerSettingsSection: Record<DrawerName, SettingsSection> = {
   hover: 'settings-shortcuts',
   selection: 'settings-shortcuts',
-  floating: 'settings-shortcuts',
   appearance: 'settings-general',
   image: 'settings-general',
   video: 'settings-video',
@@ -631,15 +600,13 @@ const selectionSummary = computed(() => {
   if (!config.value.selectionAreaEnabled) return selectionTextSummary;
   return textSummary === '已关闭' ? '圈选翻译已启用' : `${selectionTextSummary} · 圈选翻译`;
 });
-const floatingSummary = computed(() => `${config.value.floatingBallPosition === 'left' ? '页面左侧' : '页面右侧'} · ${fullPageHotkey.value}`);
 const displaySummary = computed(() => config.value.display === 1 ? `双语 · ${styleLabel.value}` : '仅显示译文');
 const imageTranslationSummary = computed(() => config.value.disableImageTranslator ? '已关闭' : '悬停图片');
 const videoSummary = computed(() => config.value.videoTranslationEnabled ? `${videoServiceLabel.value} · YouTube` : '点击开启 · YouTube');
-const drawerTitle = computed(() => ({ hover: '鼠标悬停翻译设置', selection: '划词翻译设置', floating: '全文悬浮球设置', appearance: '译文显示设置', image: '图片翻译设置', video: '视频字幕设置' }[activeDrawer.value]));
+const drawerTitle = computed(() => ({ hover: '鼠标悬停翻译设置', selection: '划词翻译设置', appearance: '译文显示设置', image: '图片翻译设置', video: '视频字幕设置' }[activeDrawer.value]));
 const drawerDescription = computed(() => ({
   hover: '把鼠标停在文本上，用轻量快捷键获取即时译文。',
   selection: '选中文字或圈选页面区域，按你的偏好获取译文。',
-  floating: '把全文翻译入口固定在最顺手的位置。',
   appearance: '调整双语布局、译文样式与界面主题。',
   image: '把鼠标移到图片上，从图片左下角打开翻译入口。',
   video: '在 YouTube 播放器中显示实时字幕译文。',
@@ -945,10 +912,6 @@ function setAreaEnabled(enabled: boolean) {
   config.value.selectionAreaEnabled = enabled;
   void broadcast({ type: 'toggleSelectionAreaTranslator', isEnabled: enabled });
 }
-function setFloatingEnabled(enabled: boolean) {
-  config.value.disableFloatingBall = !enabled;
-  void broadcast({ type: 'toggleFloatingBall', isEnabled: enabled });
-}
 function setImageTranslatorEnabled(enabled: boolean) {
   config.value.disableImageTranslator = !enabled;
   void broadcast({ type: 'toggleImageTranslator', isEnabled: enabled });
@@ -956,11 +919,6 @@ function setImageTranslatorEnabled(enabled: boolean) {
 function setVideoTranslationEnabled(enabled: boolean) {
   config.value.videoTranslationEnabled = enabled;
 }
-function handleFloatingHotkeyChange() {
-  if (config.value.floatingBallHotkey === 'custom' && !config.value.customFloatingBallHotkey) showCustomHotkeyDialog.value = true;
-}
-function confirmFloatingHotkey(hotkey: string) { config.value.customFloatingBallHotkey = hotkey; config.value.floatingBallHotkey = 'custom'; }
-function cancelFloatingHotkey() { if (!config.value.customFloatingBallHotkey) config.value.floatingBallHotkey = 'Alt+T'; }
 function confirmMouseHotkey(hotkey: string) { config.value.customHotkey = hotkey; config.value.hotkey = 'custom'; }
 function cancelMouseHotkey() { if (!config.value.customHotkey) config.value.hotkey = 'Control'; }
 function confirmSelectionHotkey(hotkey: string) {

--- a/scripts/run-document-translation-test.cjs
+++ b/scripts/run-document-translation-test.cjs
@@ -172,6 +172,7 @@ async function main() {
     result.extensionId = extensionId;
     const documentUrl = `chrome-extension://${extensionId}/document.html`;
     const popupUrl = `chrome-extension://${extensionId}/popup.html`;
+    const optionsUrl = `chrome-extension://${extensionId}/options.html`;
 
     const page = await newPageWithoutForeground(context, args.timeout);
     captureErrors(page, 'document', errors);
@@ -216,7 +217,7 @@ async function main() {
         if (pdfPageRows !== pdfPageCount || pdfPageRows < 2) {
           fail(`PDF 阅读器必须一次渲染全部页面并纵向排列：页面行 ${pdfPageRows}，页数 ${pdfPageCount}`);
         }
-        const pdfScroll = await page.locator('[data-pdf-scroll]').evaluate((element) => ({
+        pdfScroll = await page.locator('[data-pdf-scroll]').evaluate((element) => ({
           rows: element.querySelectorAll('.pdf-page-row').length,
           documentVerticalOverflow: document.documentElement.scrollHeight > document.documentElement.clientHeight,
           horizontalOverflow: element.scrollWidth > element.clientWidth,
@@ -364,9 +365,44 @@ async function main() {
     })));
     const videoIndex = featureOrder.findIndex((item) => item.text.includes('视频字幕'));
     const documentIndex = featureOrder.findIndex((item) => item.feature === 'document-translation');
+    if (featureOrder.length !== 6) fail(`Popup 快捷功能卡应为 6 个，实际为 ${featureOrder.length}`);
+    if (featureOrder.some((item) => item.text.includes('全文悬浮球'))) fail('Popup 不应显示全文翻译悬浮球设置入口');
+    if (await popup.getByRole('switch', {name: '启用或关闭全文翻译悬浮球'}).count() !== 0) {
+      fail('Popup 不应保留全文翻译悬浮球设置抽屉');
+    }
     if (videoIndex < 0 || documentIndex !== videoIndex + 1) fail('文档翻译卡片必须紧跟在视频字幕卡片下面');
     if (!featureOrder[documentIndex].text.includes('Beta 测试')) fail('文档翻译卡片必须标注 Beta 测试');
-    result.assertions.popupDocumentBeta = 'passed';
+    result.assertions.popupFeatures = {
+      count: featureOrder.length,
+      floatingBallSettingsHidden: true,
+      documentBetaAfterVideo: true,
+    };
+
+    const optionsPage = await newPageWithoutForeground(context, args.timeout);
+    captureErrors(optionsPage, 'options', errors);
+    await optionsPage.goto(`${optionsUrl}#settings-advanced`, {waitUntil: 'domcontentloaded', timeout: args.timeout});
+    const floatingBallRow = optionsPage.locator('.settings-control-row').filter({hasText: '全文翻译悬浮球'});
+    await floatingBallRow.waitFor({state: 'visible', timeout: args.timeout});
+    const floatingBallControlCount = await floatingBallRow.getByRole('switch').count();
+    if (floatingBallControlCount < 1) {
+      fail('完整设置页缺少全文翻译悬浮球开关');
+    }
+    await optionsPage.screenshot({path: path.join(artifactsDir, 'options-floating-ball-switch.png'), fullPage: true});
+    result.screenshots.push(path.join(artifactsDir, 'options-floating-ball-switch.png'));
+    await optionsPage.getByRole('button', {name: /交互与快捷键/u}).click();
+    const fullPageHotkeyRow = optionsPage.locator('.settings-control-row').filter({hasText: '全文翻译快捷键'});
+    await fullPageHotkeyRow.waitFor({state: 'visible', timeout: args.timeout});
+    const fullPageHotkeyControlCount = await fullPageHotkeyRow.getByRole('combobox').count();
+    if (fullPageHotkeyControlCount < 1) {
+      fail('完整设置页缺少全文翻译快捷键控件');
+    }
+    result.assertions.optionsFloatingBallSettings = {
+      switchControls: floatingBallControlCount,
+      hotkeyControls: fullPageHotkeyControlCount,
+    };
+    await optionsPage.screenshot({path: path.join(artifactsDir, 'options-floating-ball-hotkey.png'), fullPage: true});
+    result.screenshots.push(path.join(artifactsDir, 'options-floating-ball-hotkey.png'));
+    await optionsPage.close();
     const openedPagePromise = context.waitForEvent('page', {timeout: args.timeout});
     await popup.getByRole('button', {name: '打开文档翻译'}).click();
     const openedPage = await openedPagePromise;

--- a/scripts/run-video-subtitle-test.cjs
+++ b/scripts/run-video-subtitle-test.cjs
@@ -70,12 +70,13 @@ async function main() {
         featurePresent: Boolean(document.querySelector('[data-feature="video-subtitle"]')),
         featureCount: document.querySelectorAll('.feature-card').length,
         imageFeaturePresent: [...document.querySelectorAll('.feature-card')].some((node) => node.textContent?.includes('图片翻译')),
+        floatingFeaturePresent: [...document.querySelectorAll('.feature-card')].some((node) => node.textContent?.includes('全文悬浮球')),
         videoBetaLabel: document.querySelector('[data-feature="video-subtitle"] .beta-badge')?.textContent?.trim(),
         popupHeight: document.body.scrollHeight,
         config: stored.config,
       };
     });
-    if (popupState.featureCount !== 6 || !popupState.imageFeaturePresent || popupState.videoBetaLabel !== 'Beta 测试' || popupState.config.videoService !== 'microsoft') {
+    if (popupState.featureCount !== 6 || !popupState.imageFeaturePresent || popupState.floatingFeaturePresent || popupState.videoBetaLabel !== 'Beta 测试' || popupState.config.videoService !== 'microsoft') {
       throw new Error(`Popup 快捷功能卡校验失败：数量=${popupState.featureCount}，图片翻译=${popupState.imageFeaturePresent}`);
     }
     await popup.locator('[data-feature="video-subtitle"]').click();

--- a/tests/popupFeatureVisibility.test.ts
+++ b/tests/popupFeatureVisibility.test.ts
@@ -1,0 +1,28 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+function source(path: string): string {
+    return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('popup feature visibility', () => {
+    it('keeps full-page floating-ball settings out of the popup', () => {
+        const popup = source('entrypoints/popup/App.vue');
+
+        expect(popup).not.toContain("openDrawer('floating')");
+        expect(popup).not.toContain("activeDrawer === 'floating'");
+        expect(popup).not.toContain('全文悬浮球');
+        expect(popup).not.toContain('启用或关闭全文翻译悬浮球');
+        expect(popup.match(/class="feature-card\b/gu)).toHaveLength(6);
+    });
+
+    it('keeps full-page floating-ball and hotkey controls in the options page', () => {
+        const options = source('components/Main.vue');
+
+        expect(options).toContain('v-model="floatingBallEnabled"');
+        expect(options).toContain('aria-label="全文翻译悬浮球"');
+        expect(options).toContain('v-model="config.floatingBallHotkey"');
+        expect(options).toContain('aria-label="全文翻译快捷键"');
+    });
+});


### PR DESCRIPTION
## 概要

- 从 popup 删除“全文悬浮球”快捷功能卡、设置抽屉与仅供该抽屉使用的处理逻辑
- 保留 popup 的全文翻译按钮、快捷键提示以及总开关对悬浮球运行状态的同步
- 保留完整设置页中的“全文翻译悬浮球”开关与“全文翻译快捷键”配置
- 增加静态回归和生产浏览器断言，防止悬浮球设置重新出现在 popup
- 加强文档翻译回归报告，记录 PDF 全页纵向滚动状态和 popup/options 可见性

## 文档与 PDF 验证

- 文档翻译继续使用浏览器原生的 PDF.js（解析/渲染）与 pdf-lib（双语 PDF 导出），未内置 BabelDOC
- 12 个示例格式均通过真实生产 Edge 加载：PDF、EPUB、DOCX、HTML、TXT、Markdown、SRT、VTT、ASS、SSA、LRC、JSON
- PDF 两页全部一次性渲染并纵向滚动，原页/译页横向对照，无左右翻页控件、无横向溢出
- 导出双语 PDF 为 2 页横向对照版式，并通过 Poppler 逐页渲染检查

## 验证

- `pnpm compile`
- `pnpm test:document`（5 个文件，43 个测试）
- `pnpm test`（60 个文件，645 个测试）
- `pnpm build`
- `pnpm build:firefox`
- 隔离生产 Edge：12 个格式、popup 6 张功能卡、options 开关/快捷键、0 控制台错误
- `git diff --check`

这是已合并文档翻译 PR #321 的后续修正。此 PR 保持 Draft，不执行合并。
