### PR TITLE
feat(popup): 支持服务与模型关键词快速搜索

### DIFF
--- a/src/app/popup/PopupApp.vue
+++ b/src/app/popup/PopupApp.vue
@@ -1,7 +1,7 @@
 <!--
  @file src/app/popup/PopupApp.vue
  文件职责：实现浏览器 Popup 的主交互界面，连接当前标签页状态、翻译配置、功能抽屉和高频操作，提供轻量但完整的控制中心。
- 主要内容：在配置 hydration 后展示服务/模型选择、页面翻译、站点规则、悬浮/划词/区域/图片/视频开关、缓存清理、文档与设置入口；监听配置并持久化，广播即时变化和处理通知/捐赠弹层。
+ 主要内容：在配置 hydration 后展示可按服务或模型关键词搜索的翻译服务选择器、页面翻译、站点规则、悬浮/划词/区域/图片/视频开关、缓存清理、文档与设置入口；监听配置并持久化，广播即时变化和处理通知/捐赠弹层。
  模块边界：组件编排用户交互与运行时消息，不实现翻译 provider、缓存存储或 content 挂载细节；公共配置由 services/store 管理，页面行为由 content feature 接收消息完成。
 -->
 <!-- Popup 页面归 app 层所有；WXT 入口只负责调用挂载函数。 -->
@@ -104,50 +104,94 @@
           <span class="chevron" :class="{ open: servicePickerOpen }">⌄</span>
         </button>
 
-        <div v-if="servicePickerOpen" class="service-picker-panel" role="listbox" aria-label="翻译服务列表">
+        <div v-if="servicePickerOpen" class="service-picker-panel" role="dialog" aria-label="选择翻译服务">
           <div class="service-picker-heading">
-            <div><strong>选择翻译服务</strong><small>常用服务优先，更多服务{{ moreServicesOpen ? '已展开' : '已收起' }}</small></div>
-            <span>{{ serviceOptions.length }}</span>
+            <div><strong>选择翻译服务</strong><small>{{ servicePickerSummary }}</small></div>
+            <span>{{ servicePickerCount }}</span>
           </div>
 
-          <div class="service-group">
-            <span class="service-group-label">常用服务</span>
-            <button
-              v-for="item in popularServiceOptions"
-              :key="item.value"
-              class="service-option"
-              type="button"
-              role="option"
-              :data-service-value="item.value"
-              :aria-selected="config.service === item.value"
-              @click="selectService(item.value)"
-            >
-              <ServiceIcon :service="item.value" :label="item.label" size="small" />
-              <span>{{ item.label }}</span>
-              <span v-if="config.service === item.value" class="service-option-check">✓</span>
-            </button>
-          </div>
+          <label class="service-search">
+            <Search aria-hidden="true" />
+            <input
+              ref="serviceSearchInput"
+              v-model="serviceSearchQuery"
+              type="search"
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="搜索翻译服务或模型"
+              placeholder="搜索服务或模型，如 gpt、qwen"
+            />
+            <button v-if="serviceSearchQuery" type="button" aria-label="清空服务搜索" @click="clearServiceSearch">×</button>
+          </label>
 
-          <button class="service-more-toggle" type="button" :aria-expanded="moreServicesOpen" @click="moreServicesOpen = !moreServicesOpen">
-            <span>更多服务</span>
-            <span class="service-more-meta">{{ moreServiceOptions.length }} 项 <b :class="{ open: moreServicesOpen }">⌄</b></span>
-          </button>
+          <div class="service-picker-results">
+            <div v-if="serviceSearchActive && serviceSearchResults.length" class="service-group" role="listbox" aria-label="匹配的翻译服务">
+              <span class="service-group-label">匹配服务</span>
+              <button
+                v-for="item in serviceSearchResults"
+                :key="item.value"
+                class="service-option"
+                type="button"
+                role="option"
+                :data-service-value="item.value"
+                :data-matching-models="item.matchingModels.join(',') || undefined"
+                :aria-selected="config.service === item.value"
+                @click="selectService(item.value)"
+              >
+                <ServiceIcon :service="item.value" :label="item.label" size="small" />
+                <span class="service-option-copy">
+                  <strong>{{ item.label }}</strong>
+                  <small v-if="item.matchingModels.length">{{ matchingModelSummary(item.matchingModels) }}</small>
+                </span>
+                <span v-if="config.service === item.value" class="service-option-check">✓</span>
+              </button>
+            </div>
 
