### PR TITLE
fix(options): 将翻译设置归入基础配置

### DIFF
--- a/scripts/testing/run-settings-center-ui-test.cjs
+++ b/scripts/testing/run-settings-center-ui-test.cjs
@@ -29,6 +29,12 @@ const expectedNavigation = [
   ['settings-data', '配置管理'],
   ['settings-about', '关于流畅阅读'],
 ];
+const expectedNavigationGroups = [
+  ['基础配置', ['settings-general', 'settings-services', 'settings-translation']],
+  ['专项翻译', ['settings-image-translation', 'settings-video', 'settings-sites']],
+  ['工具与学习', ['settings-translation-center', 'settings-vocabulary']],
+  ['系统与数据', ['settings-advanced', 'settings-data', 'settings-about']],
+];
 const expectedGeneralGroups = ['选择翻译服务', '译文显示', '网页辅助'];
 const expectedTranslationGroups = ['鼠标悬浮翻译', '划词翻译', '输入框翻译', '全文翻译'];
 const configDatabaseName = 'FluentReadConfiguration';
@@ -398,6 +404,14 @@ async function main() {
       throw new Error(`导航顺序或名称异常：${JSON.stringify(navigationContract)}`);
     }
     report.informationArchitecture.navigation = navigationContract;
+    const navigationGroupContract = await page.locator('nav[aria-label="设置分类"] .nav-group').evaluateAll(groups => groups.map(group => [
+      group.querySelector('.nav-group-label')?.textContent?.trim(),
+      [...group.querySelectorAll('button[data-section]')].map(button => button.dataset.section),
+    ]));
+    if (JSON.stringify(navigationGroupContract) !== JSON.stringify(expectedNavigationGroups)) {
+      throw new Error(`导航分组异常：${JSON.stringify(navigationGroupContract)}`);
+    }
+    report.informationArchitecture.navigationGroups = navigationGroupContract;
 
     for (let index = 0; index < navCount; index += 1) {
       const button = navButtons.nth(index);

--- a/src/features/settings/model/navigation.ts
+++ b/src/features/settings/model/navigation.ts
@@ -39,17 +39,17 @@ export const navigationGroups: NavigationGroup[] = [
         kicker: '基础配置', title: '翻译服务', detail: '配置可用的翻译服务、模型、连接和凭据。',
         searchDescription: '微软翻译、OpenAI、DeepSeek、Gemini、模型与令牌',
       },
+      {
+        id: 'settings-translation', icon: '译', label: '翻译设置', description: '悬浮、划词、输入框与全文', group: '基础配置',
+        heading: '翻译设置', summary: '按使用顺序管理鼠标悬浮、划词、输入框和全文翻译。',
+        kicker: '基础配置', title: '翻译设置', detail: '设置鼠标悬浮、划词、输入框与全文翻译的触发方式。',
+        searchDescription: '鼠标悬浮翻译、划词翻译、输入框翻译、全文翻译、自定义快捷键、右键菜单、悬浮球、翻译进度',
+      },
     ],
   },
   {
     label: '专项翻译',
     items: [
-      {
-        id: 'settings-translation', icon: '译', label: '翻译设置', description: '悬浮、划词、输入框与全文', group: '专项翻译',
-        heading: '翻译设置', summary: '按使用顺序管理鼠标悬浮、划词、输入框和全文翻译。',
-        kicker: '专项翻译', title: '翻译设置', detail: '设置鼠标悬浮、划词、输入框与全文翻译的触发方式。',
-        searchDescription: '鼠标悬浮翻译、划词翻译、输入框翻译、全文翻译、自定义快捷键、右键菜单、悬浮球、翻译进度',
-      },
       {
         id: 'settings-image-translation', icon: '图', label: '图片与圈选翻译', description: '图片、圈选与 OCR', group: '专项翻译',
         heading: '图片与圈选翻译', summary: '管理网页图片、圈选区域和本地 OCR 语言包。',

--- a/tests/optionsNavigation.test.ts
+++ b/tests/optionsNavigation.test.ts
@@ -19,12 +19,11 @@ describe('options navigation view-model', () => {
     }))).toEqual([
       {
         label: '基础配置',
-        items: ['settings-general', 'settings-services'],
+        items: ['settings-general', 'settings-services', 'settings-translation'],
       },
       {
         label: '专项翻译',
         items: [
-          'settings-translation',
           'settings-image-translation',
           'settings-video',
           'settings-sites',
@@ -52,6 +51,10 @@ describe('options navigation view-model', () => {
       '配置管理',
       '关于流畅阅读',
     ])
+    expect(resolveNavigationItem('settings-translation')).toMatchObject({
+      group: '基础配置',
+      kicker: '基础配置',
+    })
     expect(DEFAULT_NAVIGATION_SECTION).toBe('settings-general')
   })
 


### PR DESCRIPTION
## 摘要

- 将“翻译设置”从“专项翻译”移动到“基础配置”，排列在“翻译服务”之后。
- 保持 settings-translation 路由 ID、旧链接兼容和页面内容不变。
- 增加导航分组的单元测试与真实 Edge 断言，防止信息架构回归。

## 测试

- 导航专项测试：10/10
- 架构测试：451/451
- 覆盖率测试：1360/1360，Statements / Branches / Functions / Lines 均为 100%
- pnpm compile
- pnpm test:audit
- pnpm build
- pnpm build:firefox
- git diff --check
- 屏幕外隔离 Edge：11 个设置页面及 1366 / 1024 / 820 / 390 四种宽度通过，无横向溢出，控制台错误为 0

## 已知基线问题

旧版通用 UI 回归套件仍等待当前产品已删除的 .config-history-panel，因此在进入本次导航断言前超时。该选择器属于旧测试基线，并非本次改动引入的回归；当前项目级设置中心 UI 验收脚本已完整通过。