### PR TITLE
fix: repair recent regressions and expand test coverage

### DIFF
--- a/components/SelectionTranslator.vue
+++ b/components/SelectionTranslator.vue
@@ -112,8 +112,8 @@ import { translateText } from '@/entrypoints/utils/translateApi';
 import { detectlang } from '@/entrypoints/utils/common';
 import { matchesConfiguredHotkey, matchesModifierOnlyHotkey, resolveConfiguredHotkey } from '@/entrypoints/utils/hotkey';
 import { isSingleEnglishWord, normalizeEnglishWord, type WordCardData, type WordPronunciation } from '@/entrypoints/utils/wordDictionary';
-import { calculateSelectionPopupPosition, chooseSelectionRect, getSelectionPresentationDelayRemaining, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, reconcileSelectionPresentation, resolveSelectionDictionaryFallback, resolveSelectionVocabularyAnswer, shouldIgnoreSelection, summarizeSelectionContext, type SelectionAnswerCandidate, type SelectionContentRequest, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
-import { VOCABULARY_BOOK_MESSAGE, type VocabularyBookResponse, type VocabularyEntry } from '@/entrypoints/utils/vocabularyBookProtocol';
+import { calculateSelectionPopupPosition, chooseSelectionRect, getSelectionPresentationDelayRemaining, isSameLanguage, normalizeSelectionText, normalizeSpeechLanguage, reconcileSelectionPresentation, resolveSelectionDictionaryFallback, resolveSelectionVocabularyAnswer, SelectionRequestTokenGate, shouldIgnoreSelection, summarizeSelectionContext, type SelectionAnswerCandidate, type SelectionContentRequest, type SelectionRect } from '@/entrypoints/utils/selectionTranslatorCore';
+import { VOCABULARY_BOOK_CHANGED_MESSAGE, VOCABULARY_BOOK_MESSAGE, type VocabularyBookResponse, type VocabularyEntry } from '@/entrypoints/utils/vocabularyBookProtocol';
 
 type SelectionTrigger = 'direct' | 'icon' | 'dot' | 'shortcut';
 type AudioKind = 'source' | 'translation' | 'word';
@@ -159,7 +159,8 @@ let translationAbortController: AbortController | null = null;
 let translationRequestId = 0;
 let wordLookupRequestId = 0;
 let copyTimer: number | null = null;
-let vocabularyRequestId = 0;
+const vocabularyLookupGate = new SelectionRequestTokenGate();
+const vocabularySaveGate = new SelectionRequestTokenGate();
 let contentRequestGeneration = 0;
 let noticeTimer: number | null = null;
 let lastTrustedSelectionInteractionAt = 0;
@@ -327,6 +328,10 @@ function resetSelectionContentState(clearSelectionText = false): void {
   isWordCardLoading.value = false;
   wordCardError.value = '';
   showChineseSupport.value = true;
+  vocabularyLookupGate.invalidate();
+  vocabularySaveGate.invalidate();
+  isVocabularySaved.value = false;
+  vocabularyBusy.value = false;
   if (clearSelectionText) selectedText.value = '';
   stopAudio();
 }
@@ -484,7 +489,7 @@ function requestSelectionContent(text: string): void {
   void requestTranslation(request);
   if (shouldUseWordCard(text)) {
     void requestWordCard(request);
-    void refreshVocabularySaved(text);
+    void refreshVocabularySaved(request);
   }
   else {
     wordLookupRequestId += 1;
@@ -492,22 +497,25 @@ function requestSelectionContent(text: string): void {
     isWordCardLoading.value = false;
     wordCardError.value = '';
     dictionaryAnswer.value = null;
-    vocabularyRequestId += 1;
     isVocabularySaved.value = false;
     vocabularyBusy.value = false;
   }
 }
 
-async function refreshVocabularySaved(text: string): Promise<void> {
-  const word = normalizeEnglishWord(text);
-  if (!word || !config.vocabularyBookEnabled || isPrivateContext) return;
-  const requestId = ++vocabularyRequestId;
+async function refreshVocabularySaved(request: SelectionContentRequest): Promise<void> {
+  const word = normalizeEnglishWord(request.text);
+  if (!word || !config.vocabularyBookEnabled || isPrivateContext) {
+    vocabularyLookupGate.invalidate();
+    isVocabularySaved.value = false;
+    return;
+  }
+  const requestToken = vocabularyLookupGate.begin();
   try {
     const response = await browser.runtime.sendMessage({type: VOCABULARY_BOOK_MESSAGE, action: 'getByTerm', term: word, sourceLanguage: 'en'}) as VocabularyBookResponse<VocabularyEntry | null>;
-    if (requestId !== vocabularyRequestId || snapshot.value?.text !== text) return;
+    if (!vocabularyLookupGate.isCurrent(requestToken) || !isContentRequestCurrent(request)) return;
     isVocabularySaved.value = response?.success === true && Boolean(response.data);
   } catch {
-    if (requestId === vocabularyRequestId) isVocabularySaved.value = false;
+    if (vocabularyLookupGate.isCurrent(requestToken)) isVocabularySaved.value = false;
   }
 }
 
@@ -542,8 +550,9 @@ async function saveVocabularyEntry(event: MouseEvent): Promise<void> {
   const contentRequest = currentContentRequest.value;
   const answer = vocabularyAnswer.value;
   if (!contentRequest || !selectedWord.value || !answer || vocabularyBusy.value || isPrivateContext) return;
+  const wasSaved = isVocabularySaved.value;
   vocabularyBusy.value = true;
-  const requestId = ++vocabularyRequestId;
+  const requestToken = vocabularySaveGate.begin();
   try {
     const response = await browser.runtime.sendMessage({
       type: VOCABULARY_BOOK_MESSAGE,
@@ -558,15 +567,14 @@ async function saveVocabularyEntry(event: MouseEvent): Promise<void> {
         context: {text: selectionContextText(), sourceUrl: pageSourceUrl(), pageTitle: document.title, capturedAt: Date.now()},
       },
     }) as VocabularyBookResponse<VocabularyEntry>;
-    if (requestId !== vocabularyRequestId || !isContentRequestCurrent(contentRequest)) return;
+    if (!vocabularySaveGate.isCurrent(requestToken) || !isContentRequestCurrent(contentRequest)) return;
     if (!response?.success || !response.data) throw new Error(response?.success ? '保存失败' : response?.error?.message || '保存失败');
-    const wasSaved = isVocabularySaved.value;
     isVocabularySaved.value = true;
     showNotice(wasSaved ? '已更新当前阅读上下文' : '已加入单词本', 'open-vocabulary');
   } catch (cause) {
-    if (requestId === vocabularyRequestId) showNotice(cause instanceof Error ? `保存失败：${cause.message}` : '保存失败，未写入单词本');
+    if (vocabularySaveGate.isCurrent(requestToken)) showNotice(cause instanceof Error ? `保存失败：${cause.message}` : '保存失败，未写入单词本');
   } finally {
-    if (requestId === vocabularyRequestId) vocabularyBusy.value = false;
+    if (vocabularySaveGate.isCurrent(requestToken)) vocabularyBusy.value = false;
   }
 }
 
@@ -700,8 +708,8 @@ function releasePageAudio(): void {
 }
 
 function stopAudio(notifyRemote = true): void {
-  const stoppedRemoteRequestId = remoteAudioRequestId;
-  const shouldNotifyRemote = notifyRemote && remoteAudioActive && stoppedRemoteRequestId !== null;
+  const stoppedRemoteRequestId = remoteAudioRequestId ?? pendingRemoteAudioRequestId;
+  const shouldNotifyRemote = notifyRemote && stoppedRemoteRequestId !== null;
   remoteAudioActive = false;
   remoteAudioRequestId = null;
   pendingRemoteAudioRequestId = null;
@@ -943,7 +951,6 @@ function hideAll(): void {
   cancelSelectionPresentation();
   selectionSettledAt = 0;
   resetSelectionContentState(true);
-  vocabularyRequestId += 1;
   showIndicator.value = false;
   showTooltip.value = false;
   snapshot.value = null;
@@ -1066,11 +1073,19 @@ function handleSelectionSettingsMessage(message: unknown): undefined {
   return undefined;
 }
 
+function handleVocabularyBookChanged(message: unknown): undefined {
+  if (!message || typeof message !== 'object' || (message as {type?: unknown}).type !== VOCABULARY_BOOK_CHANGED_MESSAGE) return undefined;
+  const request = currentContentRequest.value;
+  if (request && isWordSelection.value) void refreshVocabularySaved(request);
+  return undefined;
+}
+
 onMounted(() => {
   updateTheme();
   systemThemeMedia = window.matchMedia('(prefers-color-scheme: dark)');
   systemThemeMedia.addEventListener('change', updateTheme);
   browser.runtime.onMessage.addListener(handleSelectionSettingsMessage);
+  browser.runtime.onMessage.addListener(handleVocabularyBookChanged);
   unsubscribeConfig = subscribeConfig(() => { selectionConfigVersion.value += 1; });
   document.addEventListener('pointerdown', handlePointerDown, true);
   document.addEventListener('pointerup', handlePointerUp, true);
@@ -1137,7 +1152,8 @@ onMounted(() => {
       if (showTooltip.value) void requestSelectionContent(snapshot.value.text);
     }
     if (previousSettings && nextSettings[9] !== previousSettings[9] && showTooltip.value && isWordSelection.value) {
-      void refreshVocabularySaved(snapshot.value.text);
+      const request = currentContentRequest.value;
+      if (request) void refreshVocabularySaved(request);
     }
   });
 });
@@ -1151,6 +1167,7 @@ onBeforeUnmount(() => {
   if (noticeTimer !== null) window.clearTimeout(noticeTimer);
   systemThemeMedia?.removeEventListener('change', updateTheme);
   browser.runtime.onMessage.removeListener(handleSelectionSettingsMessage);
+  browser.runtime.onMessage.removeListener(handleVocabularyBookChanged);
   unsubscribeConfig?.();
   unsubscribeConfig = null;
   tooltipResizeObserver?.disconnect();

--- a/components/VocabularyBook.vue
+++ b/components/VocabularyBook.vue
@@ -43,8 +43,8 @@
 
       <section v-if="reviewActive" class="review-shell" aria-live="polite">
         <header class="review-header">
-          <div><span class="eyebrow">主动回忆</span><strong>{{ reviewPosition }} / {{ reviewQueue.length }}</strong></div>
-          <button type="button" @click="finishReview">退出本轮</button>
+          <div><span class="eyebrow">主动回忆</span><strong>{{ reviewPosition }} / {{ reviewTotal }}</strong></div>
+          <button type="button" :disabled="actionBusy" @click="finishReview">退出本轮</button>
         </header>
 
         <div v-if="currentReview" class="review-card">
@@ -79,7 +79,7 @@
 
       <template v-else>
         <section class="primary-actions">
-          <button class="start-review" type="button" :disabled="loading || reviewPlan.length === 0" @click="startReview">
+          <button class="start-review" type="button" :disabled="loading || actionBusy || reviewPlan.length === 0" @click="startReview">
             <span aria-hidden="true">▶</span>
             <span><strong>{{ reviewPlan.length ? `开始复习 ${reviewPlan.length} 个` : '今天没有到期单词' }}</strong><small>先回忆，再用“忘了 / 记得”更新掌握程度</small></span>
           </button>
@@ -171,6 +171,11 @@ import {
 import {
   buildAnkiTsv,
   buildVocabularyCloze,
+  advanceVocabularyReviewSession,
+  createVocabularyLifecycleGuard,
+  createVocabularyReviewSession,
+  reconcileVocabularyReviewSession,
+  vocabularyReviewSessionProgress,
   VOCABULARY_BOOK_CHANGED_MESSAGE,
   VOCABULARY_BOOK_EXPORT_FORMAT,
   VOCABULARY_BOOK_EXPORT_VERSION,
@@ -184,6 +189,7 @@ import {
   type VocabularyImportResult,
   type VocabularyRemovalSnapshot,
   type VocabularyReviewResult,
+  type VocabularyReviewSessionState,
   type VocabularyScheduledReviewRating,
   type VocabularyStatus,
   vocabularyImportNeedsConfirmation,
@@ -215,6 +221,7 @@ const toastMessage = ref('');
 // Keep the structured-clone snapshot raw so browser.runtime.sendMessage never receives a Vue Proxy.
 const undoExport = shallowRef<VocabularyBookExport | null>(null);
 const currentTime = ref(Date.now());
+const lifecycle = createVocabularyLifecycleGuard();
 let toastTimer: number | null = null;
 let timeRefreshTimer: number | null = null;
 let darkMedia: MediaQueryList | null = null;
@@ -223,8 +230,10 @@ let completedLoadGeneration = 0;
 let loadLoopPromise: Promise<void> | null = null;
 
 const reviewActive = computed(() => reviewStarted.value);
-const currentReview = computed(() => reviewQueue.value[reviewIndex.value] || null);
-const reviewPosition = computed(() => Math.min(reviewIndex.value + 1, reviewQueue.value.length));
+const reviewSessionProgress = computed(() => vocabularyReviewSessionProgress(reviewSessionState()));
+const currentReview = computed(() => reviewSessionProgress.value.current);
+const reviewTotal = computed(() => reviewSessionProgress.value.total);
+const reviewPosition = computed(() => reviewSessionProgress.value.position);
 const dueEntries = computed(() => entries.value
   .filter(entry => entry.nextReviewAt !== null && entry.nextReviewAt <= currentTime.value)
   .sort((left, right) => (left.nextReviewAt || 0) - (right.nextReviewAt || 0)));
@@ -287,6 +296,7 @@ function applyTheme(): void {
 function scheduleTimeRefresh(): void {
   if (timeRefreshTimer !== null) window.clearTimeout(timeRefreshTimer);
   timeRefreshTimer = null;
+  if (!lifecycle.isActive()) return;
   const timestamp = Date.now();
   currentTime.value = timestamp;
   if (document.visibilityState === 'hidden') return;
@@ -302,11 +312,13 @@ function scheduleTimeRefresh(): void {
 }
 
 function handleVisibilityChange(): void {
+  if (!lifecycle.isActive()) return;
   scheduleTimeRefresh();
   if (document.visibilityState === 'visible') void loadEntries();
 }
 
 async function loadEntries(): Promise<void> {
+  if (!lifecycle.isActive()) return;
   loadRequestGeneration += 1;
   if (loadLoopPromise) return loadLoopPromise;
   loadLoopPromise = runLoadEntriesLoop().finally(() => { loadLoopPromise = null; });
@@ -314,19 +326,21 @@ async function loadEntries(): Promise<void> {
 }
 
 async function runLoadEntriesLoop(): Promise<void> {
+  if (!lifecycle.isActive()) return;
   loading.value = true;
   loadError.value = '';
   try {
-    while (completedLoadGeneration < loadRequestGeneration) {
+    while (lifecycle.isActive() && completedLoadGeneration < loadRequestGeneration) {
       const generation = loadRequestGeneration;
       try {
         const nextEntries = await requestVocabulary<VocabularyEntry[]>({ type: VOCABULARY_BOOK_MESSAGE, action: 'list' });
-        if (generation === loadRequestGeneration) {
+        if (lifecycle.isActive() && generation === loadRequestGeneration) {
           entries.value = nextEntries;
           loadError.value = '';
+          reconcileActiveReviewQueue();
         }
       } catch (cause) {
-        if (generation === loadRequestGeneration) {
+        if (lifecycle.isActive() && generation === loadRequestGeneration) {
           loadError.value = cause instanceof Error ? cause.message : '无法读取本地单词本';
         }
       } finally {
@@ -334,8 +348,10 @@ async function runLoadEntriesLoop(): Promise<void> {
       }
     }
   } finally {
-    loading.value = false;
-    scheduleTimeRefresh();
+    if (lifecycle.isActive()) {
+      loading.value = false;
+      scheduleTimeRefresh();
+    }
   }
 }
 
@@ -364,19 +380,38 @@ function replaceEntry(next: VocabularyEntry): void {
   scheduleTimeRefresh();
 }
 
+function reviewSessionState(): VocabularyReviewSessionState {
+  return {
+    queue: reviewQueue.value,
+    completed: reviewIndex.value,
+    answerVisible: reviewAnswerVisible.value,
+  };
+}
+
+function applyReviewSession(session: VocabularyReviewSessionState): void {
+  reviewQueue.value = session.queue;
+  reviewIndex.value = session.completed;
+  reviewAnswerVisible.value = session.answerVisible;
+}
+
+function reconcileActiveReviewQueue(): void {
+  if (!reviewActive.value || actionBusy.value) return;
+  applyReviewSession(reconcileVocabularyReviewSession(
+    reviewSessionState(),
+    entries.value,
+    Date.now(),
+  ));
+}
+
 function startReview(): void {
-  reviewQueue.value = [...reviewPlan.value];
-  reviewIndex.value = 0;
-  reviewAnswerVisible.value = false;
+  applyReviewSession(createVocabularyReviewSession(reviewPlan.value));
   reviewStats.value = { reviewed: 0, good: 0, again: 0 };
   reviewStarted.value = reviewQueue.value.length > 0;
 }
 
 function finishReview(): void {
   reviewStarted.value = false;
-  reviewQueue.value = [];
-  reviewIndex.value = 0;
-  reviewAnswerVisible.value = false;
+  applyReviewSession(createVocabularyReviewSession([]));
 }
 
 async function rateReview(rating: VocabularyScheduledReviewRating): Promise<void> {
@@ -393,12 +428,16 @@ async function rateReview(rating: VocabularyScheduledReviewRating): Promise<void
     replaceEntry(result.entry);
     reviewStats.value.reviewed += 1;
     reviewStats.value[rating] += 1;
-    reviewIndex.value += 1;
-    reviewAnswerVisible.value = false;
+    applyReviewSession(advanceVocabularyReviewSession(reviewSessionState(), entry.id));
   } catch (cause) {
     showToast(cause instanceof Error ? cause.message : '复习记录保存失败');
   } finally {
-    actionBusy.value = false;
+    try {
+      await loadEntries();
+    } finally {
+      actionBusy.value = false;
+      reconcileActiveReviewQueue();
+    }
   }
 }
 
@@ -563,6 +602,7 @@ function downloadFile(name: string, body: string, type: string): void {
   window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 function showToast(message: string, keepUndo = false): void {
+  if (!lifecycle.isActive()) return;
   toastMessage.value = message;
   if (!keepUndo) undoExport.value = null;
   if (toastTimer !== null) window.clearTimeout(toastTimer);
@@ -570,11 +610,11 @@ function showToast(message: string, keepUndo = false): void {
 }
 
 function handleBookChanged(message: unknown): undefined {
-  if ((message as VocabularyBookChangedMessage)?.type === VOCABULARY_BOOK_CHANGED_MESSAGE) void loadEntries();
+  if (lifecycle.isActive() && (message as VocabularyBookChangedMessage)?.type === VOCABULARY_BOOK_CHANGED_MESSAGE) void loadEntries();
   return undefined;
 }
 function handleReviewKeyboard(event: KeyboardEvent): void {
-  if (!reviewActive.value || actionBusy.value) return;
+  if (!lifecycle.isActive() || !reviewActive.value || actionBusy.value) return;
   const target = event.target as HTMLElement | null;
   if (target?.matches('input, textarea, select, button, a')) return;
   if (event.key === 'Escape') { event.preventDefault(); finishReview(); return; }
@@ -590,24 +630,26 @@ let unsubscribeConfig: (() => void) | null = null;
 onMounted(async () => {
   darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
   darkMedia.addEventListener('change', applyTheme);
-  await configReady;
-  betaEnabled.value = runtimeConfig.vocabularyBookEnabled;
-  selectionTranslatorEnabled.value = runtimeConfig.selectionTranslatorMode !== 'disabled';
-  targetLanguageKey.value = normalizeLanguageKey(runtimeConfig.to);
-  applyTheme();
-  unsubscribeConfig = subscribeConfig(next => {
-    betaEnabled.value = next.vocabularyBookEnabled;
-    selectionTranslatorEnabled.value = next.selectionTranslatorMode !== 'disabled';
-    targetLanguageKey.value = normalizeLanguageKey(next.to);
+  await lifecycle.runAfterReady(configReady, async () => {
+    betaEnabled.value = runtimeConfig.vocabularyBookEnabled;
+    selectionTranslatorEnabled.value = runtimeConfig.selectionTranslatorMode !== 'disabled';
+    targetLanguageKey.value = normalizeLanguageKey(runtimeConfig.to);
     applyTheme();
+    unsubscribeConfig = subscribeConfig(next => {
+      betaEnabled.value = next.vocabularyBookEnabled;
+      selectionTranslatorEnabled.value = next.selectionTranslatorMode !== 'disabled';
+      targetLanguageKey.value = normalizeLanguageKey(next.to);
+      applyTheme();
+    });
+    browser.runtime.onMessage.addListener(handleBookChanged);
+    window.addEventListener('keydown', handleReviewKeyboard);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    await loadEntries();
   });
-  browser.runtime.onMessage.addListener(handleBookChanged);
-  window.addEventListener('keydown', handleReviewKeyboard);
-  document.addEventListener('visibilitychange', handleVisibilityChange);
-  await loadEntries();
 });
 
 onBeforeUnmount(() => {
+  lifecycle.dispose();
   unsubscribeConfig?.();
   browser.runtime.onMessage.removeListener(handleBookChanged);
   window.removeEventListener('keydown', handleReviewKeyboard);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -12,6 +12,7 @@ import {
 } from "@/entrypoints/utils/config";
 import {CONNECTION_TEST_MESSAGE, CONTEXT_MENU_IDS, getMimoEndpoint, MINIMAX_ENDPOINTS} from "@/entrypoints/utils/constant";
 import {getMissingCredentialMessage} from "@/entrypoints/utils/configValidation";
+import {getFullPageContextMenuPresentation} from "@/entrypoints/utils/siteRules";
 import {resolveConfiguredModel, services, servicesType} from "@/entrypoints/utils/option";
 import {synthesizeEdgeTts} from "@/entrypoints/utils/edgeTts";
 import {lookupWord, type WordCardData} from "@/entrypoints/utils/wordDictionary";
@@ -61,6 +62,7 @@ import {
 
 // 翻译状态管理
 let translationStateMap = new Map<number, boolean>(); // tabId -> isTranslated
+let siteDisabledStateMap = new Map<number, boolean>(); // tabId -> isSiteDisabled
 
 const OPTIONS_SECTION_IDS = new Set([
     'settings-general',
@@ -88,11 +90,22 @@ function vocabularyFailure(error: unknown): VocabularyBookResponse<never> {
 }
 
 function notifyVocabularyBookChanged(reason: VocabularyBookChangedMessage['reason'], entryId?: string): void {
-    void browser.runtime.sendMessage({
+    const message: VocabularyBookChangedMessage = {
         type: VOCABULARY_BOOK_CHANGED_MESSAGE,
         reason,
         ...(entryId ? {entryId} : {}),
-    }).catch(() => undefined);
+    };
+    // Extension pages receive runtime messages, while content scripts require
+    // tabs.sendMessage. Keep both broadcasts fire-and-forget so the originating
+    // upsert response is not delayed by unrelated or restricted tabs.
+    void browser.runtime.sendMessage(message).catch(() => undefined);
+    void browser.tabs.query({})
+        .then((tabs: Array<{id?: number}>) => Promise.allSettled(
+            tabs
+                .filter((tab) => typeof tab.id === 'number')
+                .map((tab) => browser.tabs.sendMessage(tab.id!, message)),
+        ))
+        .catch(() => undefined);
 }
 
 async function handleVocabularyBookAction(message: any, sender: any): Promise<VocabularyBookResponse> {
@@ -239,16 +252,35 @@ const latestConfigSequenceByClient = new Map<string, number>();
 
 interface ActiveSelectionTts {
     tabId: number;
-    requestId: number;
+    clientRequestId: number;
+    playbackRequestId: number;
+    controller: AbortController;
+    playbackStarted: boolean;
 }
 
 let activeSelectionTts: ActiveSelectionTts | null = null;
+let selectionTtsGeneration = 0;
+
+function beginSelectionTts(tabId: number, clientRequestId: number): ActiveSelectionTts {
+    const request: ActiveSelectionTts = {
+        tabId,
+        clientRequestId,
+        playbackRequestId: ++selectionTtsGeneration,
+        controller: new AbortController(),
+        playbackStarted: false,
+    };
+    activeSelectionTts = request;
+    return request;
+}
 
 async function stopActiveSelectionTts(): Promise<void> {
     const active = activeSelectionTts;
     activeSelectionTts = null;
     if (!active) return;
-    await stopSelectionTtsWithOffscreen(active.requestId).catch(() => undefined);
+    active.controller.abort();
+    if (active.playbackStarted) {
+        await stopSelectionTtsWithOffscreen(active.playbackRequestId).catch(() => undefined);
+    }
 }
 
 function googleSelectionTtsUrl(text: string, language: string): string {
@@ -257,15 +289,14 @@ function googleSelectionTtsUrl(text: string, language: string): string {
 
 async function forwardSelectionTtsState(message: any): Promise<void> {
     const tabId = Number.isInteger(message.tabId) ? message.tabId : null;
-    const requestId = Number.isInteger(message.requestId) ? message.requestId : null;
-    if (tabId === null || requestId === null) return;
+    const playbackRequestId = Number.isInteger(message.requestId) ? message.requestId : null;
+    if (tabId === null || playbackRequestId === null) return;
     const active = activeSelectionTts;
-    if (active && active.tabId === tabId && active.requestId === requestId) {
-        activeSelectionTts = null;
-    }
+    if (!active || active.tabId !== tabId || active.playbackRequestId !== playbackRequestId) return;
+    activeSelectionTts = null;
     await browser.tabs.sendMessage(tabId, {
         type: 'selectionTtsState',
-        requestId,
+        requestId: active.clientRequestId,
         state: message.state,
         error: typeof message.error === 'string' ? message.error : undefined,
     }).catch(() => undefined);
@@ -763,26 +794,35 @@ export default defineBackground({
         let contextMenuEnabled = true;
         let contextMenuSyncQueue: Promise<void> = Promise.resolve();
 
-        const readTabTranslationState = async (tabId: number, force = false): Promise<boolean> => {
-            if (!force && translationStateMap.has(tabId)) {
-                return translationStateMap.get(tabId) === true;
+        const readTabTranslationState = async (tabId: number, force = false): Promise<{isTranslated: boolean; isSiteDisabled: boolean}> => {
+            if (!force && translationStateMap.has(tabId) && siteDisabledStateMap.has(tabId)) {
+                return {
+                    isTranslated: translationStateMap.get(tabId) === true,
+                    isSiteDisabled: siteDisabledStateMap.get(tabId) === true,
+                };
             }
 
             try {
                 const response = await browser.tabs.sendMessage(tabId, {
                     type: 'getFullPageTranslationState',
-                }) as { status?: string; isTranslated?: boolean } | undefined;
+                }) as { status?: string; isTranslated?: boolean; isSiteDisabled?: boolean } | undefined;
                 if (response?.status === 'success') {
                     const isTranslated = response.isTranslated === true;
+                    const isSiteDisabled = response.isSiteDisabled === true;
                     translationStateMap.set(tabId, isTranslated);
-                    return isTranslated;
+                    siteDisabledStateMap.set(tabId, isSiteDisabled);
+                    return {isTranslated, isSiteDisabled};
                 }
             } catch {
                 // 浏览器内部页或尚未注入内容脚本的页面无法查询，按未翻译处理。
             }
 
-            const fallback = translationStateMap.get(tabId) === true;
-            translationStateMap.set(tabId, fallback);
+            const fallback = {
+                isTranslated: translationStateMap.get(tabId) === true,
+                isSiteDisabled: siteDisabledStateMap.get(tabId) === true,
+            };
+            translationStateMap.set(tabId, fallback.isTranslated);
+            siteDisabledStateMap.set(tabId, fallback.isSiteDisabled);
             return fallback;
         };
 
@@ -795,12 +835,13 @@ export default defineBackground({
             if (!activeTabs.some((tab) => tab.id === tabId)) return;
             // MV3 service worker 重启后内存 Map 会丢失；首次更新时向仍在运行的
             // 内容脚本重新读取状态，避免菜单需要点击两次才能恢复原文。
-            const isTranslated = await readTabTranslationState(tabId);
+            const state = await readTabTranslationState(tabId, true);
+            const presentation = getFullPageContextMenuPresentation(state.isTranslated, state.isSiteDisabled);
 
             try {
                 await browser.contextMenus.update(CONTEXT_MENU_IDS.TRANSLATE_FULL_PAGE, {
-                    enabled: true,
-                    title: isTranslated ? '流畅阅读取消翻译' : '流畅阅读翻译',
+                    enabled: presentation.enabled,
+                    title: presentation.title,
                 });
             } catch (error) {
                 console.error('Failed to update context menu:', error);
@@ -865,15 +906,19 @@ export default defineBackground({
                     try {
                         // 点击属于用户显式动作，始终读取页面真值，避免后台休眠或
                         // 消息丢失留下的陈旧状态导致执行相反操作。
-                        const isTranslated = await readTabTranslationState(tab.id, true);
+                        const state = await readTabTranslationState(tab.id, true);
+                        if (state.isSiteDisabled) {
+                            await updateContextMenus(tab.id);
+                            return;
+                        }
                         const response = await browser.tabs.sendMessage(tab.id, {
                             type: 'contextMenuTranslate',
-                            action: isTranslated ? 'restore' : 'fullPage',
+                            action: state.isTranslated ? 'restore' : 'fullPage',
                         }) as { status?: string; isTranslated?: boolean } | undefined;
                         if (response?.status !== 'success') return;
                         const nextState = typeof response.isTranslated === 'boolean'
                             ? response.isTranslated
-                            : !isTranslated;
+                            : !state.isTranslated;
                         translationStateMap.set(tab.id, nextState);
                         await updateContextMenus(tab.id);
                     } catch (error) {
@@ -894,6 +939,7 @@ export default defineBackground({
         browser.tabs.onUpdated.addListener((tabId: any, changeInfo: any) => {
             if (changeInfo.status === 'loading') {
                 translationStateMap.set(tabId, false);
+                siteDisabledStateMap.set(tabId, false);
                 if (isContextMenuSupported) void updateContextMenus(tabId);
             }
         });
@@ -901,6 +947,7 @@ export default defineBackground({
         // 监听标签页关闭事件，清理状态
         browser.tabs.onRemoved.addListener((tabId: any) => {
             translationStateMap.delete(tabId);
+            siteDisabledStateMap.delete(tabId);
         });
 
         // 处理翻译请求
@@ -941,6 +988,17 @@ export default defineBackground({
                         const tabId = sender?.tab?.id;
                         if (typeof tabId === 'number') {
                             translationStateMap.set(tabId, message.isTranslated === true);
+                            if (isContextMenuSupported) void updateContextMenus(tabId);
+                        }
+                        resolve({ success: true });
+                        return;
+                    }
+
+                    if (message.type === 'siteExtensionDisabledState') {
+                        const tabId = sender?.tab?.id;
+                        if (typeof tabId === 'number') {
+                            siteDisabledStateMap.set(tabId, message.isDisabled === true);
+                            if (message.isDisabled === true) translationStateMap.set(tabId, false);
                             if (isContextMenuSupported) void updateContextMenus(tabId);
                         }
                         resolve({ success: true });
@@ -1005,7 +1063,13 @@ export default defineBackground({
 
                     if (message.type === 'selectionTtsStop') {
                         const requestId = Number.isSafeInteger(message.requestId) ? message.requestId : undefined;
-                        if (activeSelectionTts && (requestId === undefined || activeSelectionTts.requestId === requestId)) {
+                        const tabId = Number.isInteger(sender?.tab?.id) ? sender.tab.id : null;
+                        if (
+                            activeSelectionTts
+                            && tabId !== null
+                            && activeSelectionTts.tabId === tabId
+                            && (requestId === undefined || activeSelectionTts.clientRequestId === requestId)
+                        ) {
                             await stopActiveSelectionTts();
                         }
                         resolve({ success: true });
@@ -1016,22 +1080,54 @@ export default defineBackground({
                         const tabId = Number.isInteger(sender?.tab?.id) ? sender.tab.id : null;
                         const requestId = Number.isSafeInteger(message.requestId) ? message.requestId : Date.now();
                         await stopActiveSelectionTts();
-                        const result = await synthesizeEdgeTts(message.text, message.language, config.selectionTtsVoices);
+                        const active = tabId === null ? null : beginSelectionTts(tabId, requestId);
+                        let result: Awaited<ReturnType<typeof synthesizeEdgeTts>>;
+                        try {
+                            result = await synthesizeEdgeTts(
+                                message.text,
+                                message.language,
+                                config.selectionTtsVoices,
+                                active?.controller.signal,
+                            );
+                        } catch (synthesisError) {
+                            if (active && activeSelectionTts === active) {
+                                activeSelectionTts = null;
+                            }
+                            throw synthesisError;
+                        }
 
-                        if (tabId !== null) {
-                            activeSelectionTts = { tabId, requestId };
+                        if (active && activeSelectionTts !== active) {
+                            resolve({ success: false, error: '语音合成已取消' });
+                            return;
+                        }
+
+                        if (tabId !== null && active) {
+                            active.playbackStarted = true;
                             try {
                                 await playSelectionTtsWithOffscreen({
                                     audioBase64: arrayBufferToBase64(result.audio),
                                     contentType: result.contentType,
                                     tabId,
-                                    requestId,
+                                    requestId: active.playbackRequestId,
                                 });
+                                if (activeSelectionTts !== active) {
+                                    // STOP 可能在 ensureOffscreenDocument 完成前已经发出，
+                                    // PLAY 随后才到达。此处二次 STOP 关闭这个窗口。
+                                    await stopSelectionTtsWithOffscreen(active.playbackRequestId).catch(() => undefined);
+                                    resolve({ success: false, error: '语音播放已取消' });
+                                    return;
+                                }
                                 resolve({ success: true, transport: 'offscreen', voice: result.voice });
                                 return;
                             } catch (offscreenError) {
-                                if (activeSelectionTts?.tabId === tabId && activeSelectionTts.requestId === requestId) {
+                                const stillCurrent = activeSelectionTts === active;
+                                if (stillCurrent) {
                                     activeSelectionTts = null;
+                                }
+                                if (!stillCurrent) {
+                                    await stopSelectionTtsWithOffscreen(active.playbackRequestId).catch(() => undefined);
+                                    resolve({ success: false, error: '语音播放已取消' });
+                                    return;
                                 }
                                 console.warn('Offscreen TTS playback unavailable, returning page audio:', offscreenError);
                             }
@@ -1059,19 +1155,30 @@ export default defineBackground({
                             return;
                         }
 
-                        activeSelectionTts = { tabId, requestId };
+                        const active = beginSelectionTts(tabId, requestId);
+                        active.playbackStarted = true;
                         try {
                             await playSelectionTtsWithOffscreen({
                                 sourceUrl: googleSelectionTtsUrl(text, language),
                                 tabId,
-                                requestId,
+                                requestId: active.playbackRequestId,
                             });
-                            resolve({ success: true, transport: 'offscreen' });
-                        } catch (offscreenError) {
-                            if (activeSelectionTts?.tabId === tabId && activeSelectionTts.requestId === requestId) {
-                                activeSelectionTts = null;
+                            if (activeSelectionTts !== active) {
+                                await stopSelectionTtsWithOffscreen(active.playbackRequestId).catch(() => undefined);
+                                resolve({ success: false, error: '语音播放已取消' });
+                            } else {
+                                resolve({ success: true, transport: 'offscreen' });
                             }
-                            resolve({ success: false, error: offscreenError instanceof Error ? offscreenError.message : String(offscreenError) });
+                        } catch (offscreenError) {
+                            const stillCurrent = activeSelectionTts === active;
+                            if (stillCurrent) {
+                                activeSelectionTts = null;
+                            } else {
+                                await stopSelectionTtsWithOffscreen(active.playbackRequestId).catch(() => undefined);
+                            }
+                            resolve(stillCurrent
+                                ? { success: false, error: offscreenError instanceof Error ? offscreenError.message : String(offscreenError) }
+                                : { success: false, error: '语音播放已取消' });
                         }
                         return;
                     }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -15,7 +15,7 @@ import {
     unmountFloatingBall,
 } from "@/entrypoints/utils/floatingBall";
 import { mountSelectionTranslator, unmountSelectionTranslator } from "@/entrypoints/utils/selectionTranslator";
-import { mountAreaTranslator, unmountAreaTranslator } from "@/entrypoints/utils/areaTranslator";
+import { isAreaTranslatorMounted, mountAreaTranslator, unmountAreaTranslator } from "@/entrypoints/utils/areaTranslator";
 import { cancelAllTranslations } from "@/entrypoints/utils/translateApi";
 import { mountImageTranslator, unmountImageTranslator } from "@/entrypoints/utils/imageTranslation";
 import {
@@ -23,8 +23,10 @@ import {
     unmountTranslationProgressPanel,
 } from "@/entrypoints/utils/translationProgressPanel";
 import {
+    canCommitInputBoxTranslation,
     getDeepActiveElement,
     getInputBoxText,
+    getInputBoxValueSnapshot,
     isInputElement,
     matchesInputBoxTrigger,
     removeTriggerSymbols,
@@ -39,13 +41,36 @@ import { isSameLanguage, normalizeSelectionText, shouldIgnoreSelection } from '@
 import { normalizeSelectionTranslatorDelay } from '@/entrypoints/utils/model';
 import {clearLegacyPageTranslationCache} from '@/entrypoints/utils/legacyPageCache';
 import {isExtensionDisabledOnSite, shouldAutoTranslatePage} from '@/entrypoints/utils/siteRules';
+import {ensureContentFeatureMounted} from '@/entrypoints/utils/contentFeatureLifecycle';
 
 let contentScriptContext: ContentScriptContext | null = null;
 let inputTooltipUi: ShadowRootContentScriptUi<HTMLElement> | null = null;
+let inputTooltipOwnerRequestId: number | null = null;
+let activeInputTranslationRequestId = 0;
+let activeInputTranslationElement: HTMLElement | null = null;
 let unmountVideoSubtitleTranslation: (() => void) | null = null;
 let unsubscribeContentConfig: (() => void) | null = null;
 let currentPageSiteDisabled = false;
 let updateCurrentPageSiteDisabled: ((disabled: boolean) => Promise<void>) | null = null;
+
+function isInputBoxTranslationEnabled(): boolean {
+    return config.on !== false && config.inputBoxTranslationTrigger !== 'disabled';
+}
+
+function inputBoxTranslationConfigKey(value: typeof config): string {
+    return JSON.stringify([
+        value.on,
+        value.inputBoxTranslationTrigger,
+        value.inputBoxTranslationTarget,
+    ]);
+}
+
+function invalidateActiveInputBoxTranslation(): void {
+    activeInputTranslationRequestId += 1;
+    activeInputTranslationElement?.classList.remove('fluent-input-translating');
+    activeInputTranslationElement = null;
+    removeExistingTooltip();
+}
 
 function shouldAutomaticallyTranslateCurrentPage(nextConfig: typeof config): boolean {
     return shouldAutoTranslatePage(window.location.href, {
@@ -191,6 +216,7 @@ function handleRuntimeMessage(
         sendResponse({
             status: 'success',
             isTranslated: !currentPageSiteDisabled && isFullPageTranslationActive(),
+            isSiteDisabled: currentPageSiteDisabled,
         });
         return true;
     }
@@ -247,6 +273,15 @@ export default defineContentScript({
         let featureController: AbortController | null = null;
         let removePageStyles: (() => void) | null = null;
         let shouldAutomaticallyTranslate = false;
+        let inputBoxConfigGeneration = 0;
+        let previousInputBoxConfigKey = inputBoxTranslationConfigKey(config);
+
+        const reportSiteDisabledState = () => {
+            void browser.runtime.sendMessage({
+                type: 'siteExtensionDisabledState',
+                isDisabled: currentPageSiteDisabled,
+            }).catch(() => undefined);
+        };
 
         const disposePageFeatures = () => {
             featureController?.abort();
@@ -269,27 +304,44 @@ export default defineContentScript({
             if (cleanedUp || currentPageSiteDisabled || featureController) return;
 
             removePageStyles = installPageStyles(ctx);
-            featureController = new AbortController();
-            setupInputBoxTranslation(featureController.signal);
+            const activationController = new AbortController();
+            featureController = activationController;
+            const isActivationCurrent = () => !cleanedUp
+                && !currentPageSiteDisabled
+                && featureController === activationController
+                && !activationController.signal.aborted;
+            setupInputBoxTranslation(activationController.signal, () => inputBoxConfigGeneration);
             // 视频字幕 Beta 只在 YouTube 播放页监听原生字幕，不采集音频或视频内容。
             unmountVideoSubtitleTranslation = mountVideoSubtitleTranslation();
             // 监听器始终注册并在触发时读取实时配置。这样扩展在当前页面由关闭
             // 切换为开启后，无需刷新页面就能恢复 Control/Alt+T。
-            setupManualTranslationTriggers(featureController.signal);
-            setupFloatingBallHotkey(featureController.signal);
+            setupManualTranslationTriggers(activationController.signal);
+            setupFloatingBallHotkey(activationController.signal);
 
             if (config.on && config.disableFloatingBall !== true) {
-                await mountFloatingBall(ctx);
-                if (cleanedUp || currentPageSiteDisabled) return;
+                await ensureContentFeatureMounted({
+                    mount: () => mountFloatingBall(ctx),
+                    isMounted: () => Boolean(document.getElementById('fluent-read-floating-ball-container')),
+                    isStillDesired: () => isActivationCurrent() && config.on && config.disableFloatingBall !== true,
+                });
+                if (!isActivationCurrent()) return;
             }
 
             if (config.on && config.disableSelectionTranslator !== true) {
-                await mountSelectionTranslator(ctx);
-                if (cleanedUp || currentPageSiteDisabled) return;
+                await ensureContentFeatureMounted({
+                    mount: () => mountSelectionTranslator(ctx),
+                    isMounted: () => Boolean(document.getElementById('fluent-read-selection-translator-container')),
+                    isStillDesired: () => isActivationCurrent() && config.on && config.disableSelectionTranslator !== true,
+                });
+                if (!isActivationCurrent()) return;
             }
             if (config.on && config.selectionAreaEnabled === true) {
-                await mountAreaTranslator(ctx);
-                if (cleanedUp || currentPageSiteDisabled) return;
+                await ensureContentFeatureMounted({
+                    mount: () => mountAreaTranslator(ctx),
+                    isMounted: isAreaTranslatorMounted,
+                    isStillDesired: () => isActivationCurrent() && config.on && config.selectionAreaEnabled === true,
+                });
+                if (!isActivationCurrent()) return;
             }
 
             // 图片翻译使用独立覆盖层，不改写宿主页面的 img 元素；点击入口由事件委托处理动态图片。
@@ -299,6 +351,7 @@ export default defineContentScript({
         const applySiteDisabledState = async (disabled: boolean) => {
             if (cleanedUp) return;
             currentPageSiteDisabled = disabled;
+            reportSiteDisabledState();
             if (disabled) {
                 shouldAutomaticallyTranslate = false;
                 disposePageFeatures();
@@ -340,6 +393,7 @@ export default defineContentScript({
             sendResponse: (response?: unknown) => void,
         ) => handleRuntimeMessage(message, ctx, sendResponse);
         browser.runtime.onMessage.addListener(runtimeMessageListener);
+        reportSiteDisabledState();
         if (!currentPageSiteDisabled) {
             await activatePageFeatures();
             shouldAutomaticallyTranslate = shouldAutomaticallyTranslateCurrentPage(config);
@@ -347,6 +401,12 @@ export default defineContentScript({
         }
 
         unsubscribeContentConfig = subscribeConfig((nextConfig) => {
+            const nextInputBoxConfigKey = inputBoxTranslationConfigKey(nextConfig);
+            if (nextInputBoxConfigKey !== previousInputBoxConfigKey) {
+                previousInputBoxConfigKey = nextInputBoxConfigKey;
+                inputBoxConfigGeneration += 1;
+                invalidateActiveInputBoxTranslation();
+            }
             const nextSiteDisabled = isExtensionDisabledOnSite(
                 window.location.href,
                 nextConfig.disabledExtensionDomains,
@@ -1001,7 +1061,7 @@ function setupFloatingBallHotkey(signal: AbortSignal) {
 /**
  * 输入框翻译功能
  */
-function setupInputBoxTranslation(signal: AbortSignal) {
+function setupInputBoxTranslation(signal: AbortSignal, readConfigGeneration: () => number) {
     let keyPressCount = 0;
     let keyPressTimer: ReturnType<typeof setTimeout> | null = null;
     let lastInputElement: HTMLElement | null = null;
@@ -1039,7 +1099,7 @@ function setupInputBoxTranslation(signal: AbortSignal) {
             // Ctrl+Enter 触发
             if (event.ctrlKey && event.key === 'Enter') {
                 event.preventDefault();
-                await handleInputBoxTranslation(activeElement);
+                await handleInputBoxTranslation(activeElement, signal, readConfigGeneration);
                 return;
             }
         } else if (triggerType === 'triple_space' || triggerType === 'triple_equal' || triggerType === 'triple_dash') {
@@ -1062,7 +1122,7 @@ function setupInputBoxTranslation(signal: AbortSignal) {
             if (keyPressCount === 3) {
                 event.preventDefault(); // 阻止默认输入
                 resetKeyPresses();
-                await handleInputBoxTranslation(activeElement);
+                await handleInputBoxTranslation(activeElement, signal, readConfigGeneration);
                 return;
             }
 
@@ -1105,9 +1165,20 @@ function setInputBoxText(element: HTMLElement, text: string): void {
 /**
  * 创建并显示翻译提示弹窗
  */
-async function createTranslationTooltip(element: HTMLElement, message: string, type: 'translating' | 'success' | 'error'): Promise<HTMLElement> {
-    // 移除已存在的提示
+async function createTranslationTooltip(
+    element: HTMLElement,
+    message: string,
+    type: 'translating' | 'success' | 'error',
+    requestId: number,
+    signal: AbortSignal,
+): Promise<HTMLElement | null> {
+    if (signal.aborted || requestId !== activeInputTranslationRequestId || currentPageSiteDisabled || !isInputBoxTranslationEnabled()) {
+        return null;
+    }
+
+    // 只有当前最新请求能替换 tooltip；旧请求即使延迟返回也不会移除新提示。
     removeExistingTooltip();
+    inputTooltipOwnerRequestId = requestId;
 
     if (!contentScriptContext) {
         throw new Error('Content script context is not ready');
@@ -1115,7 +1186,7 @@ async function createTranslationTooltip(element: HTMLElement, message: string, t
 
     const rect = element.getBoundingClientRect();
 
-    inputTooltipUi = await createShadowRootUi<HTMLElement>(contentScriptContext, {
+    const ui = await createShadowRootUi<HTMLElement>(contentScriptContext, {
         name: 'fluent-read-input-tooltip-ui',
         position: 'overlay',
         alignment: 'top-left',
@@ -1174,11 +1245,23 @@ async function createTranslationTooltip(element: HTMLElement, message: string, t
         },
     });
 
-    inputTooltipUi.shadowHost.id = 'fluent-input-translation-tooltip-host';
-    inputTooltipUi.shadowHost.setAttribute('data-fluent-read-ui', 'input-tooltip');
-    inputTooltipUi.mount();
+    if (
+        signal.aborted
+        || requestId !== activeInputTranslationRequestId
+        || inputTooltipOwnerRequestId !== requestId
+        || currentPageSiteDisabled
+        || !isInputBoxTranslationEnabled()
+    ) {
+        ui.remove();
+        return null;
+    }
 
-    const tooltip = inputTooltipUi.mounted!;
+    inputTooltipUi = ui;
+    ui.shadowHost.id = 'fluent-input-translation-tooltip-host';
+    ui.shadowHost.setAttribute('data-fluent-read-ui', 'input-tooltip');
+    ui.mount();
+
+    const tooltip = ui.mounted!;
     
     // 如果禁用动画，直接显示，否则使用淡入效果
     if (!config.animations) {
@@ -1209,12 +1292,15 @@ function getTooltipIcon(type: 'translating' | 'success' | 'error'): string {
 /**
  * 移除现有的提示弹窗
  */
-function removeExistingTooltip(): void {
+function removeExistingTooltip(ownerRequestId?: number): void {
+    if (ownerRequestId !== undefined && inputTooltipOwnerRequestId !== ownerRequestId) return;
+
     const ui = inputTooltipUi;
     const existing = ui?.mounted;
     inputTooltipUi = null;
-    if (ui && existing) {
-        if (!config.animations) {
+    inputTooltipOwnerRequestId = null;
+    if (ui) {
+        if (!existing || !config.animations) {
             // 如果禁用动画，直接移除
             ui.remove();
         } else {
@@ -1228,7 +1314,11 @@ function removeExistingTooltip(): void {
 /**
  * 添加输入框动画效果
  */
-function addInputBoxAnimation(element: HTMLElement, animationType: 'translating' | 'success' | 'error'): void {
+function addInputBoxAnimation(
+    element: HTMLElement,
+    animationType: 'translating' | 'success' | 'error',
+    ownerRequestId: number,
+): void {
     // 如果禁用了动画，则不添加动画效果
     if (!config.animations) {
         return;
@@ -1243,6 +1333,7 @@ function addInputBoxAnimation(element: HTMLElement, animationType: 'translating'
     // 如果不是翻译中的动画，在动画完成后移除类
     if (animationType !== 'translating') {
         setTimeout(() => {
+            if (ownerRequestId !== activeInputTranslationRequestId) return;
             element.classList.remove(`fluent-input-${animationType}`);
         }, animationType === 'success' ? 1000 : 600);
     }
@@ -1275,92 +1366,106 @@ async function translateWithMicrosoft(text: string, targetLang: string): Promise
 /**
  * 处理输入框翻译
  */
-async function handleInputBoxTranslation(element: HTMLElement): Promise<void> {
+async function handleInputBoxTranslation(
+    element: HTMLElement,
+    signal: AbortSignal,
+    readConfigGeneration: () => number,
+): Promise<void> {
+    invalidateActiveInputBoxTranslation();
+    const requestId = activeInputTranslationRequestId;
+    activeInputTranslationElement = element;
+    const configGeneration = readConfigGeneration();
+    const inputSnapshot = getInputBoxValueSnapshot(element);
+    const originalText = getInputBoxText(element);
+    const trigger = config.inputBoxTranslationTrigger;
+    const targetLanguage = config.inputBoxTranslationTarget;
+
+    const isCurrentAndUnchanged = () => requestId === activeInputTranslationRequestId
+        && canCommitInputBoxTranslation({
+            signal,
+            expectedValue: inputSnapshot,
+            currentValue: getInputBoxValueSnapshot(element),
+            expectedConfigGeneration: configGeneration,
+            currentConfigGeneration: readConfigGeneration(),
+            isEnabled: isInputBoxTranslationEnabled(),
+            isSiteDisabled: currentPageSiteDisabled,
+        });
+    const clearOwnedVisuals = () => {
+        if (requestId !== activeInputTranslationRequestId) return;
+        element.classList.remove('fluent-input-translating');
+        if (activeInputTranslationElement === element) activeInputTranslationElement = null;
+        removeExistingTooltip(requestId);
+    };
+    const handleAbort = () => clearOwnedVisuals();
+    signal.addEventListener('abort', handleAbort, { once: true });
+
     try {
-        if (currentPageSiteDisabled) return;
-        const originalText = getInputBoxText(element);
-        
-        if (!originalText) {
-            return;
-        }
-        
+        if (!isCurrentAndUnchanged() || !originalText) return;
+
         // 根据触发方式去除末尾的触发符号
-        const cleanedText = removeTriggerSymbols(originalText, config.inputBoxTranslationTrigger);
-        
-        if (!cleanedText) {
+        const cleanedText = removeTriggerSymbols(originalText, trigger);
+        if (!cleanedText) return;
+
+        // 新请求接管当前提示，之前请求的 finally/定时器只能移除自己的 tooltip。
+        removeExistingTooltip();
+        addInputBoxAnimation(element, 'translating', requestId);
+        const loadingTooltip = await createTranslationTooltip(
+            element,
+            '微软翻译中',
+            'translating',
+            requestId,
+            signal,
+        );
+        if (!loadingTooltip || !isCurrentAndUnchanged()) {
+            clearOwnedVisuals();
             return;
         }
-        
-        // 显示翻译中的动画和提示
-        addInputBoxAnimation(element, 'translating');
-        await createTranslationTooltip(element, '微软翻译中', 'translating');
-        if (currentPageSiteDisabled) {
-            element.classList.remove('fluent-input-translating');
-            removeExistingTooltip();
-            return;
-        }
-        
+
         try {
-            // 直接调用微软翻译API，不使用缓存
-            const translatedText = await translateWithMicrosoft(cleanedText, config.inputBoxTranslationTarget);
-            if (currentPageSiteDisabled) {
-                element.classList.remove('fluent-input-translating');
-                removeExistingTooltip();
+            // runtime.sendMessage 无法中断已发往 background 的请求，
+            // 因此在结果落地前同时校验 feature signal、请求序号与输入快照。
+            const translatedText = await translateWithMicrosoft(cleanedText, targetLanguage);
+            if (!isCurrentAndUnchanged()) {
+                clearOwnedVisuals();
                 return;
             }
-            
+
+            element.classList.remove('fluent-input-translating');
+            removeExistingTooltip(requestId);
             if (translatedText && translatedText !== cleanedText) {
-                // 移除翻译中的动画
-                element.classList.remove('fluent-input-translating');
-                
-                // 设置翻译结果
                 setInputBoxText(element, translatedText);
-                
-                // 显示成功动画和提示
-                addInputBoxAnimation(element, 'success');
-                removeExistingTooltip();
-                await createTranslationTooltip(element, '翻译成功', 'success');
+                addInputBoxAnimation(element, 'success', requestId);
+                await createTranslationTooltip(element, '翻译成功', 'success', requestId, signal);
             } else {
-                // 翻译结果与原文相同或为空
-                element.classList.remove('fluent-input-translating');
-                addInputBoxAnimation(element, 'error');
-                removeExistingTooltip();
-                await createTranslationTooltip(element, '内容无需翻译', 'error');
+                addInputBoxAnimation(element, 'error', requestId);
+                await createTranslationTooltip(element, '内容无需翻译', 'error', requestId, signal);
             }
         } catch (translationError) {
-            if (currentPageSiteDisabled) {
-                element.classList.remove('fluent-input-translating');
-                removeExistingTooltip();
+            if (!isCurrentAndUnchanged()) {
+                clearOwnedVisuals();
                 return;
             }
-            // 翻译失败
             element.classList.remove('fluent-input-translating');
-            addInputBoxAnimation(element, 'error');
-            removeExistingTooltip();
-            await createTranslationTooltip(element, '微软翻译失败', 'error');
+            addInputBoxAnimation(element, 'error', requestId);
+            removeExistingTooltip(requestId);
+            await createTranslationTooltip(element, '微软翻译失败', 'error', requestId, signal);
             console.error('微软翻译失败:', translationError);
         }
-        
-        // 自动隐藏提示
-        setTimeout(() => removeExistingTooltip(), 2500);
-        
+
+        // 所有者校验保证旧请求的定时器不会移除新 tooltip。
+        setTimeout(() => removeExistingTooltip(requestId), 2500);
     } catch (error) {
-        if (currentPageSiteDisabled) {
-            element.classList.remove('fluent-input-translating');
-            removeExistingTooltip();
+        if (!isCurrentAndUnchanged()) {
+            clearOwnedVisuals();
             return;
         }
         console.error('输入框翻译失败:', error);
-        
-        // 移除翻译中的动画
         element.classList.remove('fluent-input-translating');
-        
-        // 显示错误动画和提示
-        addInputBoxAnimation(element, 'error');
-        removeExistingTooltip();
-        await createTranslationTooltip(element, '翻译服务暂时不可用', 'error');
-        
-        // 自动隐藏错误提示
-        setTimeout(() => removeExistingTooltip(), 3000);
+        addInputBoxAnimation(element, 'error', requestId);
+        removeExistingTooltip(requestId);
+        await createTranslationTooltip(element, '翻译服务暂时不可用', 'error', requestId, signal);
+        setTimeout(() => removeExistingTooltip(requestId), 3000);
+    } finally {
+        signal.removeEventListener('abort', handleAbort);
     }
 }

--- a/entrypoints/document/App.vue
+++ b/entrypoints/document/App.vue
@@ -443,8 +443,10 @@ const pdfPreviewPageStates = ref<PdfPreviewPageState[]>([]);
 const epubChapterIndex = ref(0);
 const docxPartIndex = ref(0);
 const hydrated = ref(false);
-const isDark = ref(window.matchMedia('(prefers-color-scheme: dark)').matches);
+const colorSchemeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+const isDark = ref(colorSchemeMedia.matches);
 let abortController: AbortController | null = null;
+let translationRequestId = 0;
 let lastSerialized = '';
 let noticeTimer: ReturnType<typeof setTimeout> | undefined;
 let pdfPreviewTimer: ReturnType<typeof setTimeout> | undefined;
@@ -747,8 +749,7 @@ function readerSourceClass(value: string): string {
 }
 
 function applyTheme(): void {
-  const media = window.matchMedia('(prefers-color-scheme: dark)');
-  isDark.value = media.matches;
+  isDark.value = colorSchemeMedia.matches;
 }
 
 async function hydrateConfig(): Promise<void> {
@@ -831,6 +832,7 @@ function handleDrop(event: DragEvent): void {
 }
 
 function resetDocument(): void {
+  translationRequestId += 1;
   abortController?.abort();
   abortController = null;
   translating.value = false;
@@ -861,6 +863,7 @@ async function startTranslation(): Promise<void> {
   progress.value = 0;
   errorMessage.value = '';
   const controller = new AbortController();
+  const requestId = ++translationRequestId;
   abortController = controller;
   try {
     const result = await translateDocumentSegments(document.segments, {
@@ -869,23 +872,28 @@ async function startTranslation(): Promise<void> {
       modelOverride: documentUsesModel.value ? documentModelValue.value : undefined,
       signal: controller.signal,
       onProgress: ({completed, total}) => {
+        if (requestId !== translationRequestId || parsedDocument.value !== document) return;
         progress.value = total > 0 ? Math.round((completed / total) * 100) : 100;
         translatedSegments.value = translatedSegments.value.length === total
           ? translatedSegments.value
           : new Array<string>(total).fill('');
       },
     });
+    if (requestId !== translationRequestId || parsedDocument.value !== document) return;
     translatedSegments.value = result;
     progress.value = 100;
   } catch (error) {
+    if (requestId !== translationRequestId || parsedDocument.value !== document) return;
     if (controller.signal.aborted) {
       showError('文档翻译已取消。');
     } else {
       showError(error instanceof Error ? error.message : String(error));
     }
   } finally {
-    translating.value = false;
-    abortController = null;
+    if (requestId === translationRequestId) {
+      translating.value = false;
+      if (abortController === controller) abortController = null;
+    }
   }
 }
 
@@ -919,19 +927,18 @@ async function openSettings(): Promise<void> {
 }
 
 onMounted(() => {
-  const media = window.matchMedia('(prefers-color-scheme: dark)');
-  media.addEventListener?.('change', applyTheme);
+  colorSchemeMedia.addEventListener?.('change', applyTheme);
   window.addEventListener('pagehide', resetDocument);
 });
 
 onUnmounted(() => {
+  translationRequestId += 1;
   abortController?.abort();
   void saveConfig(config).catch(() => undefined);
   if (noticeTimer) clearTimeout(noticeTimer);
   if (pdfPreviewTimer) clearTimeout(pdfPreviewTimer);
   clearPdfPreviewUrls();
-  const media = window.matchMedia('(prefers-color-scheme: dark)');
-  media.removeEventListener?.('change', applyTheme);
+  colorSchemeMedia.removeEventListener?.('change', applyTheme);
   window.removeEventListener('pagehide', resetDocument);
 });
 </script>

--- a/entrypoints/utils/areaTranslator.ts
+++ b/entrypoints/utils/areaTranslator.ts
@@ -10,6 +10,10 @@ let mountingPromise: Promise<any> | null = null;
 let mountRequestId = 0;
 let contentScriptContext: ContentScriptContext | null = null;
 
+export function isAreaTranslatorMounted(): boolean {
+  return Boolean(document.getElementById('fluent-read-area-translator-container'));
+}
+
 export function mountAreaTranslator(ctx?: ContentScriptContext) {
   if (ctx) contentScriptContext = ctx;
   if (areaTranslatorInstance || mountingPromise || config.selectionAreaEnabled !== true) return mountingPromise;

--- a/entrypoints/utils/contentFeatureLifecycle.ts
+++ b/entrypoints/utils/contentFeatureLifecycle.ts
@@ -1,0 +1,17 @@
+export interface EnsureContentFeatureMountedOptions {
+    mount: () => unknown | PromiseLike<unknown>;
+    isMounted: () => boolean;
+    isStillDesired: () => boolean;
+}
+
+/**
+ * A restored activation can initially receive the mounting promise from the
+ * activation that was just disabled. Once that stale promise settles, retry
+ * exactly once when the new activation still wants the feature and no host was
+ * mounted. Individual mount helpers retain ownership of their own request IDs.
+ */
+export async function ensureContentFeatureMounted(options: EnsureContentFeatureMountedOptions): Promise<void> {
+    await options.mount();
+    if (!options.isStillDesired() || options.isMounted()) return;
+    await options.mount();
+}

--- a/entrypoints/utils/documentTranslation.ts
+++ b/entrypoints/utils/documentTranslation.ts
@@ -93,16 +93,22 @@ export type BinaryDocumentData =
 interface LiteralPart {
     kind: 'literal';
     value: string;
+    /** Markdown source-line group used to keep protected inline syntax in place. */
+    bilingualGroup?: number;
 }
 
 interface SegmentPart {
     kind: 'segment';
     segmentIndex: number;
     source: string;
+    /** Original encoded HTML text used when the bilingual source is rendered. */
+    rawSource?: string;
     prefix: string;
     suffix: string;
     /** Repeat a structural prefix when a bilingual line needs a second cue. */
     bilingualPrefix?: string;
+    /** Markdown source-line group used to render one coherent bilingual line. */
+    bilingualGroup?: number;
 }
 
 type DocumentPart = LiteralPart | SegmentPart;
@@ -140,7 +146,6 @@ const FORMAT_LABELS: Record<DocumentFormat, string> = {
 };
 
 const PROTECTED_HTML_TAGS = new Set(['head', 'script', 'style', 'pre', 'code', 'textarea']);
-const HTML_TOKEN_PATTERN = /<!--[\s\S]*?-->|<![^>]*>|<[^>]+>/gu;
 const MARKDOWN_PROTECTED_PATTERN = /(`{1,3}[^`\n]+`{1,3}|!\[[^\]]*\]\([^)]+\)|\[[^\]]+\]\((?:https?:\/\/|#)[^)]+\)|<https?:\/\/[^>]+>|https?:\/\/[^\s)]+)/gu;
 const TIMED_SUBTITLE_PATTERN = /^\s*(?:\d{1,3}:)?\d{2}:\d{2}[,.]\d{3}\s*-->\s*(?:\d{1,3}:)?\d{2}:\d{2}[,.]\d{3}(?:\s+.*)?$/u;
 const LRC_TIME_PATTERN = /^(\s*(?:\[[^\]\r\n]+\])+)/u;
@@ -189,38 +194,45 @@ function trimSource(value: string): {prefix: string; source: string; suffix: str
     return {prefix: match[1], source: match[2], suffix: match[3]};
 }
 
-function addLiteral(parts: DocumentPart[], value: string): void {
+type SegmentOptions = Pick<SegmentPart, 'bilingualPrefix' | 'bilingualGroup'>
+    & Omit<Partial<DocumentSegment>, 'id' | 'source'>;
+
+function addLiteral(parts: DocumentPart[], value: string, bilingualGroup?: number): void {
     if (!value) return;
     const last = parts[parts.length - 1];
-    if (last?.kind === 'literal') {
+    if (last?.kind === 'literal' && last.bilingualGroup === bilingualGroup) {
         last.value += value;
         return;
     }
-    parts.push({kind: 'literal', value});
+    parts.push({kind: 'literal', value, bilingualGroup});
 }
 
 function addSegment(
     parts: DocumentPart[],
     segments: DocumentSegment[],
     value: string,
-    options: Pick<SegmentPart, 'bilingualPrefix'> & Omit<Partial<DocumentSegment>, 'id' | 'source'> = {},
+    options: SegmentOptions = {},
+    transformSource?: (source: string) => string,
 ): void {
     const trimmed = trimSource(value);
     if (!trimmed) {
-        addLiteral(parts, value);
+        addLiteral(parts, value, options.bilingualGroup);
         return;
     }
 
     const segmentIndex = segments.length;
-    const {bilingualPrefix, ...segmentOptions} = options;
-    segments.push({id: segmentIndex, source: trimmed.source, ...segmentOptions});
+    const {bilingualPrefix, bilingualGroup, ...segmentOptions} = options;
+    const source = transformSource ? transformSource(trimmed.source) : trimmed.source;
+    segments.push({id: segmentIndex, source, ...segmentOptions});
     parts.push({
         kind: 'segment',
         segmentIndex,
-        source: trimmed.source,
+        source,
+        ...(source === trimmed.source ? {} : {rawSource: trimmed.source}),
         prefix: trimmed.prefix,
         suffix: trimmed.suffix,
         bilingualPrefix,
+        bilingualGroup,
     });
 }
 
@@ -229,14 +241,14 @@ function addProtectedText(
     segments: DocumentSegment[],
     value: string,
     pattern: RegExp,
-    options: Pick<SegmentPart, 'bilingualPrefix'> & Omit<Partial<DocumentSegment>, 'id' | 'source'> = {},
+    options: SegmentOptions = {},
 ): void {
     pattern.lastIndex = 0;
     let cursor = 0;
     let match = pattern.exec(value);
     while (match) {
         addSegment(parts, segments, value.slice(cursor, match.index), options);
-        addLiteral(parts, match[0]);
+        addLiteral(parts, match[0], options.bilingualGroup);
         cursor = match.index + match[0].length;
         match = pattern.exec(value);
     }
@@ -270,7 +282,7 @@ function parseTextDocument(content: string, format: 'txt' | 'markdown'): Pick<Pa
     const lines = splitWithEndings(content);
     let inFence = false;
 
-    lines.forEach((line) => {
+    lines.forEach((line, lineIndex) => {
         const fence = /^\s*(`{3,}|~{3,})/u.test(line.text);
         const horizontalRule = /^\s*(?:[-*_]\s*){3,}$/u.test(line.text);
         if (format === 'markdown' && (fence || inFence || horizontalRule)) {
@@ -280,7 +292,9 @@ function parseTextDocument(content: string, format: 'txt' | 'markdown'): Pick<Pa
         }
 
         if (format === 'markdown') {
-            addProtectedText(parts, segments, line.text, MARKDOWN_PROTECTED_PATTERN);
+            addProtectedText(parts, segments, line.text, MARKDOWN_PROTECTED_PATTERN, {
+                bilingualGroup: lineIndex,
+            });
         } else {
             addSegment(parts, segments, line.text);
         }
@@ -290,24 +304,109 @@ function parseTextDocument(content: string, format: 'txt' | 'markdown'): Pick<Pa
     return {parts, segments};
 }
 
+const HTML_ENTITY_FALLBACKS: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    bull: '•',
+    cent: '¢',
+    copy: '©',
+    emsp: ' ',
+    ensp: ' ',
+    euro: '€',
+    gt: '>',
+    hellip: '…',
+    laquo: '«',
+    ldquo: '“',
+    lsquo: '‘',
+    lt: '<',
+    mdash: '—',
+    middot: '·',
+    ndash: '–',
+    nbsp: ' ',
+    pound: '£',
+    quot: '"',
+    raquo: '»',
+    rdquo: '”',
+    reg: '®',
+    rsquo: '’',
+    thinsp: ' ',
+    trade: '™',
+    yen: '¥',
+};
+
+function decodeHtmlEntities(value: string): string {
+    if (!value.includes('&')) return value;
+    if (typeof globalThis.document !== 'undefined') {
+        const textarea = globalThis.document.createElement('textarea');
+        textarea.innerHTML = value;
+        return textarea.value;
+    }
+
+    return value.replace(/&(?:#x([0-9a-f]+)|#([0-9]+)|([a-z][a-z0-9]+));/giu, (entity, hex, decimal, name) => {
+        if (name) return HTML_ENTITY_FALLBACKS[String(name).toLowerCase()] ?? entity;
+        const codePoint = Number.parseInt(hex || decimal, hex ? 16 : 10);
+        return Number.isInteger(codePoint) && codePoint > 0 && codePoint <= 0x10ffff
+            ? String.fromCodePoint(codePoint)
+            : '�';
+    });
+}
+
+interface HtmlToken {
+    index: number;
+    value: string;
+}
+
+/** Find the next HTML token without treating `>` inside a quoted attribute as the tag boundary. */
+function findNextHtmlToken(content: string, from: number): HtmlToken | null {
+    let index = content.indexOf('<', from);
+    while (index >= 0) {
+        const next = content[index + 1];
+        if (next && (next === '!' || next === '?' || next === '/' || /[a-z]/iu.test(next))) {
+            if (content.startsWith('<!--', index)) {
+                const commentEnd = content.indexOf('-->', index + 4);
+                const end = commentEnd >= 0 ? commentEnd + 3 : content.length;
+                return {index, value: content.slice(index, end)};
+            }
+
+            let quote = '';
+            for (let cursor = index + 1; cursor < content.length; cursor += 1) {
+                const character = content[cursor];
+                if (quote) {
+                    if (character === quote) quote = '';
+                    continue;
+                }
+                if (character === '"' || character === "'") {
+                    quote = character;
+                    continue;
+                }
+                if (character === '>') {
+                    return {index, value: content.slice(index, cursor + 1)};
+                }
+            }
+            return null;
+        }
+        index = content.indexOf('<', index + 1);
+    }
+    return null;
+}
+
 function parseHtmlDocument(content: string): Pick<ParsedDocument, 'parts' | 'segments'> {
     const parts: DocumentPart[] = [];
     const segments: DocumentSegment[] = [];
     let cursor = 0;
     let protectedTag = '';
 
-    HTML_TOKEN_PATTERN.lastIndex = 0;
-    let match = HTML_TOKEN_PATTERN.exec(content);
+    let match = findNextHtmlToken(content, 0);
     while (match) {
-        const tag = match[0];
-        if (!protectedTag) addSegment(parts, segments, content.slice(cursor, match.index));
+        const tag = match.value;
+        if (!protectedTag) addSegment(parts, segments, content.slice(cursor, match.index), {}, decodeHtmlEntities);
         else addLiteral(parts, content.slice(cursor, match.index));
         addLiteral(parts, tag);
 
         const closing = tag.match(/^<\s*\/\s*([a-z0-9-]+)/iu)?.[1]?.toLowerCase();
         if (closing && closing === protectedTag) {
             protectedTag = '';
-        } else if (!closing) {
+        } else if (!closing && !protectedTag) {
             const opening = tag.match(/^<\s*([a-z0-9-]+)/iu)?.[1]?.toLowerCase();
             if (opening && PROTECTED_HTML_TAGS.has(opening) && !/\/\s*>$/u.test(tag)) {
                 protectedTag = opening;
@@ -315,17 +414,17 @@ function parseHtmlDocument(content: string): Pick<ParsedDocument, 'parts' | 'seg
         }
 
         cursor = match.index + tag.length;
-        match = HTML_TOKEN_PATTERN.exec(content);
+        match = findNextHtmlToken(content, cursor);
     }
 
     if (cursor < content.length) {
         if (protectedTag) addLiteral(parts, content.slice(cursor));
-        else addSegment(parts, segments, content.slice(cursor));
+        else addSegment(parts, segments, content.slice(cursor), {}, decodeHtmlEntities);
     }
     return {parts, segments};
 }
 
-function parseTimedSubtitleDocument(content: string): Pick<ParsedDocument, 'parts' | 'segments'> {
+function parseTimedSubtitleDocument(content: string, format: 'srt' | 'vtt'): Pick<ParsedDocument, 'parts' | 'segments'> {
     const parts: DocumentPart[] = [];
     const segments: DocumentSegment[] = [];
     const lines = splitWithEndings(content);
@@ -344,6 +443,10 @@ function parseTimedSubtitleDocument(content: string): Pick<ParsedDocument, 'part
         cursorLine += 1;
         const textStartLine = cursorLine;
         while (cursorLine < lines.length && lines[cursorLine].text.trim() && !TIMED_SUBTITLE_PATTERN.test(lines[cursorLine].text)) {
+            const nextLineStartsCue = format === 'srt'
+                && /^\s*\d+\s*$/u.test(lines[cursorLine].text)
+                && TIMED_SUBTITLE_PATTERN.test(lines[cursorLine + 1]?.text || '');
+            if (nextLineStartsCue) break;
             cursorLine += 1;
         }
 
@@ -513,7 +616,7 @@ export function parseDocument(fileName: string, content: string): ParsedDocument
                 ? parseAssDocument(content)
                 : format === 'lrc'
                     ? parseLrcDocument(content)
-                    : parseTimedSubtitleDocument(content);
+                    : parseTimedSubtitleDocument(content, format);
 
     return {fileName, format, label: getDocumentFormatLabel(format), ...parsed};
 }
@@ -541,38 +644,75 @@ function preserveSubtitleMarkup(source: string, translation: string): string {
     return translation;
 }
 
+function originalPartSource(part: SegmentPart): string {
+    return part.rawSource ?? part.source;
+}
+
 function formatBilingualTranslation(document: ParsedDocument, part: SegmentPart, translation: string): string {
+    const source = originalPartSource(part);
     const formattedTranslation = ['srt', 'vtt', 'ass'].includes(document.format)
         ? preserveSubtitleMarkup(part.source, translation)
         : translation;
     if (document.format === 'html') {
-        return `${part.prefix}${part.source}${part.suffix}<br><span data-fluent-read-document-translation="true">${escapeHtml(translation)}</span>`;
+        return `${part.prefix}${source}${part.suffix}<br><span data-fluent-read-document-translation="true">${escapeHtml(translation)}</span>`;
     }
     if (document.format === 'markdown') {
-        return `${part.prefix}${part.source}${part.suffix}\n> ${translation}`;
+        return `${part.prefix}${source}${part.suffix}\n> ${translation}`;
     }
     if (document.format === 'ass') {
-        return `${part.prefix}${part.source}${part.suffix}\\N${formattedTranslation.replace(/\r?\n/gu, '\\N')}`;
+        return `${part.prefix}${source}${part.suffix}\\N${formattedTranslation.replace(/\r?\n/gu, '\\N')}`;
     }
     if (part.bilingualPrefix) {
-        return `${part.prefix}${part.source}${part.suffix}\n${part.bilingualPrefix}${formattedTranslation}`;
+        return `${part.prefix}${source}${part.suffix}\n${part.bilingualPrefix}${formattedTranslation}`;
     }
-    return `${part.prefix}${part.source}${part.suffix}\n${formattedTranslation}`;
+    return `${part.prefix}${source}${part.suffix}\n${formattedTranslation}`;
 }
 
 function renderParts(document: ParsedDocument, translations: readonly string[], mode: DocumentRenderMode): string {
-    return document.parts.map((part) => {
-        if (part.kind === 'literal') return part.value;
+    const output: string[] = [];
+    for (let index = 0; index < document.parts.length; index += 1) {
+        const part = document.parts[index];
+        if (mode === 'bilingual' && document.format === 'markdown' && part.bilingualGroup !== undefined) {
+            const group = part.bilingualGroup;
+            const groupParts: DocumentPart[] = [];
+            while (index < document.parts.length && document.parts[index].bilingualGroup === group) {
+                groupParts.push(document.parts[index]);
+                index += 1;
+            }
+            index -= 1;
+            const source = groupParts.map((entry) => entry.kind === 'literal'
+                ? entry.value
+                : `${entry.prefix}${originalPartSource(entry)}${entry.suffix}`).join('');
+            if (!groupParts.some((entry) => entry.kind === 'segment')) {
+                output.push(source);
+                continue;
+            }
+            const translated = groupParts.map((entry) => {
+                if (entry.kind === 'literal') return entry.value;
+                return `${entry.prefix}${translations[entry.segmentIndex] ?? entry.source}${entry.suffix}`;
+            }).join('').replace(/\r\n?|\n/gu, '\n> ');
+            output.push(`${source}\n> ${translated}`);
+            continue;
+        }
+        if (part.kind === 'literal') {
+            output.push(part.value);
+            continue;
+        }
         const translation = translations[part.segmentIndex] ?? part.source;
-        if (mode === 'bilingual') return formatBilingualTranslation(document, part, translation);
+        if (mode === 'bilingual') {
+            output.push(formatBilingualTranslation(document, part, translation));
+            continue;
+        }
         if (document.format === 'html') {
-            return `${part.prefix}${escapeHtml(translation)}${part.suffix}`;
+            output.push(`${part.prefix}${escapeHtml(translation)}${part.suffix}`);
+            continue;
         }
         const formattedTranslation = ['srt', 'vtt', 'ass'].includes(document.format)
             ? preserveSubtitleMarkup(part.source, translation)
             : translation;
-        return `${part.prefix}${formattedTranslation}${part.suffix}`;
-    }).join('');
+        output.push(`${part.prefix}${formattedTranslation}${part.suffix}`);
+    }
+    return output.join('');
 }
 
 function getAtPath(value: unknown, path: Array<string | number>): unknown {

--- a/entrypoints/utils/documentTranslationApi.ts
+++ b/entrypoints/utils/documentTranslationApi.ts
@@ -111,25 +111,35 @@ export async function translateDocumentSegments(
     }
 
     let nextIndex = 0;
+    let stopped = false;
     const workerCount = Math.min(3, segments.length);
     const worker = async () => {
         while (true) {
+            if (stopped) return;
             throwIfAborted(options.signal);
             const index = nextIndex;
             nextIndex += 1;
             if (index >= segments.length) return;
 
             try {
-                translations[segments[index].id] = await translateText(segments[index].source, context, {
+                const translation = await translateText(segments[index].source, context, {
                     signal: options.signal,
                     pageContext,
                     serviceOverride: options.serviceOverride,
                     modelOverride: options.modelOverride,
                     maxRetries: options.maxRetries,
                 });
+                // Promise.all rejects as soon as one worker fails, but the other
+                // in-flight workers still settle later. Do not let those workers
+                // report stale progress or claim more document segments.
+                if (stopped) return;
+                translations[segments[index].id] = translation;
                 completed += 1;
                 reportProgress();
             } catch (error) {
+                if (stopped) return;
+                stopped = true;
+                if (options.signal?.aborted) throwIfAborted(options.signal);
                 throw new Error(`第 ${index + 1} 段文档翻译失败：${getErrorMessage(error)}`);
             }
         }

--- a/entrypoints/utils/documentTranslationBinary.ts
+++ b/entrypoints/utils/documentTranslationBinary.ts
@@ -30,7 +30,7 @@ if (typeof window !== 'undefined') {
 
 const BINARY_DOCUMENT_FORMATS = new Set<DocumentFormat>(['pdf', 'epub', 'docx']);
 const DOCX_PARAGRAPH_PATTERN = /<w:p\b[^>]*>[\s\S]*?<\/w:p>/gu;
-const DOCX_TEXT_TOKEN_PATTERN = /<w:t\b[^>]*>([\s\S]*?)<\/w:t>|<w:tab\b[^>]*\/>|<w:br\b[^>]*\/>/gu;
+const DOCX_TEXT_TOKEN_PATTERN = /<w:t\b[^>]*>([\s\S]*?)<\/w:t>|<w:tab\b[^>]*\/>|<w:(?:br|cr)\b[^>]*\/>/gu;
 const ARCHIVE_ENTRY_LIMIT = 4_000;
 const ARCHIVE_ENTRY_BYTES_LIMIT = 24 * 1024 * 1024;
 const ARCHIVE_TOTAL_BYTES_LIMIT = 96 * 1024 * 1024;
@@ -975,8 +975,13 @@ async function renderEpub(document: ParsedDocument, translations: readonly strin
 }
 
 function docxTextNodes(value: string): string {
-    const lines = value.replace(/\r\n?/gu, '\n').split('\n');
-    return lines.map((line, index) => `${index > 0 ? '<w:br/>' : ''}<w:t xml:space="preserve">${xmlEscape(line)}</w:t>`).join('');
+    const tokens = value.replace(/\r\n?/gu, '\n').split(/(\n|\t)/u);
+    const content = tokens.map((token) => {
+        if (token === '\n') return '<w:br/>';
+        if (token === '\t') return '<w:tab/>';
+        return token ? `<w:t xml:space="preserve">${xmlEscape(token)}</w:t>` : '';
+    }).join('');
+    return content || '<w:t></w:t>';
 }
 
 function translatedDocxParagraph(value: string): string {
@@ -985,8 +990,8 @@ function translatedDocxParagraph(value: string): string {
 
 function replaceDocxParagraphText(paragraph: string, value: string): string {
     let replaced = false;
-    return paragraph.replace(/<w:t\b[^>]*>[\s\S]*?<\/w:t>/gu, () => {
-        if (replaced) return '<w:t></w:t>';
+    return paragraph.replace(/<w:t\b[^>]*>[\s\S]*?<\/w:t>|<w:tab\b[^>]*\/>|<w:(?:br|cr)\b[^>]*\/>/gu, () => {
+        if (replaced) return '';
         replaced = true;
         return docxTextNodes(value);
     });

--- a/entrypoints/utils/documentTranslationPreview.ts
+++ b/entrypoints/utils/documentTranslationPreview.ts
@@ -6,6 +6,8 @@ import {
 
 export type DocumentPreviewMode = DocumentRenderMode | 'source';
 
+const PREVIEW_SOFT_BREAK = '\u2028';
+
 const PREVIEW_STYLE = `
 :root { color-scheme: light; font-family: Inter, "SF Pro Text", "PingFang SC", "Microsoft YaHei", system-ui, sans-serif; color: #20242d; background: #fff; }
 * { box-sizing: border-box; }
@@ -75,7 +77,8 @@ function inlineMarkdown(value: string): string {
         const index = tokens.push(html) - 1;
         return `\u0000${index}\u0000`;
     };
-    let working = value.replace(/`([^`\n]+)`/gu, (_, code: string) => token(`<code>${escapeHtml(code)}</code>`));
+    let working = value.replace(new RegExp(PREVIEW_SOFT_BREAK, 'gu'), () => token('<br>'));
+    working = working.replace(/`([^`\n]+)`/gu, (_, code: string) => token(`<code>${escapeHtml(code)}</code>`));
     working = working.replace(/!\[([^\]]*)\]\([^)]+\)/gu, (_, alt: string) => token(`<span class="reader-link">${escapeHtml(alt || '图片')}</span>`));
     working = working.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+|#[^)]+)\)/gu, (_, label: string) => token(`<span class="reader-link">${escapeHtml(label)}</span>`));
     working = escapeHtml(working)
@@ -174,7 +177,15 @@ export function createDocumentPreviewHtml(
 ): string {
     const sourceTranslations = document.segments.map((segment) => segment.source);
     const source = renderDocument(document, sourceTranslations, 'translated');
-    const translated = renderDocument(document, translations, 'translated');
+    const previewTranslations = ['markdown', 'txt'].includes(document.format)
+        ? Array.from({length: document.segments.length}, (_, index) => {
+            const translation = translations[index];
+            return translation === undefined
+                ? document.segments[index].source
+                : translation.replace(/\r\n?|\n/gu, PREVIEW_SOFT_BREAK);
+        })
+        : translations;
+    const translated = renderDocument(document, previewTranslations, 'translated');
 
     if (document.format === 'html') {
         const content = mode === 'source'

--- a/entrypoints/utils/edgeTts.ts
+++ b/entrypoints/utils/edgeTts.ts
@@ -46,6 +46,20 @@ interface EndpointToken {
 
 let endpointToken: EndpointToken | null = null;
 
+function createAbortError(): Error {
+  try {
+    return new DOMException('语音合成已取消', 'AbortError');
+  } catch {
+    const error = new Error('语音合成已取消');
+    error.name = 'AbortError';
+    return error;
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw createAbortError();
+}
+
 function normalizeLanguage(language: string): string {
   const normalized = String(language || '').replace(/_/gu, '-').trim();
   if (!normalized || normalized === 'auto' || normalized === 'detect') return 'en-US';
@@ -111,10 +125,12 @@ function tokenExpiry(token: string): number {
   }
 }
 
-async function getEndpointToken(): Promise<EndpointToken> {
+async function getEndpointToken(signal?: AbortSignal): Promise<EndpointToken> {
+  throwIfAborted(signal);
   if (endpointToken && Date.now() < endpointToken.expiresAt - 3 * 60 * 1000) return endpointToken;
 
   const signature = await createSignature(ENDPOINT_URL);
+  throwIfAborted(signal);
   const response = await runtimeFetch(ENDPOINT_URL, {
     method: 'POST',
     headers: {
@@ -128,12 +144,14 @@ async function getEndpointToken(): Promise<EndpointToken> {
       'Content-Type': 'application/json; charset=utf-8',
     },
     body: '',
+    signal,
   });
   if (!response.ok) throw new Error(`Edge TTS endpoint failed: ${response.status}`);
   const payload = await readJsonResponse<{ t?: string; r?: string }>(
     response,
     'Edge TTS endpoint returned invalid JSON',
   );
+  throwIfAborted(signal);
   if (!payload.t || !payload.r) throw new Error('Edge TTS endpoint returned an invalid token');
   endpointToken = { token: payload.t, region: payload.r, expiresAt: tokenExpiry(payload.t) };
   return endpointToken;
@@ -179,9 +197,10 @@ function concatBuffers(buffers: ArrayBuffer[]): ArrayBuffer {
   return output.buffer;
 }
 
-async function synthesizeWithVoice(voice: string, endpoint: EndpointToken, chunks: string[]): Promise<EdgeTtsAudio> {
+async function synthesizeWithVoice(voice: string, endpoint: EndpointToken, chunks: string[], signal?: AbortSignal): Promise<EdgeTtsAudio> {
   const audioBuffers: ArrayBuffer[] = [];
   for (const chunk of chunks) {
+    throwIfAborted(signal);
     const response = await runtimeFetch(`https://${endpoint.region}.tts.speech.microsoft.com/cognitiveservices/v1`, {
       method: 'POST',
       headers: {
@@ -191,25 +210,29 @@ async function synthesizeWithVoice(voice: string, endpoint: EndpointToken, chunk
         'X-Microsoft-OutputFormat': OUTPUT_FORMAT,
       },
       body: buildEdgeTtsSsml(chunk, voice),
+      signal,
     });
     if (!response.ok) throw new Error(`Edge TTS synthesis failed: ${response.status}`);
     audioBuffers.push(await response.arrayBuffer());
   }
+  throwIfAborted(signal);
   return { audio: concatBuffers(audioBuffers), contentType: 'audio/mpeg', voice };
 }
 
-export async function synthesizeEdgeTts(text: string, language: string, preferredVoices: unknown = []): Promise<EdgeTtsAudio> {
+export async function synthesizeEdgeTts(text: string, language: string, preferredVoices: unknown = [], signal?: AbortSignal): Promise<EdgeTtsAudio> {
+  throwIfAborted(signal);
   if (!text.trim()) throw new Error('Edge TTS 文本为空');
   const voices = edgeTtsVoiceCandidatesForLanguage(language, preferredVoices);
   if (voices.length === 0) throw new Error('Edge TTS voice is unavailable for this language');
 
-  const endpoint = await getEndpointToken();
+  const endpoint = await getEndpointToken(signal);
   const chunks = splitText(text);
   const failures: string[] = [];
   for (const voice of voices) {
     try {
-      return await synthesizeWithVoice(voice, endpoint, chunks);
+      return await synthesizeWithVoice(voice, endpoint, chunks, signal);
     } catch (error) {
+      if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) throw createAbortError();
       failures.push(`${voice}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/entrypoints/utils/inputBox.ts
+++ b/entrypoints/utils/inputBox.ts
@@ -39,6 +39,39 @@ export function getInputBoxText(element: HTMLElement): string {
     return (element.innerText || element.textContent || '').trim();
 }
 
+/**
+ * 获取输入目标的原始值快照。与 getInputBoxText 不同，这里保留首尾空白，
+ * 用于确认异步翻译返回前用户是否编辑过输入框。
+ */
+export function getInputBoxValueSnapshot(element: HTMLElement): string {
+    const tagName = element.tagName.toLowerCase();
+
+    if (tagName === 'input' || tagName === 'textarea') {
+        return (element as HTMLInputElement | HTMLTextAreaElement).value;
+    }
+
+    return element.innerText || element.textContent || '';
+}
+
+export interface InputBoxTranslationCommitState {
+    signal: AbortSignal;
+    expectedValue: string;
+    currentValue: string;
+    expectedConfigGeneration: number;
+    currentConfigGeneration: number;
+    isEnabled: boolean;
+    isSiteDisabled: boolean;
+}
+
+/** 判断一个异步输入框翻译结果是否仍可安全写回页面。 */
+export function canCommitInputBoxTranslation(state: InputBoxTranslationCommitState): boolean {
+    return !state.signal.aborted
+        && state.isEnabled
+        && !state.isSiteDisabled
+        && state.currentConfigGeneration === state.expectedConfigGeneration
+        && state.currentValue === state.expectedValue;
+}
+
 /** 判断一次键盘事件是否匹配当前的三连击触发方式。 */
 export function matchesInputBoxTrigger(event: KeyboardEvent, trigger: InputBoxTrigger): boolean {
     switch (trigger) {

--- a/entrypoints/utils/selectionTranslatorCore.ts
+++ b/entrypoints/utils/selectionTranslatorCore.ts
@@ -33,6 +33,24 @@ export interface SelectionAnswerCandidate extends SelectionContentRequest {
     answer: string;
 }
 
+/** Keep independent async channels from invalidating one another's completion. */
+export class SelectionRequestTokenGate {
+    private generation = 0;
+
+    begin(): number {
+        this.generation += 1;
+        return this.generation;
+    }
+
+    invalidate(): void {
+        this.generation += 1;
+    }
+
+    isCurrent(token: number): boolean {
+        return token === this.generation;
+    }
+}
+
 function normalizeSelectionRequestLanguage(value: string): string {
     return String(value || '').trim().replace(/_/g, '-').toLowerCase();
 }

--- a/entrypoints/utils/siteRules.ts
+++ b/entrypoints/utils/siteRules.ts
@@ -17,6 +17,11 @@ export interface AutoTranslatePageConfig {
     disabledExtensionDomains?: readonly string[];
 }
 
+export interface FullPageContextMenuPresentation {
+    enabled: boolean;
+    title: string;
+}
+
 function parseSiteUrl(input: string | URL): URL | null {
     if (input instanceof URL) {
         return input.protocol === 'http:' || input.protocol === 'https:'
@@ -139,4 +144,18 @@ export function shouldAutoTranslatePage(
     // 就应生效。HTTP(S) 与可注册域名限制只属于新增的网站名单。
     if (config.autoTranslate === true) return true;
     return isAlwaysTranslateSite(input, config.alwaysTranslateDomains);
+}
+
+/** 让右键菜单的可用性与当前站点生命周期状态保持一致。 */
+export function getFullPageContextMenuPresentation(
+    isTranslated: boolean,
+    isSiteDisabled: boolean,
+): FullPageContextMenuPresentation {
+    if (isSiteDisabled) {
+        return {enabled: false, title: '流畅阅读（当前网站已禁用）'};
+    }
+    return {
+        enabled: true,
+        title: isTranslated ? '流畅阅读取消翻译' : '流畅阅读翻译',
+    };
 }

--- a/entrypoints/utils/translateApi.ts
+++ b/entrypoints/utils/translateApi.ts
@@ -16,6 +16,7 @@ import { resolveConfiguredModel, servicesType } from './option';
 import { getPageTranslationContext } from './pageContext';
 import { getMissingCredentialMessage } from './configValidation';
 import { isTrustedCredentialStorageContext } from './credentials';
+import { getTranslationLanguages } from './translationLanguage';
 import {
   isRetryableTranslationError,
   TranslationRequestError,
@@ -163,17 +164,18 @@ function scheduleVideoCountSave(): void {
  */
 export async function translateText(origin: string, context: string = document.title, options: TranslateOptions = {}): Promise<string> {
   const selectedService = options.serviceOverride || config.service;
+  const selectedModel = resolveConfiguredModel(
+    options.modelOverride || config.model[selectedService],
+    options.modelOverride || config.customModel[selectedService],
+  );
+  const selectedLanguages = getTranslationLanguages(options);
   const {
     retryDelay = 1000, 
     timeout = 45000,
     useCache = config.useCache,
     skipLanguageDetection = false,
-    serviceOverride,
-    sourceLanguage,
-    targetLanguage,
     signal,
     queueSession,
-    modelOverride,
   } = options;
   const aiSdkService = servicesType.isAiSdk(selectedService);
   const explicitRetryPolicy = options.maxRetries !== undefined;
@@ -188,14 +190,13 @@ export async function translateText(origin: string, context: string = document.t
     return origin || '';
   }
 
-  const service = serviceOverride || config.service;
-  assertTranslationCredentials(service, modelOverride);
+  assertTranslationCredentials(selectedService, selectedModel);
   // 如果目标语言与当前文本语言相同，直接返回原文
-  if (!skipLanguageDetection && detectlang(origin.replace(/[\s\u3000]/g, '')) === (targetLanguage || config.to)) {
+  if (!skipLanguageDetection && detectlang(origin.replace(/[\s\u3000]/g, '')) === selectedLanguages.targetLanguage) {
     return origin;
   }
 
-  const pageContext = await resolvePageContext(options.pageContext, service, modelOverride);
+  const pageContext = await resolvePageContext(options.pageContext, selectedService, selectedModel);
   throwIfAborted(signal);
 
   // 同一富文本回退可能产生多个短请求；合并持久化写入，避免每个 slot
@@ -215,10 +216,10 @@ export async function translateText(origin: string, context: string = document.t
             pageContext,
             origin,
             useCache,
-            serviceOverride,
-            sourceLanguage,
-            targetLanguage,
-            modelOverride,
+            serviceOverride: selectedService,
+            sourceLanguage: selectedLanguages.sourceLanguage,
+            targetLanguage: selectedLanguages.targetLanguage,
+            modelOverride: selectedModel,
             requestTimeoutMs: Math.max(1_000, timeout - 1_000),
           }),
           timeout,
@@ -267,24 +268,24 @@ export async function translateTextBatch(
   if (origins.length === 0) return [];
 
   const selectedService = options.serviceOverride || config.service;
+  const selectedModel = resolveConfiguredModel(
+    options.modelOverride || config.model[selectedService],
+    options.modelOverride || config.customModel[selectedService],
+  );
+  const selectedLanguages = getTranslationLanguages(options);
   const {
     retryDelay = 1000,
     timeout = 45000,
     useCache = config.useCache,
-    serviceOverride,
-    sourceLanguage,
-    targetLanguage,
     signal,
     queueSession,
-    modelOverride,
   } = options;
-  const service = serviceOverride || config.service;
-  assertTranslationCredentials(service, modelOverride);
+  assertTranslationCredentials(selectedService, selectedModel);
   const aiSdkService = servicesType.isAiSdk(selectedService);
   const explicitRetryPolicy = options.maxRetries !== undefined;
   const maxRetries = options.maxRetries ?? (aiSdkService ? 2 : 3);
   throwIfAborted(signal);
-  const pageContext = await resolvePageContext(options.pageContext, service, modelOverride);
+  const pageContext = await resolvePageContext(options.pageContext, selectedService, selectedModel);
   throwIfAborted(signal);
 
   scheduleTranslationCountSave();
@@ -299,10 +300,10 @@ export async function translateTextBatch(
             pageContext,
             origin: origins,
             useCache,
-            serviceOverride,
-            sourceLanguage,
-            targetLanguage,
-            modelOverride,
+            serviceOverride: selectedService,
+            sourceLanguage: selectedLanguages.sourceLanguage,
+            targetLanguage: selectedLanguages.targetLanguage,
+            modelOverride: selectedModel,
             requestTimeoutMs: Math.max(1_000, timeout - 1_000),
           }),
           timeout,
@@ -339,7 +340,10 @@ export async function translateVideoText(origin: string): Promise<string> {
   if (!cleanedOrigin) return origin || '';
 
   const service = config.videoService;
-  const pageContext = await resolvePageContext(undefined, service);
+  const model = resolveConfiguredModel(config.model[service], config.customModel[service]);
+  const languages = getTranslationLanguages();
+  const useCache = config.useCache;
+  const pageContext = await resolvePageContext(undefined, service, model);
 
   // 视频字幕是高频、短文本请求。计数保留在内存中，并合并为低频写入，避免
   // storage 写入和配置订阅回调把播放器主线程拖入高频循环。
@@ -349,8 +353,11 @@ export async function translateVideoText(origin: string): Promise<string> {
         context: `YouTube 视频字幕：${typeof document === 'undefined' ? '' : document.title}`,
         pageContext,
         origin,
-        useCache: config.useCache,
+        useCache,
         serviceOverride: service,
+        modelOverride: model,
+        sourceLanguage: languages.sourceLanguage,
+        targetLanguage: languages.targetLanguage,
         requestTimeoutMs: 19_000,
       }), 20_000, undefined, lease);
     return unwrapTranslationResponse<string>(response);

--- a/entrypoints/utils/vocabularyBook.ts
+++ b/entrypoints/utils/vocabularyBook.ts
@@ -510,13 +510,15 @@ export class VocabularyBookRepository {
     });
   }
 
-  private async pruneReviewLogs(entryId: string): Promise<void> {
+  private async pruneReviewLogs(entryId: string): Promise<string[]> {
     const logs = await this.db.reviewLogs.where('entryId').equals(entryId).sortBy('reviewedAt');
-    if (logs.length <= VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY) return;
+    if (logs.length <= VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY) return [];
     logs.sort((left, right) => left.reviewedAt - right.reviewedAt || left.id.localeCompare(right.id));
-    await this.db.reviewLogs.bulkDelete(
-      logs.slice(0, logs.length - VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY).map((log) => log.id),
-    );
+    const deletedIds = logs
+      .slice(0, logs.length - VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY)
+      .map((log) => log.id);
+    await this.db.reviewLogs.bulkDelete(deletedIds);
+    return deletedIds;
   }
 
   async review(
@@ -743,19 +745,30 @@ export class VocabularyBookRepository {
         // Review logs are immutable. Re-importing the same export is
         // idempotent, and a malicious ID collision may not overwrite a log
         // that belongs to another word.
-        if (usedLogIds.has(log.id)) continue;
+        if (usedLogIds.has(log.id)) {
+          skipped += 1;
+          continue;
+        }
         usedLogIds.add(log.id);
         logsToAdd.push(log);
       }
 
       if (logsToAdd.length > 0) await this.db.reviewLogs.bulkAdd(logsToAdd);
-      for (const entryId of affectedEntryIds) await this.pruneReviewLogs(entryId);
+      const deletedLogIds = new Set<string>();
+      for (const entryId of affectedEntryIds) {
+        for (const deletedId of await this.pruneReviewLogs(entryId)) deletedLogIds.add(deletedId);
+      }
+      const retainedImportedLogs = logsToAdd.reduce(
+        (count, log) => count + (deletedLogIds.has(log.id) ? 0 : 1),
+        0,
+      );
+      skipped += logsToAdd.length - retainedImportedLogs;
 
       return {
         inserted,
         updated,
         skipped,
-        reviewLogsImported: logsToAdd.length,
+        reviewLogsImported: retainedImportedLogs,
       };
     });
   }

--- a/entrypoints/utils/vocabularyBookProtocol.ts
+++ b/entrypoints/utils/vocabularyBookProtocol.ts
@@ -107,6 +107,125 @@ export interface VocabularyEntry {
   schemaVersion: typeof VOCABULARY_ENTRY_SCHEMA_VERSION;
 }
 
+/**
+ * Keep an in-progress review batch stable while replacing pending cards with
+ * the latest persisted snapshots. Cards removed or reviewed elsewhere are no
+ * longer pending, and unrelated newly-due cards wait for the next batch.
+ */
+export function reconcileVocabularyReviewQueue(
+  queue: readonly VocabularyEntry[],
+  latestEntries: readonly VocabularyEntry[],
+  now = Date.now(),
+): VocabularyEntry[] {
+  const latestById = new Map(latestEntries.map((entry) => [entry.id, entry]));
+  const seen = new Set<string>();
+  const reconciled: VocabularyEntry[] = [];
+
+  for (const queuedEntry of queue) {
+    if (seen.has(queuedEntry.id)) continue;
+    seen.add(queuedEntry.id);
+    const latest = latestById.get(queuedEntry.id);
+    if (!latest || latest.nextReviewAt === null || latest.nextReviewAt > now) continue;
+    reconciled.push(latest);
+  }
+
+  return reconciled;
+}
+
+export interface VocabularyReviewSessionState {
+  queue: VocabularyEntry[];
+  completed: number;
+  answerVisible: boolean;
+}
+
+export interface VocabularyReviewSessionProgress {
+  current: VocabularyEntry | null;
+  position: number;
+  total: number;
+}
+
+export function createVocabularyReviewSession(
+  queue: readonly VocabularyEntry[],
+): VocabularyReviewSessionState {
+  return {
+    queue: [...queue],
+    completed: 0,
+    answerVisible: false,
+  };
+}
+
+export function advanceVocabularyReviewSession(
+  session: VocabularyReviewSessionState,
+  entryId: string,
+): VocabularyReviewSessionState {
+  const containsEntry = session.queue.some((entry) => entry.id === entryId);
+  return {
+    queue: session.queue[0]?.id === entryId
+      ? session.queue.slice(1)
+      : session.queue.filter((entry) => entry.id !== entryId),
+    completed: session.completed + (containsEntry ? 1 : 0),
+    answerVisible: false,
+  };
+}
+
+export function reconcileVocabularyReviewSession(
+  session: VocabularyReviewSessionState,
+  latestEntries: readonly VocabularyEntry[],
+  now = Date.now(),
+): VocabularyReviewSessionState {
+  const previous = session.queue[0];
+  const queue = reconcileVocabularyReviewQueue(session.queue, latestEntries, now);
+  const next = queue[0];
+  const currentChanged = !previous
+    || !next
+    || previous.id !== next.id
+    || previous.updatedAt !== next.updatedAt
+    || previous.reviewCount !== next.reviewCount;
+  return {
+    queue,
+    completed: session.completed,
+    answerVisible: currentChanged ? false : session.answerVisible,
+  };
+}
+
+export function vocabularyReviewSessionProgress(
+  session: VocabularyReviewSessionState,
+): VocabularyReviewSessionProgress {
+  const current = session.queue[0] ?? null;
+  const total = session.completed + session.queue.length;
+  return {
+    current,
+    position: current ? Math.min(session.completed + 1, total) : total,
+    total,
+  };
+}
+
+export interface VocabularyLifecycleGuard {
+  isActive(): boolean;
+  dispose(): void;
+  runAfterReady(
+    ready: PromiseLike<unknown>,
+    initialize: () => void | PromiseLike<void>,
+  ): Promise<boolean>;
+}
+
+/** Prevent an async mounted hook from registering work after its component was removed. */
+export function createVocabularyLifecycleGuard(): VocabularyLifecycleGuard {
+  let active = true;
+  return {
+    isActive: () => active,
+    dispose: () => {
+      active = false;
+    },
+    async runAfterReady(ready, initialize) {
+      await ready;
+      if (!active) return false;
+      await initialize();
+      return active;
+    },
+  };
+}
+
 export interface VocabularyReviewLog {
   id: string;
   entryId: string;
@@ -182,7 +301,9 @@ export interface VocabularyExportOptions {
 export interface VocabularyImportResult {
   inserted: number;
   updated: number;
+  /** Invalid, duplicate, colliding, or retention-pruned entries and logs. */
   skipped: number;
+  /** Imported review logs still present after per-entry retention pruning. */
   reviewLogsImported: number;
 }
 

--- a/tests/contentFeatureLifecycle.test.ts
+++ b/tests/contentFeatureLifecycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureContentFeatureMounted } from '@/entrypoints/utils/contentFeatureLifecycle';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((nextResolve) => { resolve = nextResolve; });
+    return {promise, resolve};
+}
+
+describe('content feature activation lifecycle', () => {
+    it('retries after a restored activation reused the disabled activation pending mount', async () => {
+        const staleMount = deferred<void>();
+        let mounted = false;
+        let callCount = 0;
+        const mount = vi.fn(() => {
+            callCount += 1;
+            if (callCount === 1) return staleMount.promise;
+            mounted = true;
+            return Promise.resolve();
+        });
+
+        const activation = ensureContentFeatureMounted({
+            mount,
+            isMounted: () => mounted,
+            isStillDesired: () => true,
+        });
+        staleMount.resolve();
+        await activation;
+
+        expect(mount).toHaveBeenCalledTimes(2);
+        expect(mounted).toBe(true);
+    });
+
+    it('does not retry a settled mount after the activation was disabled again', async () => {
+        const staleMount = deferred<void>();
+        let desired = true;
+        const mount = vi.fn(() => staleMount.promise);
+
+        const activation = ensureContentFeatureMounted({
+            mount,
+            isMounted: () => false,
+            isStillDesired: () => desired,
+        });
+        desired = false;
+        staleMount.resolve();
+        await activation;
+
+        expect(mount).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/documentTranslation.test.ts
+++ b/tests/documentTranslation.test.ts
@@ -59,6 +59,14 @@ describe('document translation parser', () => {
         expect(output).toContain('[Guide](https://example.com)');
     });
 
+    it('Markdown 双语导出按原始行组合内联代码前后的译文', () => {
+        const document = parseDocument('guide.md', 'Use `npm install` now.\n');
+
+        expect(renderDocument(document, ['使用', '现在。'], 'bilingual')).toBe(
+            'Use `npm install` now.\n> 使用 `npm install` 现在。\n',
+        );
+    });
+
     it('保留 SRT 时间轴、字幕标签和双语行', () => {
         const source = '1\n00:00:01,000 --> 00:00:03,000\n<i>Hello</i> world\n\n2\n00:00:04,000 --> 00:00:05,000\nNext line';
         const document = parseDocument('episode.srt', source);
@@ -68,6 +76,28 @@ describe('document translation parser', () => {
         expect(output).toContain('00:00:01,000 --> 00:00:03,000');
         expect(output).toContain('<i>Hello</i> world\n<i>你好</i> 世界');
         expect(output).toContain('2\n00:00:04,000 --> 00:00:05,000');
+    });
+
+    it('无空行分隔的 SRT 不会把下一条序号吞进上一段译文', () => {
+        const source = [
+            '1',
+            '00:00:01,000 --> 00:00:03,000',
+            'First cue',
+            '2',
+            '00:00:04,000 --> 00:00:05,000',
+            'Second cue',
+        ].join('\n');
+        const document = parseDocument('episode.srt', source);
+
+        expect(document.segments.map((segment) => segment.source)).toEqual(['First cue', 'Second cue']);
+        expect(renderDocument(document, ['第一条', '第二条'], 'translated')).toBe([
+            '1',
+            '00:00:01,000 --> 00:00:03,000',
+            '第一条',
+            '2',
+            '00:00:04,000 --> 00:00:05,000',
+            '第二条',
+        ].join('\n'));
     });
 
     it('保留 VTT 头部和 ASS 对话字段', () => {
@@ -114,5 +144,60 @@ describe('document translation parser', () => {
         const textPreview = createDocumentPreviewHtml(text, ['第一段', '第二段'], 'translated');
         expect(textPreview).toContain('第一段');
         expect(textPreview).not.toContain('First paragraph');
+    });
+
+    it('Markdown 译文包含换行时仍与原始行一一对应', () => {
+        const document = parseDocument('guide.md', '# One\n\nTwo');
+        const preview = createDocumentPreviewHtml(document, ['# 一\n额外行', '二'], 'translated');
+
+        expect(preview).toContain('<h1 class="reader-translation fluentread-translation">一<br>额外行</h1>');
+        expect(preview).toContain('<p class="reader-translation fluentread-translation">二</p>');
+        expect(preview).not.toContain('>Two<');
+    });
+
+    it('TXT 译文内的空行保留在当前段落而不会挤占下一段', () => {
+        const document = parseDocument('notes.txt', 'First\n\nSecond');
+        const preview = createDocumentPreviewHtml(document, ['第一\n\n补充', '第二'], 'translated');
+
+        expect(preview).toContain('<p class="reader-translation fluentread-translation">第一<br><br>补充</p>');
+        expect(preview).toContain('<p class="reader-translation fluentread-translation">第二</p>');
+        expect(preview).not.toContain('>First<');
+        expect(preview).not.toContain('>Second<');
+    });
+
+    it('HTML 文本实体以可读文本翻译且预览不会双重转义', () => {
+        const document = parseDocument('guide.html', '<p>Hello&nbsp;world &amp; friends</p>');
+
+        expect(document.segments.map((segment) => segment.source)).toEqual(['Hello\u00a0world & friends']);
+        const sourcePreview = createDocumentPreviewHtml(document, [], 'source');
+        expect(sourcePreview).toContain('Hello\u00a0world &amp; friends');
+        expect(sourcePreview).not.toContain('&amp;nbsp;');
+        expect(sourcePreview).not.toContain('&amp;amp; friends');
+
+        const bilingual = renderDocument(document, ['你好世界与朋友'], 'bilingual');
+        expect(bilingual).toContain('Hello&nbsp;world &amp; friends');
+        expect(bilingual).toContain('你好世界与朋友');
+    });
+
+    it('HTML 属性值中的大于号不会被当作标签结束位置', () => {
+        const source = '<p title="1 > 0" data-note="> stays quoted">Hello</p>';
+        const document = parseDocument('guide.html', source);
+
+        expect(document.segments.map((segment) => segment.source)).toEqual(['Hello']);
+        expect(renderDocument(document, ['你好'], 'translated')).toBe(
+            '<p title="1 > 0" data-note="> stays quoted">你好</p>',
+        );
+    });
+
+    it('HTML 嵌套受保护标签不会让 pre 剩余内容进入翻译队列', () => {
+        const document = parseDocument(
+            'guide.html',
+            '<pre>before<code>const value = 1;</code>after</pre><p>Translate me</p>',
+        );
+
+        expect(document.segments.map((segment) => segment.source)).toEqual(['Translate me']);
+        expect(renderDocument(document, ['翻译我'], 'translated')).toBe(
+            '<pre>before<code>const value = 1;</code>after</pre><p>翻译我</p>',
+        );
     });
 });

--- a/tests/documentTranslationApi.test.ts
+++ b/tests/documentTranslationApi.test.ts
@@ -87,4 +87,33 @@ describe('document translation API', () => {
         await expect(translateDocumentSegments([{id: 0, source: 'Broken'}], {fileName: 'sample.json'}))
             .rejects.toThrow('第 1 段文档翻译失败：provider unavailable');
     });
+
+    it('AI 并行 worker 首次失败后不再派发余下段落或继续报告进度', async () => {
+        mocks.config.service = 'openai';
+        const releaseSlowRequests: Array<() => void> = [];
+        const progress: number[] = [];
+        mocks.translateText.mockImplementation((origin: string) => {
+            if (origin === 'fail') return Promise.reject(new Error('provider unavailable'));
+            return new Promise<string>((resolve) => {
+                releaseSlowRequests.push(() => resolve(`T:${origin}`));
+            });
+        });
+        const segments = Array.from({length: 8}, (_, id) => ({
+            id,
+            source: id === 0 ? 'fail' : `Source ${id}`,
+        }));
+
+        await expect(translateDocumentSegments(segments, {
+            fileName: 'sample.md',
+            onProgress: ({completed}) => progress.push(completed),
+        })).rejects.toThrow('第 1 段文档翻译失败');
+        expect(mocks.translateText).toHaveBeenCalledTimes(3);
+
+        releaseSlowRequests.forEach((release) => release());
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mocks.translateText).toHaveBeenCalledTimes(3);
+        expect(progress).toEqual([0]);
+    });
 });

--- a/tests/documentTranslationBinary.test.ts
+++ b/tests/documentTranslationBinary.test.ts
@@ -85,6 +85,37 @@ describe('binary document translation formats', () => {
         expect(linkedChapter).not.toContain('<title>译文：');
     });
 
+    it('ePub 章节的文本实体以可读文本翻译并保留原 XHTML 表达', async () => {
+        const zip = new JSZip();
+        zip.file('mimetype', 'application/epub+zip', {compression: 'STORE'});
+        zip.file('META-INF/container.xml', [
+            '<container><rootfiles>',
+            '<rootfile full-path="OEBPS/content.opf"/>',
+            '</rootfiles></container>',
+        ].join(''));
+        zip.file('OEBPS/content.opf', [
+            '<package><manifest>',
+            '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>',
+            '</manifest><spine><itemref idref="chapter"/></spine></package>',
+        ].join(''));
+        zip.file('OEBPS/chapter.xhtml', [
+            '<html><head><title>Entities</title></head><body>',
+            '<p>Hello&#160;world &amp; friends</p>',
+            '</body></html>',
+        ].join(''));
+        const bytes = await zip.generateAsync({type: 'uint8array'});
+
+        const parsed = await parseBinaryDocument('entities.epub', bytes);
+        expect(parsed.segments.map((segment) => segment.source)).toEqual(['Hello\u00a0world & friends']);
+
+        const download = await createDocumentDownload(parsed, ['你好世界与朋友'], 'bilingual');
+        const exportedZip = await JSZip.loadAsync(download.data as Uint8Array);
+        const chapter = await exportedZip.file('OEBPS/chapter.xhtml')!.async('string');
+        expect(chapter).toContain('Hello&#160;world &amp; friends');
+        expect(chapter).not.toContain('Hello&amp;#160;world');
+        expect(chapter).toContain('你好世界与朋友');
+    });
+
     it('提取 DOCX 正文、页眉和页脚，并保持 OOXML 包可重新解析', async () => {
         const parsed = await parseBinaryDocument('sample.docx', loadBytes('sample.docx'));
         expect(parsed.format).toBe('docx');
@@ -108,6 +139,32 @@ describe('binary document translation formats', () => {
 
         const reparsed = await parseBinaryDocument('sample.bilingual.docx', download.data as Uint8Array);
         expect(reparsed.segments.length).toBeGreaterThan(parsed.segments.length);
+    });
+
+    it('DOCX 仅译文导出不会重复原段落的换行和制表符', async () => {
+        const zip = new JSZip();
+        zip.file('[Content_Types].xml', '<Types/>');
+        zip.file('word/document.xml', [
+            '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r>',
+            '<w:t>Hello</w:t><w:br/><w:t>World</w:t><w:cr/><w:t>More</w:t><w:tab/><w:t>Again</w:t>',
+            '</w:r></w:p></w:body></w:document>',
+        ].join(''));
+        const bytes = await zip.generateAsync({type: 'uint8array'});
+        const parsed = await parseBinaryDocument('line-breaks.docx', bytes);
+
+        expect(parsed.segments[0].source).toBe('Hello\nWorld\nMore\tAgain');
+        const download = await createDocumentDownload(parsed, ['你好\n世界\n更多\t继续'], 'translated');
+        const exportedZip = await JSZip.loadAsync(download.data as Uint8Array);
+        const documentXml = await exportedZip.file('word/document.xml')!.async('string');
+
+        expect(documentXml.match(/<w:br\s*\/>/gu)).toHaveLength(2);
+        expect(documentXml).not.toContain('<w:cr');
+        expect(documentXml.match(/<w:tab\s*\/>/gu)).toHaveLength(1);
+        expect(documentXml).toMatch(/更多<\/w:t><w:tab\/><w:t xml:space="preserve">继续/u);
+        expect(documentXml).not.toContain('Hello');
+        expect(documentXml).not.toContain('World');
+        expect(documentXml).not.toContain('More');
+        expect(documentXml).not.toContain('Again');
     });
 
     it('PDF 双语导出将每张原页和保留版式的译页并排放在同一页', async () => {

--- a/tests/inputBox.test.ts
+++ b/tests/inputBox.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+    canCommitInputBoxTranslation,
     getInputBoxText,
+    getInputBoxValueSnapshot,
     isInputElement,
     matchesInputBoxTrigger,
     removeTriggerSymbols,
@@ -41,5 +43,69 @@ describe('输入框快捷键', () => {
         expect(removeTriggerSymbols('Hello   ', 'triple_space')).toBe('Hello');
         expect(removeTriggerSymbols('Hello===', 'triple_equal')).toBe('Hello');
         expect(getInputBoxText({ ...fakeElement('DIV'), innerText: ' Hello world ' } as unknown as HTMLElement)).toBe('Hello world');
+    });
+
+    it('用原始值快照检测翻译期间的用户编辑', () => {
+        const input = { ...fakeElement('INPUT'), value: 'Hello  ' } as unknown as HTMLElement;
+        expect(getInputBoxValueSnapshot(input)).toBe('Hello  ');
+
+        const contentEditable = {
+            ...fakeElement('DIV', { contenteditable: 'true' }),
+            innerText: ' Hello\n',
+        } as unknown as HTMLElement;
+        expect(getInputBoxValueSnapshot(contentEditable)).toBe(' Hello\n');
+    });
+
+    it('禁用后即使恢复启用，旧 feature signal 的结果仍不可落地', () => {
+        const controller = new AbortController();
+        controller.abort();
+
+        expect(canCommitInputBoxTranslation({
+            signal: controller.signal,
+            expectedValue: 'Hello',
+            currentValue: 'Hello',
+            expectedConfigGeneration: 0,
+            currentConfigGeneration: 0,
+            isEnabled: true,
+            isSiteDisabled: false,
+        })).toBe(false);
+    });
+
+    it('用户在请求期间编辑输入框时拒绝覆盖新内容', () => {
+        const controller = new AbortController();
+
+        expect(canCommitInputBoxTranslation({
+            signal: controller.signal,
+            expectedValue: 'Hello',
+            currentValue: 'Hello!',
+            expectedConfigGeneration: 0,
+            currentConfigGeneration: 0,
+            isEnabled: true,
+            isSiteDisabled: false,
+        })).toBe(false);
+        expect(canCommitInputBoxTranslation({
+            signal: controller.signal,
+            expectedValue: 'Hello',
+            currentValue: 'Hello',
+            expectedConfigGeneration: 0,
+            currentConfigGeneration: 0,
+            isEnabled: true,
+            isSiteDisabled: false,
+        })).toBe(true);
+    });
+
+    it('输入翻译关闭后快速恢复也会永久作废旧配置 generation', () => {
+        const controller = new AbortController();
+
+        expect(canCommitInputBoxTranslation({
+            signal: controller.signal,
+            expectedValue: 'Hello',
+            currentValue: 'Hello',
+            expectedConfigGeneration: 2,
+            currentConfigGeneration: 3,
+            // 模拟关闭后已经快速恢复，当前看起来又是 enabled。
+            isEnabled: true,
+            isSiteDisabled: false,
+        })).toBe(false);
     });
 });

--- a/tests/selectionTranslatorCore.test.ts
+++ b/tests/selectionTranslatorCore.test.ts
@@ -11,6 +11,7 @@ import {
     reconcileSelectionPresentation,
     resolveSelectionDictionaryFallback,
     resolveSelectionVocabularyAnswer,
+    SelectionRequestTokenGate,
     summarizeSelectionContext,
 } from '@/entrypoints/utils/selectionTranslatorCore';
 import { buildEdgeTtsSsml, edgeTtsVoiceCandidatesForLanguage, edgeTtsVoiceForLanguage, synthesizeEdgeTts } from '@/entrypoints/utils/edgeTts';
@@ -65,6 +66,33 @@ describe('selection translator presentation stability', () => {
         expect(reconcileSelectionPresentation(openTooltip, 'icon', true)).toEqual({showIndicator: true, showTooltip: false});
         expect(reconcileSelectionPresentation(openTooltip, 'dot', true)).toEqual({showIndicator: true, showTooltip: false});
         expect(reconcileSelectionPresentation(openTooltip, 'shortcut', true)).toEqual({showIndicator: false, showTooltip: false});
+    });
+});
+
+describe('selection translator async request generations', () => {
+    it('keeps vocabulary lookup refreshes independent from an in-flight save', () => {
+        const lookupGate = new SelectionRequestTokenGate();
+        const saveGate = new SelectionRequestTokenGate();
+        const saveToken = saveGate.begin();
+        const firstLookup = lookupGate.begin();
+        const refreshedLookup = lookupGate.begin();
+
+        expect(lookupGate.isCurrent(firstLookup)).toBe(false);
+        expect(lookupGate.isCurrent(refreshedLookup)).toBe(true);
+        expect(saveGate.isCurrent(saveToken)).toBe(true);
+    });
+
+    it('invalidates both channels when the active selection is reset', () => {
+        const lookupGate = new SelectionRequestTokenGate();
+        const saveGate = new SelectionRequestTokenGate();
+        const lookupToken = lookupGate.begin();
+        const saveToken = saveGate.begin();
+
+        lookupGate.invalidate();
+        saveGate.invalidate();
+
+        expect(lookupGate.isCurrent(lookupToken)).toBe(false);
+        expect(saveGate.isCurrent(saveToken)).toBe(false);
     });
 });
 
@@ -190,6 +218,39 @@ describe('selection translator text and speech language normalization', () => {
             expect(String(fetchMock.mock.calls[1]?.[0])).toContain('.tts.speech.microsoft.com');
             expect(fetchMock.mock.calls[1]?.[1]?.body).toContain('en-US-JennyNeural');
             expect(fetchMock.mock.calls[2]?.[1]?.body).toContain('en-US-AvaMultilingualNeural');
+        } finally {
+            vi.stubGlobal('fetch', originalFetch);
+        }
+    });
+
+    it('aborts a pending Edge TTS synthesis instead of trying another voice', async () => {
+        const originalFetch = globalThis.fetch;
+        const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+            if (String(input).includes('/apps/endpoint')) {
+                return Promise.resolve({ok: true, json: async () => ({t: 'abort-test-token', r: 'eastus'})} as Response);
+            }
+            return new Promise<Response>((_resolve, reject) => {
+                const rejectAbort = () => {
+                    const error = new Error('aborted');
+                    error.name = 'AbortError';
+                    reject(error);
+                };
+                init?.signal?.addEventListener('abort', rejectAbort, {once: true});
+                if (init?.signal?.aborted) rejectAbort();
+            });
+        });
+        vi.stubGlobal('fetch', fetchMock);
+        const controller = new AbortController();
+
+        try {
+            const request = synthesizeEdgeTts('cancel me', 'en-US', [], controller.signal);
+            await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+            controller.abort();
+
+            await expect(request).rejects.toMatchObject({name: 'AbortError'});
+            const synthesisCalls = fetchMock.mock.calls.filter(([input]) => String(input).includes('.tts.speech.microsoft.com'));
+            expect(synthesisCalls).toHaveLength(1);
+            expect(synthesisCalls[0]?.[1]?.signal).toBe(controller.signal);
         } finally {
             vi.stubGlobal('fetch', originalFetch);
         }

--- a/tests/siteRules.test.ts
+++ b/tests/siteRules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    getFullPageContextMenuPresentation,
     getSiteBaseDomain,
     isAlwaysTranslateSite,
     isExtensionDisabledOnSite,
@@ -77,6 +78,21 @@ describe('始终翻译网站规则', () => {
             alwaysTranslateDomains: [],
             disabledExtensionDomains: disabledDomains,
         })).toBe(false);
+    });
+
+    it('禁用站点时同步禁用全文翻译右键菜单', () => {
+        expect(getFullPageContextMenuPresentation(false, true)).toEqual({
+            enabled: false,
+            title: '流畅阅读（当前网站已禁用）',
+        });
+        expect(getFullPageContextMenuPresentation(false, false)).toEqual({
+            enabled: true,
+            title: '流畅阅读翻译',
+        });
+        expect(getFullPageContextMenuPresentation(true, false)).toEqual({
+            enabled: true,
+            title: '流畅阅读取消翻译',
+        });
     });
 
     it('同时保留旧全局自动翻译开关，并只对网站名单限制网页协议', () => {

--- a/tests/translateApiPerformance.test.ts
+++ b/tests/translateApiPerformance.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     model: {mock: 'mock-model', 'mock-ai': 'mock-ai-model'} as Record<string, string>,
     customModel: {mock: '', 'mock-ai': ''} as Record<string, string>,
     service: 'mock',
+    from: 'en',
     to: 'zh-CN',
     useCache: true,
     enableAIContext: false,
@@ -65,6 +66,11 @@ describe('translation API request lifecycle performance', () => {
     mocks.config.enableAIContext = false;
     mocks.config.service = 'mock';
     mocks.config.videoService = 'mock';
+    mocks.config.from = 'en';
+    mocks.config.to = 'zh-CN';
+    mocks.config.useCache = true;
+    mocks.config.model.mock = 'mock-model';
+    mocks.config.model['mock-ai'] = 'mock-ai-model';
     Object.defineProperty(globalThis, 'document', {
       value: {title: 'Fixture video title'},
       configurable: true,
@@ -159,6 +165,82 @@ describe('translation API request lifecycle performance', () => {
       requestTimeoutMs: 44_000,
     }));
     expect(mocks.config.model['mock-ai']).toBe('mock-ai-model');
+  });
+
+  it('普通单条和批量请求在排队前冻结默认服务、模型与语言', async () => {
+    mocks.config.maxConcurrentTranslations = 1;
+    const blocker = deferred<string>();
+    mocks.sendMessage.mockImplementation(({origin}: {origin: string | string[]}) => {
+      if (origin === 'Blocking source') return blocker.promise;
+      return Promise.resolve(Array.isArray(origin) ? origin.map(value => `译:${value}`) : `译:${origin}`);
+    });
+
+    const first = translateText('Blocking source', 'Context', {maxRetries: 0});
+    await vi.waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+    const queuedSingle = translateText('Queued source', 'Context', {maxRetries: 0});
+    const queuedBatch = translateTextBatch(['Queued batch source'], 'Context', {maxRetries: 0});
+
+    mocks.config.service = 'mock-ai';
+    mocks.config.model['mock-ai'] = 'changed-model';
+    mocks.config.from = 'ja';
+    mocks.config.to = 'fr';
+    blocker.resolve('阻塞请求译文');
+
+    await expect(first).resolves.toBe('阻塞请求译文');
+    await expect(queuedSingle).resolves.toBe('译:Queued source');
+    await expect(queuedBatch).resolves.toEqual(['译:Queued batch source']);
+
+    expect(mocks.sendMessage.mock.calls.slice(1).map(([message]) => message)).toEqual([
+      expect.objectContaining({
+        origin: 'Queued source',
+        serviceOverride: 'mock',
+        modelOverride: 'mock-model',
+        sourceLanguage: 'en',
+        targetLanguage: 'zh-CN',
+      }),
+      expect.objectContaining({
+        origin: ['Queued batch source'],
+        serviceOverride: 'mock',
+        modelOverride: 'mock-model',
+        sourceLanguage: 'en',
+        targetLanguage: 'zh-CN',
+      }),
+    ]);
+  });
+
+  it('视频请求在排队前冻结视频服务、模型与语言', async () => {
+    mocks.config.maxConcurrentTranslations = 1;
+    const blocker = deferred<string>();
+    mocks.sendMessage
+      .mockImplementationOnce(() => blocker.promise)
+      .mockResolvedValueOnce('字幕译文');
+
+    const first = translateText('Blocking source', 'Context', {maxRetries: 0});
+    await vi.waitFor(() => expect(mocks.sendMessage).toHaveBeenCalledTimes(1));
+    mocks.config.videoService = 'mock-ai';
+    mocks.config.model['mock-ai'] = 'video-model';
+    mocks.config.from = 'en';
+    mocks.config.to = 'ja';
+    const video = translateVideoText('Queued subtitle');
+    await Promise.resolve();
+
+    mocks.config.videoService = 'mock';
+    mocks.config.model['mock-ai'] = 'changed-video-model';
+    mocks.config.from = 'de';
+    mocks.config.to = 'fr';
+    mocks.config.useCache = false;
+    blocker.resolve('阻塞请求译文');
+
+    await expect(first).resolves.toBe('阻塞请求译文');
+    await expect(video).resolves.toBe('字幕译文');
+    expect(mocks.sendMessage).toHaveBeenLastCalledWith(expect.objectContaining({
+      origin: 'Queued subtitle',
+      serviceOverride: 'mock-ai',
+      modelOverride: 'video-model',
+      sourceLanguage: 'en',
+      targetLanguage: 'ja',
+      useCache: true,
+    }));
   });
 
   it('lets migrated AI SDK services own retries and restores structured error details', async () => {
@@ -316,6 +398,9 @@ describe('translation API request lifecycle performance', () => {
       origin: 'A subtitle source',
       useCache: true,
       serviceOverride: 'mock-ai',
+      modelOverride: 'mock-ai-model',
+      sourceLanguage: 'en',
+      targetLanguage: 'zh-CN',
       requestTimeoutMs: 19_000,
     });
   });

--- a/tests/userscriptUnsupportedCapabilities.test.ts
+++ b/tests/userscriptUnsupportedCapabilities.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest';
 import {
+    isAreaTranslatorMounted,
     mountAreaTranslator,
     mountImageTranslator,
     mountNewApiComponent,
@@ -11,6 +12,7 @@ import {
 
 describe('userscript extension-only capability stubs', () => {
     it('never mounts area, image, or video runtimes', () => {
+        expect(isAreaTranslatorMounted()).toBe(false);
         expect(mountAreaTranslator()).toBeUndefined();
         expect(mountImageTranslator()).toBeUndefined();
         expect(unmountAreaTranslator()).toBeUndefined();

--- a/tests/vocabularyBook.test.ts
+++ b/tests/vocabularyBook.test.ts
@@ -5,15 +5,22 @@ import {
   VOCABULARY_BOOK_EXPORT_VERSION,
   VOCABULARY_BOOK_MAX_ENTRIES,
   VOCABULARY_ENTRY_SCHEMA_VERSION,
+  VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY,
   VOCABULARY_REVIEW_AGAIN_DELAY_MS,
   VOCABULARY_REVIEW_GOOD_INTERVALS_MS,
   FluentReadVocabularyBookDatabase,
   VocabularyBookRepository,
+  advanceVocabularyReviewSession,
   buildAnkiTsv,
   buildVocabularyCloze,
   buildVocabularyIdentityKey,
+  createVocabularyLifecycleGuard,
+  createVocabularyReviewSession,
   normalizeEnglishWord,
+  reconcileVocabularyReviewQueue,
+  reconcileVocabularyReviewSession,
   sanitizeVocabularySourceUrl,
+  vocabularyReviewSessionProgress,
   vocabularyImportNeedsConfirmation,
   type VocabularyBookExport,
 } from '@/entrypoints/utils/vocabularyBook';
@@ -86,6 +93,77 @@ describe('review and import presentation helpers', () => {
     expect(vocabularyImportNeedsConfirmation(20 * 1024 * 1024)).toBe(false);
     expect(vocabularyImportNeedsConfirmation(20 * 1024 * 1024 + 1)).toBe(true);
     expect(vocabularyImportNeedsConfirmation(Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+
+  it('advances and reconciles review-session position after an external review or deletion', async () => {
+    const common = await repository.upsert(baseInput(), NOW);
+    const rare = await repository.upsert(
+      baseInput({ term: 'Rare', translation: '罕见' }),
+      NOW + 1,
+    );
+    const stable = await repository.upsert(
+      baseInput({ term: 'Stable', translation: '稳定' }),
+      NOW + 2,
+    );
+    const unrelated = await repository.upsert(
+      baseInput({ term: 'Other', translation: '其他' }),
+      NOW + 3,
+    );
+
+    const started = { ...createVocabularyReviewSession([common, rare, stable]), answerVisible: true };
+    const afterCommon = advanceVocabularyReviewSession(started, common.id);
+    expect(vocabularyReviewSessionProgress(afterCommon)).toMatchObject({
+      current: rare,
+      position: 2,
+      total: 3,
+    });
+    expect(afterCommon.answerVisible).toBe(false);
+
+    const withRareAnswer = { ...afterCommon, answerVisible: true };
+    await repository.review(rare.id, 'good', NOW + 10);
+    const afterExternalReview = reconcileVocabularyReviewSession(
+      withRareAnswer,
+      await repository.list(),
+      NOW + 20,
+    );
+    expect(afterExternalReview.queue.map((entry) => entry.id)).toEqual([stable.id]);
+    expect(afterExternalReview.answerVisible).toBe(false);
+    expect(vocabularyReviewSessionProgress(afterExternalReview)).toMatchObject({
+      current: stable,
+      position: 2,
+      total: 2,
+    });
+    expect(afterExternalReview.queue.some((entry) => entry.id === unrelated.id)).toBe(false);
+
+    await repository.remove(rare.id);
+    const afterExternalDelete = reconcileVocabularyReviewSession(
+      withRareAnswer,
+      await repository.list(),
+      NOW + 20,
+    );
+    expect(afterExternalDelete.queue.map((entry) => entry.id)).toEqual([stable.id]);
+    expect(afterExternalDelete.answerVisible).toBe(false);
+    expect(vocabularyReviewSessionProgress(afterExternalDelete)).toMatchObject({
+      current: stable,
+      position: 2,
+      total: 2,
+    });
+    expect(reconcileVocabularyReviewQueue([stable], [], NOW + 20)).toEqual([]);
+  });
+
+  it('does not initialize an async component lifecycle after it was disposed', async () => {
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => { resolveReady = resolve; });
+    const lifecycle = createVocabularyLifecycleGuard();
+    let initialized = false;
+    const initialization = lifecycle.runAfterReady(ready, () => { initialized = true; });
+
+    lifecycle.dispose();
+    resolveReady();
+
+    await expect(initialization).resolves.toBe(false);
+    expect(initialized).toBe(false);
+    expect(lifecycle.isActive()).toBe(false);
   });
 });
 
@@ -406,6 +484,53 @@ describe('JSON export and import', () => {
       status: 'mastered',
     });
     expect(merged?.translations['zh-cn'].text).toBe('本地新译文');
+  });
+
+  it('reports only imported review logs that remain after retention pruning', async () => {
+    const entry = await repository.upsert(baseInput(), NOW);
+    const incoming = await repository.exportData({ includePrivateContext: true, now: NOW + 1 });
+    incoming.reviewLogs = Array.from(
+      { length: VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY + 1 },
+      (_, index) => ({
+        id: `10000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+        entryId: entry.id,
+        rating: 'again' as const,
+        reviewedAt: NOW + index,
+        beforeLevel: 0 as const,
+        afterLevel: 0 as const,
+        nextReviewAt: NOW + index + VOCABULARY_REVIEW_AGAIN_DELAY_MS,
+      }),
+    );
+    await repository.clear();
+
+    const result = await repository.importData(incoming, NOW + 2);
+    const restored = await repository.getByTerm('en', 'common');
+    const retainedLogs = await repository.getReviewLogs(restored!.id);
+
+    expect(result).toMatchObject({
+      inserted: 1,
+      skipped: 1,
+      reviewLogsImported: VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY,
+    });
+    expect(retainedLogs).toHaveLength(VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY);
+    expect(retainedLogs[0]?.reviewedAt).toBe(NOW + 1);
+    expect(retainedLogs.at(-1)?.reviewedAt).toBe(NOW + VOCABULARY_REVIEW_LOG_MAX_PER_ENTRY);
+  });
+
+  it('counts immutable review-log collisions as skipped on idempotent re-import', async () => {
+    const entry = await repository.upsert(baseInput(), NOW);
+    await repository.review(entry.id, 'good', NOW + 1);
+    const incoming = await repository.exportData({ includePrivateContext: true, now: NOW + 2 });
+
+    const result = await repository.importData(incoming, NOW + 3);
+
+    expect(result).toMatchObject({
+      inserted: 0,
+      updated: 0,
+      skipped: 2,
+      reviewLogsImported: 0,
+    });
+    await expect(repository.getReviewLogs(entry.id)).resolves.toHaveLength(1);
   });
 
   it('merges encounter snapshots independently from the latest reviewed learning state', async () => {

--- a/tests/vocabularyBookComponent.test.ts
+++ b/tests/vocabularyBookComponent.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'components/VocabularyBook.vue'), 'utf8');
+
+function extractBlock(startNeedle: string, endNeedle: string): string {
+  const start = source.indexOf(startNeedle);
+  const end = source.indexOf(endNeedle, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('VocabularyBook component lifecycle wiring', () => {
+  it('registers async listeners and initial load only after configReady is still active', () => {
+    const mountedBlock = extractBlock('onMounted(async () => {', 'onBeforeUnmount(() => {');
+    const guardedInitialization = extractBlock(
+      'await lifecycle.runAfterReady(configReady, async () => {',
+      '});\n});\n\nonBeforeUnmount',
+    );
+
+    expect(mountedBlock).not.toContain('await configReady;');
+    expect(guardedInitialization).toContain('unsubscribeConfig = subscribeConfig');
+    expect(guardedInitialization).toContain('browser.runtime.onMessage.addListener(handleBookChanged)');
+    expect(guardedInitialization).toContain("window.addEventListener('keydown', handleReviewKeyboard)");
+    expect(guardedInitialization).toContain("document.addEventListener('visibilitychange', handleVisibilityChange)");
+    expect(guardedInitialization).toContain('await loadEntries();');
+  });
+
+  it('disposes the lifecycle guard before removing listeners', () => {
+    const unmountBlock = extractBlock('onBeforeUnmount(() => {', '</script>');
+    expect(unmountBlock.indexOf('lifecycle.dispose();')).toBeGreaterThanOrEqual(0);
+    expect(unmountBlock.indexOf('lifecycle.dispose();')).toBeLessThan(
+      unmountBlock.indexOf('browser.runtime.onMessage.removeListener(handleBookChanged)'),
+    );
+  });
+});

--- a/tests/vocabularyBookComponentLifecycle.test.ts
+++ b/tests/vocabularyBookComponentLifecycle.test.ts
@@ -1,0 +1,190 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import vue from '@vitejs/plugin-vue';
+import { parseHTML } from 'linkedom';
+import { createServer, type Plugin } from 'vite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface ComponentTestState {
+  browser: {
+    runtime: {
+      sendMessage: () => Promise<unknown>;
+      onMessage: {
+        addListener: () => void;
+        removeListener: () => void;
+      };
+    };
+  };
+  config: Record<string, unknown>;
+  configReady: Promise<void>;
+  requestConfigSave: () => Promise<void>;
+  subscribeConfig: () => () => void;
+}
+
+const TEST_STATE_KEY = '__fluentReadVocabularyLifecycleTest';
+
+function setComponentTestState(state: ComponentTestState | undefined): void {
+  const target = globalThis as typeof globalThis & Record<string, unknown>;
+  if (state) target[TEST_STATE_KEY] = state;
+  else delete target[TEST_STATE_KEY];
+}
+
+function componentMocks(): Plugin {
+  return {
+    name: 'vocabulary-lifecycle-test-mocks',
+    enforce: 'pre',
+    resolveId(id) {
+      if (id === 'webextension-polyfill') return '\0vocabulary-browser-mock';
+      if (
+        id === '@/entrypoints/utils/config'
+        || id.endsWith('/entrypoints/utils/config')
+        || id.endsWith('/entrypoints/utils/config.ts')
+      ) {
+        return '\0vocabulary-config-mock';
+      }
+      return null;
+    },
+    load(id) {
+      if (id === '\0vocabulary-browser-mock') {
+        return `export default globalThis.${TEST_STATE_KEY}.browser;`;
+      }
+      if (id === '\0vocabulary-config-mock') {
+        return [
+          `const state = globalThis.${TEST_STATE_KEY};`,
+          'export const config = state.config;',
+          'export const configReady = state.configReady;',
+          'export const requestConfigSave = state.requestConfigSave;',
+          'export const subscribeConfig = state.subscribeConfig;',
+        ].join('\n');
+      }
+      return null;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setComponentTestState(undefined);
+});
+
+describe('VocabularyBook mounted lifecycle', () => {
+  it('does not subscribe, register listeners, or list after unmounting before configReady', async () => {
+    const calls = {
+      runtimeAdd: 0,
+      runtimeSend: 0,
+      subscribe: 0,
+    };
+    let resolveConfigReady!: () => void;
+    const configReady = new Promise<void>((resolveReady) => { resolveConfigReady = resolveReady; });
+    setComponentTestState({
+      browser: {
+        runtime: {
+          sendMessage: async () => {
+            calls.runtimeSend += 1;
+            return { success: true, data: [] };
+          },
+          onMessage: {
+            addListener: () => { calls.runtimeAdd += 1; },
+            removeListener: () => undefined,
+          },
+        },
+      },
+      config: {
+        theme: 'auto',
+        vocabularyBookEnabled: false,
+        selectionTranslatorMode: 'disabled',
+        to: 'zh-CN',
+      },
+      configReady,
+      requestConfigSave: async () => undefined,
+      subscribeConfig: () => {
+        calls.subscribe += 1;
+        return () => undefined;
+      },
+    });
+
+    const { window } = parseHTML('<html><body><div id="app"></div></body></html>');
+    const { document } = window;
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    const windowAdd = vi.fn();
+    const windowRemove = vi.fn();
+    Object.defineProperties(window, {
+      addEventListener: { configurable: true, value: windowAdd },
+      removeEventListener: { configurable: true, value: windowRemove },
+    });
+    const documentAdd = vi.spyOn(document, 'addEventListener');
+    const mediaAdd = vi.fn();
+    const mediaRemove = vi.fn();
+    const matchMedia = vi.fn(() => ({
+      matches: false,
+      addEventListener: mediaAdd,
+      removeEventListener: mediaRemove,
+    }));
+    window.matchMedia = matchMedia as unknown as typeof window.matchMedia;
+
+    vi.stubGlobal('window', window);
+    vi.stubGlobal('document', document);
+    vi.stubGlobal('Node', window.Node);
+    vi.stubGlobal('Element', window.Element);
+    vi.stubGlobal('HTMLElement', window.HTMLElement);
+    vi.stubGlobal('SVGElement', window.SVGElement);
+    vi.stubGlobal('Event', window.Event);
+    vi.stubGlobal('navigator', window.navigator);
+
+    const require = createRequire(import.meta.url);
+    const vueRuntime = require('vue') as typeof import('vue');
+    const server = await createServer({
+      appType: 'custom',
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [componentMocks(), vue()],
+      resolve: { alias: { '@': resolve(process.cwd(), '.') } },
+      root: process.cwd(),
+      server: { hmr: false, middlewareMode: true },
+      ssr: { noExternal: ['webextension-polyfill'] },
+    });
+
+    try {
+      const loaded = await server.ssrLoadModule('/components/VocabularyBook.vue');
+      const component = loaded.default as { render?: () => null; ssrRender?: unknown };
+      component.ssrRender = undefined;
+      component.render = () => null;
+      const renderer = vueRuntime.createRenderer<Record<string, never>, Record<string, unknown>>({
+        patchProp: () => undefined,
+        insert: () => undefined,
+        remove: () => undefined,
+        createElement: () => ({}),
+        createText: () => ({}),
+        createComment: () => ({}),
+        setText: () => undefined,
+        setElementText: () => undefined,
+        parentNode: () => null,
+        nextSibling: () => null,
+        querySelector: () => null,
+        setScopeId: () => undefined,
+        cloneNode: () => ({}),
+        insertStaticContent: () => [{}, {}],
+      });
+      const app = renderer.createApp(component as import('vue').Component);
+      app.provide(vueRuntime.ssrContextKey, { modules: new Set<string>() });
+      app.config.warnHandler = () => undefined;
+      app.mount({});
+      await vueRuntime.nextTick();
+      expect(matchMedia).toHaveBeenCalledTimes(1);
+
+      app.unmount();
+      resolveConfigReady();
+      await configReady;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(calls).toEqual({ runtimeAdd: 0, runtimeSend: 0, subscribe: 0 });
+      expect(windowAdd.mock.calls.filter(([type]) => type === 'keydown')).toHaveLength(0);
+      expect(documentAdd.mock.calls.filter(([type]) => type === 'visibilitychange')).toHaveLength(0);
+      expect(mediaAdd).toHaveBeenCalledTimes(1);
+      expect(mediaRemove).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/userscript/unsupportedCapabilities.ts
+++ b/userscript/unsupportedCapabilities.ts
@@ -5,6 +5,10 @@ export function mountAreaTranslator(): undefined {
 
 export function unmountAreaTranslator(): void {}
 
+export function isAreaTranslatorMounted(): boolean {
+    return false;
+}
+
 export function mountImageTranslator(): void {}
 
 export function unmountImageTranslator(): void {}


### PR DESCRIPTION
## Summary

- fix document translation concurrency, Markdown/HTML/SRT parsing, DOCX controls, preview alignment, and stale task writeback
- fix vocabulary import reporting, in-progress review reconciliation, component teardown, and selection-card state broadcasts
- fix queued translation configuration drift, input-box late writes, selection TTS cancellation, and site disable/restore lifecycle races
- add focused unit, component-mount, integration, and regression coverage for the repaired paths

## Validation

- `pnpm test` — 62 files, 672 tests passed
- `pnpm test:document` — 5 files, 53 tests passed
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm test:userscript`
- `git diff --check`
- isolated production Edge UI suite: popup/options, persistence, responsive layouts, service catalog, and CSS isolation passed with zero console errors
- isolated production Edge document suite: all 12 formats loaded; PDF/ePub/DOCX bilingual exports validated with zero console errors
- isolated real-page translation toggle: translation counts `1 -> 0 -> 1`, neighboring paragraph remained `0 -> 0 -> 0`
- isolated same-page site disable/restore regression passed

Browser checks used a temporary profile and a screen-off normal-sized Edge window with `macos-hidden-cdp` / `launchservices-no-foreground`.

## Test coverage change

- baseline: 59 test files / 643 tests
- final: 62 test files / 672 tests
- net: +3 test files / +29 tests

## Notes

- The installed generic UI runner still contained stale feature-card/navigation counts and headings. Only a temporary local assertion adapter was updated; no product behavior was changed to satisfy stale assertions.