-          <div v-if="moreServicesOpen" class="service-group service-group-more">
-            <button
-              v-for="item in moreServiceOptions"
-              :key="item.value"
-              class="service-option"
-              type="button"
-              role="option"
-              :data-service-value="item.value"
-              :aria-selected="config.service === item.value"
-              @click="selectService(item.value)"
-            >
-              <ServiceIcon :service="item.value" :label="item.label" size="small" />
-              <span>{{ item.label }}</span>
-              <span v-if="config.service === item.value" class="service-option-check">✓</span>
-            </button>
+            <p v-else-if="serviceSearchActive" class="service-search-empty" role="status">
+              没有找到包含“{{ serviceSearchQuery.trim() }}”的服务或模型
+            </p>
+
+            <template v-else>
+              <div class="service-group" role="listbox" aria-label="常用翻译服务">
+                <span class="service-group-label">常用服务</span>
+                <button
+                  v-for="item in popularServiceOptions"
+                  :key="item.value"
+                  class="service-option"
+                  type="button"
+                  role="option"
+                  :data-service-value="item.value"
+                  :aria-selected="config.service === item.value"
+                  @click="selectService(item.value)"
+                >
+                  <ServiceIcon :service="item.value" :label="item.label" size="small" />
+                  <span class="service-option-copy"><strong>{{ item.label }}</strong></span>
+                  <span v-if="config.service === item.value" class="service-option-check">✓</span>
+                </button>
+              </div>
+
+              <button class="service-more-toggle" type="button" :aria-expanded="moreServicesOpen" @click="moreServicesOpen = !moreServicesOpen">
+                <span>更多服务</span>
+                <span class="service-more-meta">{{ moreServiceOptions.length }} 项 <b :class="{ open: moreServicesOpen }">⌄</b></span>
+              </button>
+
+              <div v-if="moreServicesOpen" class="service-group service-group-more" role="listbox" aria-label="更多翻译服务">
+                <button
+                  v-for="item in moreServiceOptions"
+                  :key="item.value"
+                  class="service-option"
+                  type="button"
+                  role="option"
+                  :data-service-value="item.value"
+                  :aria-selected="config.service === item.value"
+                  @click="selectService(item.value)"
+                >
+                  <ServiceIcon :service="item.value" :label="item.label" size="small" />
+                  <span class="service-option-copy"><strong>{{ item.label }}</strong></span>
+                  <span v-if="config.service === item.value" class="service-option-check">✓</span>
+                </button>
+              </div>
+            </template>
           </div>
         </div>
       </div>
