### PR TITLE
fix(popup): remove video subtitle card highlight

### DIFF
--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -337,11 +337,6 @@ footer button {
 .video-beta-banner small { color: var(--muted); font-size: 9px; }
 .video-feature-card .feature-icon.teal { font-size: 12px; letter-spacing: -.04em; }
 .document-feature-card .feature-icon.blue { font-size: 14px; }
-.video-feature-card.needs-enable {
-  border-color: rgba(239, 71, 118, .38);
-  background: linear-gradient(135deg, var(--surface), rgba(239, 71, 118, .06));
-  box-shadow: 0 6px 18px rgba(239, 71, 118, .08);
-}
 .video-feature-card.needs-enable small { color: var(--brand-strong); font-weight: 700; }
 .feature-card > i { width: 6px; height: 6px; }
 .feature-card > b { color: var(--muted); font-size: 18px; font-weight: 400; }

--- a/tests/popupFeatureVisibility.test.ts
+++ b/tests/popupFeatureVisibility.test.ts
@@ -37,6 +37,16 @@ describe('popup feature visibility', () => {
         expect(options).toContain('aria-label="全文翻译快捷键"');
     });
 
+    it('keeps the default-disabled video subtitle card visually neutral', () => {
+        const popup = source('src/app/popup/PopupApp.vue');
+        const styles = source('src/app/popup/popup.css');
+
+        expect(popup).toContain(":class=\"{ 'needs-enable': !config.videoTranslationEnabled }\"");
+        expect(popup).toContain("'点击开启 · YouTube'");
+        expect(styles).not.toMatch(/\.video-feature-card\.needs-enable\s*\{/u);
+        expect(styles).toContain('.video-feature-card.needs-enable small { color: var(--brand-strong); font-weight: 700; }');
+    });
+
     it('keeps unsupported capability explanations reachable while disabling only their actions', () => {
         const popup = source('src/app/popup/PopupApp.vue');
 


### PR DESCRIPTION
## Summary

- remove the pink border, gradient, and shadow from the default-disabled video subtitle shortcut card
- preserve the disabled-state hint, accessibility label, and click interaction
- add a regression assertion so the card remains visually neutral

This restores the visual intent of #328 after the style was reintroduced during later popup migration work.

## Verification

- pnpm exec vitest run tests/popupFeatureVisibility.test.ts
- pnpm test:regression
- pnpm test:audit
- pnpm compile
- pnpm build
- pnpm build:firefox
- isolated production Edge computed-style check: video card matches an ordinary card with a 1px gray border, no gradient, no shadow, and zero console errors

## UI harness note

The generic full UI suite still times out on an unrelated stale config-history selector, and its popup-only suite times out waiting for a transient cache-clearing label. Focused production Edge proof for this change passed.