@@ -506,7 +550,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import browser from 'webextension-polyfill';
 import {
   config as runtimeConfig,
@@ -514,7 +558,7 @@ import {
   requestConfigSave,
   subscribeConfig,
 } from '@/src/services/config/store';
-import { Setting } from '@element-plus/icons-vue';
+import { Search, Setting } from '@element-plus/icons-vue';
 import {
   Config,
   SELECTION_TRANSLATOR_DELAY_MAX,
@@ -524,9 +568,9 @@ import {
   normalizeConfig,
   normalizeSelectionTranslatorDelay,
 } from '@/src/core/config/model';
-import { options, resolveConfiguredModel, servicesType } from '@/src/core/config/catalog';
+import { models, options, resolveConfiguredModel, servicesType } from '@/src/core/config/catalog';
 import { getMissingCredentialMessage } from '@/src/core/config/validation';
-import { getSelectedModelLabel } from '@/src/ui/view-model/serviceCatalog';
+import { getSelectedModelLabel, searchServiceOptions } from '@/src/ui/view-model/serviceCatalog';
 import { SELECTION_TTS_VOICE_OPTIONS } from '@/src/core/config/selectionTts';
 import { getSiteBaseDomain } from '@/src/core/site-rules/domain';
 import { requestTranslationCacheClear } from './cache';
@@ -557,8 +601,10 @@ const noticeType = ref<'success' | 'error'>('success');
 const showCustomMouseHotkeyDialog = ref(false);
 const showCustomSelectionHotkeyDialog = ref(false);
 const servicePicker = ref<HTMLElement | null>(null);
+const serviceSearchInput = ref<HTMLInputElement | null>(null);
+const serviceSearchQuery = ref('');
 const servicePickerOpen = ref(false);
-const moreServicesOpen = ref(true);
+const moreServicesOpen = ref(false);
 const hydrated = ref(false);
 let lastSerialized = '';
 let applyingExternalConfig = false;
@@ -576,13 +622,29 @@ const persistConfig = (value: unknown) => requestConfigSave(value, browser.runti
 
 const allServiceOptions = computed(() => options.services.filter((item: any) => !item.disabled));
 const serviceOptions = computed(() => filterAvailableTranslationServices(allServiceOptions.value));
+const serviceSearchActive = computed(() => Boolean(serviceSearchQuery.value.trim()));
+const serviceSearchResults = computed(() => searchServiceOptions(
+  serviceOptions.value,
+  serviceSearchQuery.value,
+  models,
+  config.value.model,
+  config.value.customModel,
+));
 const videoServiceOptions = computed(() => filterAvailableTranslationServices(allServiceOptions.value));
 const videoSubtitleFontSizeOptions = VIDEO_SUBTITLE_FONT_SIZE_OPTIONS;
 const popularServiceValues = ['freeTranslation', 'microsoft', 'google', 'deepL', 'deeplx', 'deepseek', 'openai', 'gemini', 'claude'];
 const popularServiceOptions = computed(() => popularServiceValues
-  .map(value => serviceOptions.value.find((item: any) => item.value === value))
+  .map(value => serviceSearchResults.value.find((item: any) => item.value === value))
   .filter((item): item is any => Boolean(item)));
-const moreServiceOptions = computed(() => serviceOptions.value.filter((item: any) => !popularServiceValues.includes(item.value)));
+const moreServiceOptions = computed(() => serviceSearchResults.value.filter((item: any) => !popularServiceValues.includes(item.value)));
+const selectedServiceIsMore = computed(() => serviceOptions.value.some((item: any) =>
+  item.value === config.value.service && !popularServiceValues.includes(item.value)));
+const servicePickerCount = computed(() => serviceSearchActive.value
+  ? `${serviceSearchResults.value.length}/${serviceOptions.value.length}`
+  : serviceOptions.value.length);
+const servicePickerSummary = computed(() => serviceSearchActive.value
+  ? '正在按服务名称与模型关键词筛选'
+  : `常用服务优先，更多服务${moreServicesOpen.value ? '已展开' : '已收起'}`);
 const styleOptions = computed(() => options.styles.filter((item: any) => !item.disabled));
 const selectedServiceUnavailableMessage = computed(() => getTranslationServiceUnavailableMessage(config.value.service));
 const selectedVideoServiceUnavailableMessage = computed(() => getTranslationServiceUnavailableMessage(config.value.videoService));
@@ -710,6 +772,7 @@ darkMode.onchange = () => { if (config.value.theme === 'auto') applyTheme('auto'
 function closeServicePicker(event?: Event) {
   if (event && servicePicker.value?.contains(event.target as Node)) return;
   servicePickerOpen.value = false;
+  serviceSearchQuery.value = '';
 }
 function openDonation() { donationVisible.value = true; }
 function closeDonation() { donationVisible.value = false; }
@@ -722,11 +785,28 @@ function handleServicePickerKeydown(event: KeyboardEvent) {
 function toggleServicePicker() {
   if (!config.value.on) return;
   servicePickerOpen.value = !servicePickerOpen.value;
-  if (servicePickerOpen.value) moreServicesOpen.value = true;
+  if (servicePickerOpen.value) {
+    moreServicesOpen.value = selectedServiceIsMore.value;
+    void nextTick(() => serviceSearchInput.value?.focus());
+  } else {
+    serviceSearchQuery.value = '';
+  }
 }
 function selectService(value: string) {
   config.value.service = value;
   servicePickerOpen.value = false;
+  serviceSearchQuery.value = '';
+}
+function clearServiceSearch() {
+  serviceSearchQuery.value = '';
+  void nextTick(() => serviceSearchInput.value?.focus());
+}
+function matchingModelSummary(matchingModels: string[]) {
+  const visibleModels = matchingModels.slice(0, 2);
+  const remainingCount = matchingModels.length - visibleModels.length;
+  return remainingCount > 0
+    ? `${visibleModels.join(' · ')} +${remainingCount}`
+    : visibleModels.join(' · ');
 }
 function toggleAIContext() {
   if (!canUseAIContext.value || !config.value.on || translating.value) return;

--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -1,7 +1,7 @@
 /**
  * @file src/app/popup/popup.css
  * 文件职责：定义固定尺寸浏览器 Popup 的视觉系统与交互状态，包括亮暗主题、服务选择、功能卡、设置抽屉、通知和响应式细节。
- * 主要内容：声明页面变量、品牌头部、加载 inert 状态、英雄操作区、服务菜单、站点控制、功能网格、开关与滑块、drawer/dialog、捐赠区和状态反馈，并适配 Element Plus 内部结构。
+ * 主要内容：声明页面变量、品牌头部、加载 inert 状态、英雄操作区、可按服务或模型筛选的服务菜单、站点控制、功能网格、开关与滑块、drawer/dialog、捐赠区和状态反馈，并适配 Element Plus 内部结构。
  * 模块边界：样式只对应 PopupApp 的 DOM 和受控第三方组件，不决定配置值、能力可用性或消息行为；跨页面 token 在 src/ui/styles，Options/文档页各自维护页面样式。
  */
 /* Popup 页面样式跟随 app 页面边界，避免 WXT 入口目录继续承载实现。 */
@@ -37,7 +37,7 @@
 * { box-sizing: border-box; }
 html, body, #app { width: 400px; min-width: 400px; min-height: 560px; margin: 0; overflow-x: hidden; background: #f6f7fb; }
 :root.dark body, :root.dark #app { background: #14161b; }
-button, select { font: inherit; }
+button, select, input { font: inherit; }
 button { color: inherit; }
 button:focus-visible, select:focus-visible { outline: 3px solid rgba(239, 71, 118, .22); outline-offset: 2px; }
 
@@ -143,15 +143,31 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
 .chevron { position: absolute; right: 14px; color: var(--muted); font-size: 18px; line-height: 1; transform: translateY(-2px); transition: transform 160ms ease; }
 .chevron.open { transform: translateY(1px) rotate(180deg); }
 .service-picker-panel {
-  position: absolute; z-index: 30; top: calc(100% + 8px); right: 0; left: 0; max-height: 318px; overflow: auto;
+  position: absolute; z-index: 30; top: calc(100% + 8px); right: 0; left: 0; display: flex; max-height: 318px; overflow: hidden; flex-direction: column;
   padding: 10px; border: 1px solid var(--line); border-radius: 18px; background: var(--surface);
-  box-shadow: 0 18px 36px rgba(27, 36, 57, .18); scrollbar-width: thin;
+  box-shadow: 0 18px 36px rgba(27, 36, 57, .18);
 }
 .service-picker-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 2px 4px 9px; }
 .service-picker-heading div { display: flex; flex-direction: column; gap: 2px; }
 .service-picker-heading strong { font-size: 12px; }
 .service-picker-heading small, .service-picker-heading > span, .service-group-label, .service-more-meta { color: var(--muted); font-size: 9px; }
 .service-picker-heading > span { padding-top: 2px; }
+.service-search {
+  display: flex; flex: none; align-items: center; gap: 7px; height: 34px; margin-bottom: 8px; padding: 0 8px;
+  border: 1px solid var(--line); border-radius: 10px; color: var(--muted); background: var(--surface-soft);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+.service-search:focus-within { border-color: rgba(239, 71, 118, .48); box-shadow: 0 0 0 3px rgba(239, 71, 118, .08); }
+.service-search > svg { width: 14px; height: 14px; flex: none; }
+.service-search input { width: 100%; min-width: 0; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 10px; }
+.service-search input::placeholder { color: var(--muted); opacity: .72; }
+.service-search input::-webkit-search-cancel-button { display: none; }
+.service-search button {
+  display: grid; width: 20px; height: 20px; flex: none; padding: 0; place-items: center; border: 0; border-radius: 6px;
+  color: var(--muted); background: transparent; cursor: pointer; font-size: 15px; line-height: 1;
+}
+.service-search button:hover { color: var(--brand-strong); background: var(--brand-soft); }
+.service-picker-results { min-height: 0; overflow-y: auto; scrollbar-width: thin; }
 .service-group { display: grid; gap: 4px; }
 .service-group-label { padding: 4px 6px 3px; font-weight: 700; }
 .service-group-more { padding-top: 6px; border-top: 1px solid var(--line); }
@@ -160,8 +176,12 @@ h2 { margin-bottom: 0; font-size: 15px; line-height: 1.35; letter-spacing: -.01e
   border-radius: 11px; color: var(--ink); background: transparent; text-align: left; cursor: pointer; transition: background 140ms ease, border-color 140ms ease;
 }
 .service-option:hover, .service-option[aria-selected="true"] { border-color: rgba(239, 71, 118, .22); background: var(--brand-soft); }
-.service-option > span:nth-child(2) { overflow: hidden; flex: 1; font-size: 11px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.service-option-copy { display: flex; min-width: 0; flex: 1; flex-direction: column; gap: 1px; }
+.service-option-copy strong, .service-option-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.service-option-copy strong { font-size: 11px; font-weight: 650; }
+.service-option-copy small { color: var(--muted); font-size: 8px; font-weight: 600; }
 .service-option-check { color: var(--brand-strong); font-size: 14px; font-weight: 800; }
+.service-search-empty { margin: 24px 10px; color: var(--muted); font-size: 10px; line-height: 1.6; text-align: center; }
 .service-more-toggle { justify-content: space-between; margin-top: 7px; border-color: var(--line); background: var(--surface-soft); font-size: 10px; font-weight: 700; }
 .service-more-toggle:hover { border-color: rgba(239, 71, 118, .32); background: var(--brand-soft); }
 .service-more-meta { display: inline-flex; align-items: center; gap: 4px; }

--- a/src/ui/view-model/serviceCatalog.ts
+++ b/src/ui/view-model/serviceCatalog.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/ui/view-model/serviceCatalog.ts
  * 文件职责：为服务与模型选择界面提供无框架的视图模型转换，把扁平配置选项整理成可搜索、可分组和可稳定展示的数据。
- * 主要内容：定义 ServiceOption/ServiceGroup，清理标签星标，按 disabled 分隔项构建服务组，按关键词过滤服务和模型，解析当前模型标签，并把常用、选中和自定义模型稳定拆分。
+ * 主要内容：定义 ServiceOption/ServiceGroup，清理标签星标，按 disabled 分隔项构建服务组，按服务或模型关键词筛选并返回命中模型，解析当前模型标签，并把常用、选中和自定义模型稳定拆分。
  * 模块边界：这些函数不读取 Vue 状态、不修改 Config，也不判断平台能力或发起连接测试；原始目录由 core/config 提供，Popup/Options 等调用方负责交互与渲染。
  */
 import { customModelString, resolveConfiguredModel, servicesType } from '@/src/core/config/catalog'
@@ -17,6 +17,10 @@ export interface ServiceGroup {
   id: string
   label: string
   items: ServiceOption[]
+}
+
+export interface ServiceSearchOption extends ServiceOption {
+  matchingModels: string[]
 }
 
 export function cleanServiceLabel(label: string) {
@@ -62,6 +66,45 @@ export function filterModels(modelOptions: string[], query: string) {
   const keyword = query.trim().toLocaleLowerCase()
   if (!keyword) return modelOptions
   return modelOptions.filter((model) => model.toLocaleLowerCase().includes(keyword))
+}
+
+function searchTextMatches(value: string, rawKeyword: string, compactKeyword: string) {
+  const normalizedValue = value.normalize('NFKC').toLocaleLowerCase()
+  if (normalizedValue.includes(rawKeyword)) return true
+  if (!compactKeyword) return false
+  return normalizedValue.replace(/[\s._/()-]+/gu, '').includes(compactKeyword)
+}
+
+export function searchServiceOptions(
+  serviceOptions: ServiceOption[],
+  query: string,
+  modelOptions: ReadonlyMap<string, readonly string[]>,
+  selectedModels: Record<string, string> = {},
+  customModels: Record<string, string> = {},
+): ServiceSearchOption[] {
+  const rawKeyword = query.trim().normalize('NFKC').toLocaleLowerCase()
+  if (!rawKeyword) return serviceOptions.map((item) => ({ ...item, matchingModels: [] }))
+
+  const compactKeyword = rawKeyword.replace(/[\s._/()-]+/gu, '')
+  return serviceOptions.flatMap((item) => {
+    const selectedModel = selectedModels[item.value]
+    const configuredModel = resolveConfiguredModel(selectedModel, customModels[item.value])
+    const searchableModels = Array.from(new Set([
+      ...(modelOptions.get(item.value) || []),
+      selectedModel,
+      configuredModel,
+    ].filter((model): model is string => Boolean(model))))
+    const matchingModels = searchableModels.filter((model) => searchTextMatches(model, rawKeyword, compactKeyword))
+    const serviceMatches = searchTextMatches(
+      `${item.label} ${item.value} ${item.description || ''}`,
+      rawKeyword,
+      compactKeyword,
+    )
+
+    return serviceMatches || matchingModels.length > 0
+      ? [{ ...item, matchingModels }]
+      : []
+  })
 }
 
 export function getSelectedModelLabel(

--- a/tests/popupFeatureVisibility.test.ts
+++ b/tests/popupFeatureVisibility.test.ts
@@ -66,4 +66,21 @@ describe('popup feature visibility', () => {
         expect(popup).toContain('Chrome内置AI翻译（当前浏览器不可用）');
         expect(popup).toContain('原有开关偏好已保留');
     });
+
+    it('supports quick popup search by service name and model keyword', () => {
+        const popup = source('src/app/popup/PopupApp.vue');
+        const styles = source('src/app/popup/popup.css');
+
+        expect(popup).toContain('searchServiceOptions(');
+        expect(popup).toContain('aria-label="搜索翻译服务或模型"');
+        expect(popup).toContain('class="service-picker-panel" role="dialog" aria-label="选择翻译服务"');
+        expect(popup).toContain('role="listbox" aria-label="匹配的翻译服务"');
+        expect(popup).toContain('placeholder="搜索服务或模型，如 gpt、qwen"');
+        expect(popup).toContain(':data-matching-models="item.matchingModels.join(\',\') || undefined"');
+        expect(popup).toContain('没有找到包含“{{ serviceSearchQuery.trim() }}”的服务或模型');
+        expect(popup).toContain('serviceSearchInput.value?.focus()');
+        expect(popup).toContain('const moreServicesOpen = ref(false)');
+        expect(popup).toContain('moreServicesOpen.value = selectedServiceIsMore.value');
+        expect(styles).toContain('.service-picker-results { min-height: 0; overflow-y: auto; scrollbar-width: thin; }');
+    });
 });

--- a/tests/serviceCatalog.test.ts
+++ b/tests/serviceCatalog.test.ts
@@ -5,6 +5,7 @@ import {
   filterModels,
   filterServiceGroups,
   getSelectedModelLabel,
+  searchServiceOptions,
   splitModelOptions,
 } from '@/src/ui/view-model/serviceCatalog'
 import { customModelString, defaultModels, models, servicesType } from '@/src/core/config/catalog'
@@ -58,6 +59,52 @@ describe('service catalog helpers', () => {
     expect(filterModels(modelOptions, 'gpt')).toEqual([
       'gpt-5-mini',
       'GPT-4o',
+    ])
+  })
+
+  it('searches popup services by service name and model keyword', () => {
+    const popupOptions = [
+      { value: 'openai', label: 'OpenAI' },
+      { value: 'tongyi', label: '千问/Qwen' },
+      { value: 'microsoft', label: '微软翻译' },
+    ]
+    const popupModels = new Map([
+      ['openai', ['gpt-5.6-luna', 'gpt-4.1-mini']],
+      ['tongyi', ['qwen3.7-max', 'qwen-mt-flash']],
+    ])
+
+    expect(searchServiceOptions(popupOptions, ' open ', popupModels)).toEqual([
+      { value: 'openai', label: 'OpenAI', matchingModels: [] },
+    ])
+    expect(searchServiceOptions(popupOptions, 'GPT 5.6', popupModels)).toEqual([
+      { value: 'openai', label: 'OpenAI', matchingModels: ['gpt-5.6-luna'] },
+    ])
+    expect(searchServiceOptions(popupOptions, 'qwen-mt', popupModels)).toEqual([
+      { value: 'tongyi', label: '千问/Qwen', matchingModels: ['qwen-mt-flash'] },
+    ])
+    expect(searchServiceOptions(popupOptions, '不存在', popupModels)).toEqual([])
+  })
+
+  it('searches the configured custom model and preserves the unfiltered order', () => {
+    const popupOptions = [
+      { value: 'custom', label: '自定义接口', description: 'OpenAI 兼容服务' },
+      { value: 'microsoft', label: '微软翻译' },
+    ]
+    const popupModels = new Map([['custom', ['gpt-5-mini', customModelString]]])
+
+    expect(searchServiceOptions(
+      popupOptions,
+      'local translation',
+      popupModels,
+      { custom: customModelString },
+      { custom: 'local/translation-model' },
+    )).toEqual([
+      { value: 'custom', label: '自定义接口', description: 'OpenAI 兼容服务', matchingModels: ['local/translation-model'] },
+    ])
+    expect(searchServiceOptions(popupOptions, ' ( ) ', popupModels)).toEqual([])
+    expect(searchServiceOptions(popupOptions, '  ', popupModels)).toEqual([
+      { value: 'custom', label: '自定义接口', description: 'OpenAI 兼容服务', matchingModels: [] },
+      { value: 'microsoft', label: '微软翻译', matchingModels: [] },
     ])
   })
 


### PR DESCRIPTION
## 改动

- 在 popup 翻译服务选择器中增加自动聚焦的快速搜索框。
- 同时匹配服务名称、服务标识、内置模型和已配置的自定义模型，并兼容 gpt 5.6 / gpt-5.6 这类分隔符差异。
- 在结果中展示命中的模型，补充清空、无结果和可访问性状态。
- 常用服务默认收起“更多服务”；当前服务属于更多服务时自动展开，选择搜索结果仍沿用该服务已有模型配置。

## 验证

- pnpm test：134 个测试文件、1828 项测试通过
- pnpm test:coverage：statements / branches / functions / lines 均为 100%
- pnpm compile
- pnpm build
- pnpm build:firefox
- 生产 Chrome MV3 产物在屏幕外独立 Edge 中验证 qwen、gpt 5.6、mimo-v2.5 和无结果场景；无横向溢出、无控制台错误，选择 MiMo 后保留默认模型

## 已知基线限制

- 通用 full UI runner 仍会被与本改动无关的配置历史旧选择器超时、缓存“清理中”瞬时状态断言阻塞；popup 服务目录、图标、展开/收起和逐项选择已在阻塞前通过，新增搜索另有生产产物定向浏览器验证。
