### PR TITLE
fix: reduce floating translation UI interference

### DIFF
--- a/scripts/run-full-page-translation-test.cjs
+++ b/scripts/run-full-page-translation-test.cjs
@@ -2,6 +2,8 @@
 
 // 这个脚本只使用临时 Edge profile 和真实 Alt+T 键盘手势，回归全文翻译的
 // 识别、按钮特殊处理、富文本结构、动态节点、Shadow DOM 以及恢复流程。
+// 传入 --verify-floating-ui 时，还会从 closed Shadow DOM 读取悬浮球透明度、
+// 展开/收起、勾选标记几何与离屏任务下的进度面板显隐。
 // 它不会连接用户正在使用的浏览器 profile，也不会通过 JS 合成键盘事件。
 
 const fs = require('node:fs');
@@ -23,12 +25,17 @@ function parseArgs(argv) {
     // 不传此参数时，脚本不会修改任何配置。
     configureService: null,
     focusSafeHelper: null,
+    verifyFloatingUi: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === '--background') continue;
     if (token === '--headed') {
       args.background = false;
+      continue;
+    }
+    if (token === '--verify-floating-ui') {
+      args.verifyFloatingUi = true;
       continue;
     }
     if (!token.startsWith('--')) throw new Error(`无法识别参数：${token}`);
@@ -87,7 +94,7 @@ async function readRequestBody(request) {
   return Buffer.concat(chunks).toString('utf8');
 }
 
-async function startTranslationFixtureServer(unexpectedNetworkRequests = []) {
+async function startTranslationFixtureServer(unexpectedNetworkRequests = [], responseDelayMs = 0) {
   let requestCount = 0;
   let translatedItemCount = 0;
   const server = http.createServer(async (request, response) => {
@@ -101,6 +108,9 @@ async function startTranslationFixtureServer(unexpectedNetworkRequests = []) {
       }
       requestCount += 1;
       translatedItemCount += Array.isArray(payload) ? payload.length : 0;
+      if (responseDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, responseDelayMs));
+      }
       response.writeHead(200, {
         'access-control-allow-origin': '*',
         'cache-control': 'no-store',
@@ -404,6 +414,214 @@ async function readShortcutDiagnostics(page) {
   }));
 }
 
+function cdpAttribute(node, name) {
+  const attributes = node?.attributes || [];
+  for (let index = 0; index < attributes.length; index += 2) {
+    if (attributes[index] === name) return attributes[index + 1] || '';
+  }
+  return '';
+}
+
+function cdpChildren(node) {
+  return [
+    ...(node?.children || []),
+    ...(node?.shadowRoots || []),
+    ...(node?.contentDocument ? [node.contentDocument] : []),
+  ];
+}
+
+function findCdpNode(node, predicate) {
+  if (!node) return null;
+  if (predicate(node)) return node;
+  for (const child of cdpChildren(node)) {
+    const match = findCdpNode(child, predicate);
+    if (match) return match;
+  }
+  return null;
+}
+
+function hasCdpClass(node, className) {
+  return cdpAttribute(node, 'class').split(/\s+/).includes(className);
+}
+
+function quadBounds(quad) {
+  if (!Array.isArray(quad) || quad.length < 8) return null;
+  const xs = [quad[0], quad[2], quad[4], quad[6]];
+  const ys = [quad[1], quad[3], quad[5], quad[7]];
+  return {
+    left: Math.min(...xs),
+    top: Math.min(...ys),
+    right: Math.max(...xs),
+    bottom: Math.max(...ys),
+  };
+}
+
+async function computedStyleValues(session, node, names) {
+  if (!node) return {};
+  const { computedStyle } = await session.send('CSS.getComputedStyleForNode', { nodeId: node.nodeId });
+  return Object.fromEntries(computedStyle
+    .filter((entry) => names.includes(entry.name))
+    .map((entry) => [entry.name, entry.value]));
+}
+
+async function nodeBounds(session, node) {
+  if (!node) return null;
+  try {
+    const { model } = await session.send('DOM.getBoxModel', { nodeId: node.nodeId });
+    return quadBounds(model.border || model.content);
+  } catch {
+    return null;
+  }
+}
+
+async function readFloatingUiState(page) {
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('DOM.enable');
+    await session.send('CSS.enable');
+    const { root } = await session.send('DOM.getDocument', { depth: -1, pierce: true });
+    const floatingHost = findCdpNode(root, node => cdpAttribute(node, 'id') === 'fluent-read-floating-ball-container');
+    const ball = findCdpNode(floatingHost, node => hasCdpClass(node, 'fr-floating-ball'));
+    const main = findCdpNode(ball, node => hasCdpClass(node, 'floating-ball-main'));
+    const translateTool = findCdpNode(ball, node => hasCdpClass(node, 'floating-ball-translate'));
+    const mainCheck = findCdpNode(main, node => node !== main && hasCdpClass(node, 'check-mark'));
+    const shortcutTooltip = findCdpNode(ball, node => hasCdpClass(node, 'shortcut-tooltip'));
+    const progressHost = findCdpNode(root, node => cdpAttribute(node, 'id') === 'fluent-read-translation-status-container');
+    const progressPanel = findCdpNode(progressHost, node => hasCdpClass(node, 'fr-translation-progress'));
+    const progressCompactCheck = findCdpNode(progressPanel, node => hasCdpClass(node, 'fr-progress-compact-check'));
+    const [mainStyle, toolStyle, mainBox, translateToolBox, checkBox] = await Promise.all([
+      computedStyleValues(session, main, ['opacity', 'transform']),
+      computedStyleValues(session, translateTool, ['opacity', 'visibility', 'display']),
+      nodeBounds(session, main),
+      nodeBounds(session, translateTool),
+      nodeBounds(session, mainCheck),
+    ]);
+    const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+    const checkVisible = Boolean(checkBox &&
+      checkBox.right > 0 && checkBox.left < viewport.width &&
+      checkBox.bottom > 0 && checkBox.top < viewport.height);
+    return {
+      host: Boolean(floatingHost),
+      ball: Boolean(ball),
+      ballClass: cdpAttribute(ball, 'class'),
+      position: cdpAttribute(ball, 'data-position'),
+      expanded: hasCdpClass(ball, 'floating-ball-expanded'),
+      translated: hasCdpClass(ball, 'is-translating'),
+      mainOpacity: Number(mainStyle.opacity),
+      mainTransform: mainStyle.transform || '',
+      mainBox,
+      translateToolBox,
+      translateToolOpacity: Number(toolStyle.opacity),
+      translateToolVisibility: toolStyle.visibility || '',
+      translateToolDisplay: toolStyle.display || '',
+      check: Boolean(mainCheck),
+      checkBox,
+      checkVisible,
+      shortcutTooltip: Boolean(shortcutTooltip),
+      progressHost: Boolean(progressHost),
+      progressPanel: Boolean(progressPanel),
+      progressPanelClass: cdpAttribute(progressPanel, 'class'),
+      progressCompact: hasCdpClass(progressPanel, 'fr-compact'),
+      progressCompactCheck: Boolean(progressCompactCheck),
+      progress: progressPanel ? {
+        running: Number(cdpAttribute(progressPanel, 'data-running')),
+        remaining: Number(cdpAttribute(progressPanel, 'data-remaining')),
+        queued: Number(cdpAttribute(progressPanel, 'data-queued')),
+        offscreen: Number(cdpAttribute(progressPanel, 'data-offscreen')),
+      } : null,
+    };
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function waitForFloatingUiState(page, predicate, timeout, description) {
+  const deadline = Date.now() + timeout;
+  let state;
+  while (Date.now() < deadline) {
+    state = await readFloatingUiState(page);
+    if (predicate(state)) return state;
+    await page.waitForTimeout(50);
+  }
+  throw new Error(`${description}：${JSON.stringify(state)}`);
+}
+
+async function assertNoAutomaticFloatingExpansion(page, durationMs = 160) {
+  const deadline = Date.now() + durationMs;
+  const samples = [];
+  do {
+    const state = await readFloatingUiState(page);
+    samples.push({expanded: state.expanded, translated: state.translated, check: state.check, shortcutTooltip: state.shortcutTooltip});
+    if (state.expanded || state.shortcutTooltip) {
+      throw new Error(`全文快捷键不应自动展开悬浮球或弹提示：${JSON.stringify({state, samples})}`);
+    }
+    await page.waitForTimeout(20);
+  } while (Date.now() < deadline);
+  return samples;
+}
+
+function isCollapsedFloatingUiState(state, translated) {
+  return Boolean(state.host && state.ball && !state.expanded && state.translated === translated &&
+    Math.abs(state.mainOpacity - 0.52) <= 0.03 && state.translateToolOpacity === 0 &&
+    state.check === translated && (!translated || state.checkVisible));
+}
+
+function assertCollapsedFloatingUi(state, translated, label) {
+  if (!isCollapsedFloatingUiState(state, translated)) {
+    throw new Error(`${label} 悬浮球没有保持低干扰收起状态：${JSON.stringify(state)}`);
+  }
+}
+
+function isExpandedFloatingUiState(state) {
+  return Boolean(state.expanded && Math.abs(state.mainOpacity - 1) <= 0.01 && state.translateToolOpacity === 1);
+}
+
+function assertExpandedFloatingUi(state, label) {
+  if (!isExpandedFloatingUiState(state)) {
+    throw new Error(`${label} 主动悬停后没有清晰展开：${JSON.stringify(state)}`);
+  }
+}
+
+async function movePointerToFloatingMain(page, state) {
+  const box = state.mainBox;
+  if (!box) throw new Error(`无法取得悬浮球几何位置：${JSON.stringify(state)}`);
+  const viewport = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+  const visibleLeft = Math.max(1, box.left);
+  const visibleRight = Math.min(viewport.width - 1, box.right);
+  const visibleTop = Math.max(1, box.top);
+  const visibleBottom = Math.min(viewport.height - 1, box.bottom);
+  if (visibleLeft >= visibleRight || visibleTop >= visibleBottom) {
+    throw new Error(`悬浮球不在可交互视口内：${JSON.stringify({state, viewport})}`);
+  }
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x: 100, y: 100});
+    await page.waitForTimeout(30);
+    await session.send('Input.dispatchMouseEvent', {
+      type: 'mouseMoved',
+      x: (visibleLeft + visibleRight) / 2,
+      y: (visibleTop + visibleBottom) / 2,
+    });
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function clickFloatingTranslateTool(page, state) {
+  const box = state.translateToolBox;
+  if (!box) throw new Error(`无法取得全文翻译按钮几何位置：${JSON.stringify(state)}`);
+  const x = (box.left + box.right) / 2;
+  const y = (box.top + box.bottom) / 2;
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseMoved', x, y});
+    await session.send('Input.dispatchMouseEvent', {type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1});
+    await session.send('Input.dispatchMouseEvent', {type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1});
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
 async function pageState(page) {
   return page.evaluate(() => {
     const get = (selector) => document.querySelector(selector);
@@ -559,7 +777,10 @@ async function main() {
         args: browserArgs,
       });
     }
-    translationFixtureServer = await startTranslationFixtureServer(unexpectedNetworkRequests);
+    translationFixtureServer = await startTranslationFixtureServer(
+      unexpectedNetworkRequests,
+      args.verifyFloatingUi ? 400 : 0,
+    );
     const fixtureUrls = {
       translationUrl: translationFixtureServer.translationUrl,
       blockedUrl: translationFixtureServer.blockedUrl,
@@ -597,8 +818,17 @@ async function main() {
       }
       await route.continue();
     });
-    if (args.configureService) {
-      await readConfig(context, args.timeout, { service: args.configureService }, createIsolatedPage);
+    const configUpdates = {};
+    if (args.configureService) configUpdates.service = args.configureService;
+    if (args.verifyFloatingUi) {
+      Object.assign(configUpdates, {
+        disableFloatingBall: false,
+        translationProgressPanelEnabled: true,
+        fullPageTranslationMode: 'viewport',
+      });
+    }
+    if (Object.keys(configUpdates).length > 0) {
+      await readConfig(context, args.timeout, configUpdates, createIsolatedPage);
     }
     const page = await createIsolatedPage();
     const networkEvents = [];
@@ -640,6 +870,36 @@ async function main() {
     const configResult = await readConfig(context, args.timeout, null, createIsolatedPage);
     if (configResult.config?.floatingBallHotkey !== 'Alt+T') throw new Error(`全文快捷键不是 Alt+T：${configResult.config?.floatingBallHotkey}`);
     if (configResult.config?.service !== args.service) throw new Error(`翻译服务不符：预期 ${args.service}，实际 ${configResult.config?.service}`);
+    const floatingUiEvidence = args.verifyFloatingUi ? {} : null;
+    if (args.verifyFloatingUi) {
+      if (configResult.config?.disableFloatingBall !== false || configResult.config?.translationProgressPanelEnabled !== true ||
+          configResult.config?.fullPageTranslationMode !== 'viewport') {
+        throw new Error(`悬浮 UI 测试配置不正确：${JSON.stringify({
+          disableFloatingBall: configResult.config?.disableFloatingBall,
+          translationProgressPanelEnabled: configResult.config?.translationProgressPanelEnabled,
+          fullPageTranslationMode: configResult.config?.fullPageTranslationMode,
+        })}`);
+      }
+      await page.evaluate(() => {
+        const fixture = document.createElement('section');
+        fixture.id = 'floating-ui-offscreen-fixture';
+        for (let index = 0; index < 60; index += 1) {
+          const paragraph = document.createElement('p');
+          paragraph.id = `floating-ui-offscreen-${index}`;
+          paragraph.style.minHeight = '80px';
+          paragraph.textContent = `Offscreen paragraph ${index} remains pending until the reader scrolls near this part of the document.`;
+          fixture.appendChild(paragraph);
+        }
+        document.body.appendChild(fixture);
+      });
+      floatingUiEvidence.initial = await waitForFloatingUiState(
+        page,
+        state => state.progressHost && isCollapsedFloatingUiState(state, false),
+        args.timeout,
+        '等待低干扰悬浮球初始状态超时',
+      );
+      assertCollapsedFloatingUi(floatingUiEvidence.initial, false, '初始');
+    }
 
     const initialClamp = await page.evaluate(() => {
       const clamp = document.querySelector('#model-description-clamp');
@@ -657,6 +917,16 @@ async function main() {
 
     await installShortcutDiagnostics(page);
     await toggleFullPage(page, activateTestPage);
+    if (args.verifyFloatingUi) {
+      floatingUiEvidence.afterShortcutSamples = await assertNoAutomaticFloatingExpansion(page);
+      floatingUiEvidence.progressDuringWork = await waitForFloatingUiState(
+        page,
+        state => Boolean(state.progressPanel && state.progress &&
+          (state.progress.running > 0 || state.progress.queued > 0)),
+        args.timeout,
+        '等待实际翻译工作展开进度面板超时',
+      );
+    }
     try {
       await waitFor(page, () => document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
         document.querySelector('#model-description .fluent-read-bilingual-content') &&
@@ -695,13 +965,153 @@ async function main() {
     }, args.timeout);
     const translated = await pageState(page);
     assertTranslated(translated, '第一次全文翻译');
-    if (artifactsDir) await page.screenshot({ path: path.join(artifactsDir, 'full-page-translated.png'), fullPage: true });
+    if (args.verifyFloatingUi) {
+      await page.waitForFunction(() => !document.querySelector('.fluent-read-loading'), undefined, {timeout: args.timeout});
+      const offscreenState = await page.evaluate(() => ({
+        lastTranslated: Boolean(document.querySelector('#floating-ui-offscreen-59 .fluent-read-bilingual-content')),
+        translatedCount: document.querySelectorAll('#floating-ui-offscreen-fixture .fluent-read-bilingual-content').length,
+      }));
+      if (offscreenState.lastTranslated || offscreenState.translatedCount >= 60) {
+        throw new Error(`离屏 fixture 没有保留待滚动候选：${JSON.stringify(offscreenState)}`);
+      }
+      floatingUiEvidence.translatedCollapsed = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, true) && !state.progressPanel,
+        args.timeout,
+        '等待全文翻译后的低干扰勾选状态超时',
+      );
+      assertCollapsedFloatingUi(floatingUiEvidence.translatedCollapsed, true, '全文翻译后');
+      await activateTestPage(page);
+      await movePointerToFloatingMain(page, floatingUiEvidence.translatedCollapsed);
+      floatingUiEvidence.expandedOnHover = await waitForFloatingUiState(
+        page,
+        isExpandedFloatingUiState,
+        Math.min(args.timeout, 15_000),
+        '等待主动悬停展开悬浮球超时',
+      );
+      assertExpandedFloatingUi(floatingUiEvidence.expandedOnHover, '全文翻译后');
+      await clickFloatingTranslateTool(page, floatingUiEvidence.expandedOnHover);
+      await waitFor(page, () => !document.querySelector('.fluent-read-bilingual-content'), args.timeout);
+      floatingUiEvidence.pointerRestored = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, false) && !state.progressPanel,
+        args.timeout,
+        '等待鼠标点击恢复后收起悬浮球超时',
+      );
+      assertCollapsedFloatingUi(floatingUiEvidence.pointerRestored, false, '鼠标点击恢复后');
+      await toggleFullPage(page, activateTestPage);
+      floatingUiEvidence.pointerRetranslateSamples = await assertNoAutomaticFloatingExpansion(page);
+      await waitFor(page, () => document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
+        document.querySelector('#model-description .fluent-read-bilingual-content') &&
+        document.querySelector('#dynamic-paragraph .fluent-read-bilingual-content') &&
+        document.querySelector('#shadow-host')?.shadowRoot?.querySelector('#shadow-paragraph .fluent-read-bilingual-content') &&
+        /[\u3400-\u9fff]/u.test(document.querySelector('#save-button')?.textContent || '') &&
+        /[\u3400-\u9fff]/u.test(document.querySelector('#cancel-button')?.textContent || ''), args.timeout);
+      await page.waitForFunction(() => !document.querySelector('.fluent-read-loading'), undefined, {timeout: args.timeout});
+      const offscreenStateAfterPointerCycle = await page.evaluate(() => ({
+        lastTranslated: Boolean(document.querySelector('#floating-ui-offscreen-59 .fluent-read-bilingual-content')),
+        translatedCount: document.querySelectorAll('#floating-ui-offscreen-fixture .fluent-read-bilingual-content').length,
+      }));
+      if (offscreenStateAfterPointerCycle.lastTranslated || offscreenStateAfterPointerCycle.translatedCount >= 60) {
+        throw new Error(`鼠标恢复再翻译后离屏 fixture 状态不正确：${JSON.stringify(offscreenStateAfterPointerCycle)}`);
+      }
+      await page.evaluate(() => document.querySelector('#floating-ui-offscreen-59')?.scrollIntoView({block: 'center'}));
+      floatingUiEvidence.progressAfterScroll = await waitForFloatingUiState(
+        page,
+        state => Boolean(state.progressPanel && state.progress &&
+          (state.progress.running > 0 || state.progress.queued > 0)),
+        args.timeout,
+        '等待滚动后的离屏任务重新展开进度面板超时',
+      );
+      await page.waitForFunction(
+        () => Boolean(document.querySelector('#floating-ui-offscreen-59 .fluent-read-bilingual-content')),
+        undefined,
+        {timeout: args.timeout},
+      );
+      await page.waitForFunction(() => !document.querySelector('.fluent-read-loading'), undefined, {timeout: args.timeout});
+      await page.evaluate(() => window.scrollTo(0, 0));
+      floatingUiEvidence.collapsedAfterScroll = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, true) && !state.progressPanel,
+        args.timeout,
+        '等待滚动批次完成后收起进度面板超时',
+      );
+      floatingUiEvidence.offscreen = {
+        initial: offscreenState,
+        afterPointerCycle: offscreenStateAfterPointerCycle,
+        translatedAfterScroll: await page.evaluate(() => Boolean(
+          document.querySelector('#floating-ui-offscreen-59 .fluent-read-bilingual-content'),
+        )),
+      };
+    }
+    if (artifactsDir) await page.screenshot({
+      path: path.join(artifactsDir, 'full-page-translated.png'),
+      fullPage: !args.verifyFloatingUi,
+    });
 
     await toggleFullPage(page, activateTestPage);
     await waitFor(page, () => !document.querySelector('.fluent-read-bilingual-content'), args.timeout);
     const restored = await pageState(page);
     assertRestored(restored);
-    if (artifactsDir) await page.screenshot({ path: path.join(artifactsDir, 'full-page-restored.png'), fullPage: true });
+    if (args.verifyFloatingUi) {
+      floatingUiEvidence.restored = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, false) && !state.progressPanel,
+        args.timeout,
+        '等待恢复原文后的悬浮状态超时',
+      );
+      assertCollapsedFloatingUi(floatingUiEvidence.restored, false, '恢复原文后');
+    }
+    if (artifactsDir) await page.screenshot({
+      path: path.join(artifactsDir, 'full-page-restored.png'),
+      fullPage: !args.verifyFloatingUi,
+    });
+
+    if (args.verifyFloatingUi) {
+      await readConfig(context, args.timeout, {disableFloatingBall: true}, createIsolatedPage);
+      floatingUiEvidence.progressOnlyInitial = await waitForFloatingUiState(
+        page,
+        state => !state.host && state.progressHost && !state.progressPanel,
+        args.timeout,
+        '等待仅进度面板配置生效超时',
+      );
+      await toggleFullPage(page, activateTestPage);
+      floatingUiEvidence.progressOnlyDuringWork = await waitForFloatingUiState(
+        page,
+        state => Boolean(state.progressPanel && !state.progressCompact && state.progress &&
+          (state.progress.running > 0 || state.progress.queued > 0)),
+        args.timeout,
+        '等待无悬浮球时展开实际进度面板超时',
+      );
+      await page.waitForFunction(
+        () => Boolean(document.querySelector('#paragraph-one .fluent-read-bilingual-content')),
+        undefined,
+        {timeout: args.timeout},
+      );
+      await page.waitForFunction(() => !document.querySelector('.fluent-read-loading'), undefined, {timeout: args.timeout});
+      floatingUiEvidence.progressOnlyCompact = await waitForFloatingUiState(
+        page,
+        state => Boolean(!state.host && state.progressCompact && state.progressCompactCheck &&
+          state.progress && state.progress.running === 0 && state.progress.queued === 0 && state.progress.offscreen > 0),
+        args.timeout,
+        '等待离屏任务退化为淡勾选超时',
+      );
+      await toggleFullPage(page, activateTestPage);
+      await waitFor(page, () => !document.querySelector('.fluent-read-bilingual-content'), args.timeout);
+      floatingUiEvidence.progressOnlyRestored = await waitForFloatingUiState(
+        page,
+        state => !state.host && !state.progressPanel,
+        args.timeout,
+        '等待仅进度面板模式恢复原文超时',
+      );
+      await readConfig(context, args.timeout, {disableFloatingBall: false}, createIsolatedPage);
+      floatingUiEvidence.remountedBeforeRetranslate = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, false),
+        args.timeout,
+        '等待重新启用悬浮球超时',
+      );
+    }
 
     await toggleFullPage(page, activateTestPage);
     await waitFor(page, () => document.querySelector('#paragraph-one .fluent-read-bilingual-content') &&
@@ -712,7 +1122,20 @@ async function main() {
       /[\u3400-\u9fff]/u.test(document.querySelector('#cancel-button')?.textContent || ''), args.timeout);
     const retranslated = await pageState(page);
     assertTranslated(retranslated, '再次全文翻译');
-    if (artifactsDir) await page.screenshot({ path: path.join(artifactsDir, 'full-page-retranslated.png'), fullPage: true });
+    if (args.verifyFloatingUi) {
+      await page.waitForFunction(() => !document.querySelector('.fluent-read-loading'), undefined, {timeout: args.timeout});
+      floatingUiEvidence.retranslated = await waitForFloatingUiState(
+        page,
+        state => isCollapsedFloatingUiState(state, true) && !state.progressPanel,
+        args.timeout,
+        '等待再次全文翻译后的悬浮状态超时',
+      );
+      assertCollapsedFloatingUi(floatingUiEvidence.retranslated, true, '再次全文翻译后');
+    }
+    if (artifactsDir) await page.screenshot({
+      path: path.join(artifactsDir, 'full-page-retranslated.png'),
+      fullPage: !args.verifyFloatingUi,
+    });
     await Promise.allSettled([...pendingWorkerFixtureInstalls]);
     if (workerFixtureInstallErrors.length > 0) {
       throw new Error(`替换 service worker 安装全文翻译 fixture 失败：${JSON.stringify(workerFixtureInstallErrors)}`);
@@ -731,13 +1154,21 @@ async function main() {
       profileDir,
       url: args.url,
       extensionId: configResult.extensionId,
-      config: { floatingBallHotkey: configResult.config.floatingBallHotkey, service: configResult.config.service, display: configResult.config.display },
+      config: {
+        floatingBallHotkey: configResult.config.floatingBallHotkey,
+        service: configResult.config.service,
+        display: configResult.config.display,
+        disableFloatingBall: configResult.config.disableFloatingBall,
+        translationProgressPanelEnabled: configResult.config.translationProgressPanelEnabled,
+        fullPageTranslationMode: configResult.config.fullPageTranslationMode,
+      },
       fixtureTranslationRequestCount,
       fixtureTranslationItemCount,
       unexpectedNetworkRequests,
       translated,
       restored,
       retranslated,
+      floatingUi: floatingUiEvidence,
       consoleErrors: runtimeErrors,
       screenshots: artifactsDir ? [
         path.join(artifactsDir, 'full-page-translated.png'),

--- a/src/features/floating-ball/content/runtime.ts
+++ b/src/features/floating-ball/content/runtime.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/floating-ball/content/runtime.ts
- * 文件职责：协调悬浮球组件在网页中的创建、恢复位置、显隐、翻译状态同步和卸载，并向组件注入全文翻译切换与打开设置页的动作。
- * 主要内容：维护单例 Shadow UI、迟到挂载 requestId、配置订阅与 position-change 消息，提供 mountFloatingBall、toggleFloatingBallTranslation、unmountFloatingBall 三个生命周期入口。
+ * 文件职责：协调悬浮球组件在网页中的创建、恢复位置、显隐、权威翻译状态同步和卸载，并向组件注入全文翻译切换与打开设置页的动作。
+ * 主要内容：维护单例 Shadow UI、迟到挂载 requestId、全文会话订阅与 position-change 消息，提供 mountFloatingBall、toggleFloatingBallTranslation、unmountFloatingBall 三个生命周期入口。
  * 模块边界：运行时只拥有挂载和桥接职责，不实现拖拽视觉或全文翻译算法；FloatingBall.vue 负责交互，full-page feature 提供翻译动作，配置持久化通过 services/config 完成。
  */
 import FloatingBall from '@/src/features/floating-ball/ui/FloatingBall.vue';
@@ -11,6 +11,7 @@ import {
   autoTranslateEnglishPage,
   isFullPageTranslationActive,
   restoreOriginalContent,
+  subscribeFullPageTranslationProgress,
 } from '@/src/features/full-page-translation/public';
 import type { ContentScriptContext } from 'wxt/utils/content-script-context';
 import type { ShadowRootContentScriptUi } from 'wxt/utils/content-script-ui/shadow-root';
@@ -18,6 +19,7 @@ import {createVueShadowUi, type VueShadowMount} from '@/src/platform/shadow-ui';
 
 interface FloatingBallExposed {
   toggleTranslation: () => void;
+  setTranslationState: (isTranslating: boolean) => void;
 }
 
 let floatingBallInstance: FloatingBallExposed | null = null;
@@ -25,6 +27,7 @@ let floatingBallUi: ShadowRootContentScriptUi<VueShadowMount> | null = null;
 let mountingPromise: Promise<FloatingBallExposed | null> | null = null;
 let mountRequestId = 0;
 let contentScriptContext: ContentScriptContext | null = null;
+let unsubscribeFullPageTranslationProgress: (() => void) | null = null;
 
 /** 创建并挂载悬浮球 */
 export function mountFloatingBall(ctx?: ContentScriptContext) {
@@ -89,6 +92,12 @@ export function mountFloatingBall(ctx?: ContentScriptContext) {
 
     floatingBallUi = ui;
     floatingBallInstance = (ui.mounted?.instance as FloatingBallExposed | null | undefined) ?? null;
+    if (floatingBallInstance) {
+      unsubscribeFullPageTranslationProgress?.();
+      unsubscribeFullPageTranslationProgress = subscribeFullPageTranslationProgress((progress) => {
+        floatingBallInstance?.setTranslationState(progress.active);
+      });
+    }
 
     return floatingBallInstance;
   }).catch((error: unknown) => {
@@ -117,6 +126,8 @@ export function toggleFloatingBallTranslation(): boolean {
 export function unmountFloatingBall() {
   // 先使仍在等待的挂载失效，再释放当前实例，避免迟到的 Promise 重新写回句柄。
   mountRequestId++;
+  unsubscribeFullPageTranslationProgress?.();
+  unsubscribeFullPageTranslationProgress = null;
   if (floatingBallUi || floatingBallInstance) {
     if (isFullPageTranslationActive()) {
       restoreOriginalContent();

--- a/src/features/floating-ball/ui/FloatingBall.vue
+++ b/src/features/floating-ball/ui/FloatingBall.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/floating-ball/ui/FloatingBall.vue
- * 文件职责：呈现可拖拽、可展开的页面悬浮球，并把点击切换翻译、拖动停靠、状态动画、打开设置和键盘关闭整合为可复用 Vue 组件。
- * 主要内容：组件根据配置计算主题和位置，使用 Pointer Capture 区分点击与拖拽，限制球体在视口内，发出位置变更与动作事件，并通过 initialTranslating 同步图标和文案。
+ * 文件职责：呈现低干扰、可拖拽和按需展开的页面悬浮球，并把全文翻译状态、拖动停靠、打开设置和键盘关闭整合为可复用 Vue 组件。
+ * 主要内容：组件根据停靠位置控制收起透明度与勾选标记，使用 Pointer Capture 区分点击与拖拽，限制球体在视口内，发出位置变更与动作事件，并通过受控状态同步图标和文案。
  * 模块边界：它只负责视觉与局部交互，不直接调用浏览器消息、保存配置或执行全文翻译；这些副作用由 content/runtime 通过 props、事件和 defineExpose 桥接。
  -->
 <template>
@@ -12,8 +12,6 @@
       'floating-ball-expanded': isExpanded,
       dragging: isDragging,
       'is-translating': isTranslating,
-      animating: isAnimating && config.animations,
-      'static-mode': !config.animations,
     }"
     :data-position="currentDisplayPosition"
     :style="positionStyle"
@@ -69,15 +67,12 @@
         <circle cx="14.27" cy="12" r="2.4" stroke="currentColor" stroke-width="1.7" />
       </svg>
     </button>
-
-    <div v-if="showShortcutTooltip" class="shortcut-tooltip" role="status">{{ shortcutTip }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import type { PropType, CSSProperties } from 'vue';
-import {config} from '@/src/services/config/store';
 
 const DRAG_THRESHOLD = 6;
 const BALL_SIZE = 42;
@@ -128,12 +123,7 @@ const draggedY = ref<number | null>(null);
 const internalPosition = ref<'left' | 'right' | null>(null);
 const isTranslating = ref(props.initialTranslating);
 const floatingBall = ref<HTMLElement | null>(null);
-const showShortcutTooltip = ref(false);
-const shortcutTip = ref('快捷键：Alt+T');
 const dragState = ref<PointerDragState | null>(null);
-const isAnimating = ref(false);
-let animationTimer: ReturnType<typeof setTimeout> | undefined;
-let tooltipTimer: ReturnType<typeof setTimeout> | undefined;
 
 const currentDisplayPosition = computed(() => internalPosition.value || props.position);
 
@@ -250,37 +240,28 @@ function removePointerListeners() {
   window.removeEventListener('pointercancel', cancelPointerInteraction);
 }
 
-function triggerAnimation() {
-  if (!config.animations) return;
-
-  if (animationTimer) clearTimeout(animationTimer);
-  if (tooltipTimer) clearTimeout(tooltipTimer);
-  isAnimating.value = true;
-  showShortcutTooltip.value = true;
-  isExpanded.value = true;
-  tooltipTimer = setTimeout(() => {
-    showShortcutTooltip.value = false;
-  }, 1800);
-  animationTimer = setTimeout(() => {
-    isAnimating.value = false;
-    animationTimer = undefined;
-  }, 500);
+function toggleTranslation(event?: MouseEvent) {
+  if (event && event.detail > 0) {
+    (event.currentTarget as HTMLElement | null)?.blur();
+    isExpanded.value = false;
+  }
+  props.onTranslationToggle(!isTranslating.value);
 }
 
-function toggleTranslation() {
-  isTranslating.value = !isTranslating.value;
-  triggerAnimation();
-  props.onTranslationToggle(isTranslating.value);
+function setTranslationState(nextState: boolean) {
+  isTranslating.value = nextState;
 }
 
-defineExpose({ toggleTranslation });
+defineExpose({ toggleTranslation, setTranslationState });
 
 function handleSettingsClick(event: MouseEvent) {
   props.onSettingsClick(event);
 }
 
 function handleDocumentKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') isExpanded.value = false;
+  if (event.key !== 'Escape' || !isExpanded.value) return;
+  floatingBall.value?.querySelector<HTMLElement>(':focus')?.blur();
+  isExpanded.value = false;
 }
 
 onMounted(() => {
@@ -294,8 +275,6 @@ onBeforeUnmount(() => {
   removePointerListeners();
   window.removeEventListener('resize', updatePositionStyle);
   document.removeEventListener('keydown', handleDocumentKeydown);
-  if (animationTimer) clearTimeout(animationTimer);
-  if (tooltipTimer) clearTimeout(tooltipTimer);
 });
 
 watch(() => props.position, (newPosition) => {
@@ -376,11 +355,13 @@ watch(() => props.initialTranslating, (nextState) => {
   overflow: visible;
 }
 
-.fr-floating-ball:not(.floating-ball-expanded)[data-position="right"] .floating-ball-main {
+.fr-floating-ball:not(.floating-ball-expanded):not(.dragging)[data-position="right"] .floating-ball-main {
+  opacity: 0.52;
   transform: translateX(50%);
 }
 
-.fr-floating-ball:not(.floating-ball-expanded)[data-position="left"] .floating-ball-main {
+.fr-floating-ball:not(.floating-ball-expanded):not(.dragging)[data-position="left"] .floating-ball-main {
+  opacity: 0.52;
   transform: translateX(-50%);
 }
 
@@ -442,14 +423,10 @@ watch(() => props.initialTranslating, (nextState) => {
   box-shadow: 0 8px 22px rgba(240, 106, 146, 0.2);
 }
 
-.is-translating .floating-ball-main {
+.floating-ball-expanded.is-translating .floating-ball-main {
   border-color: transparent;
   box-shadow: none;
   filter: drop-shadow(0 8px 12px rgba(240, 106, 146, 0.3));
-}
-
-.animating .floating-ball-main {
-  animation: floating-ball-pulse 0.62s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .check-mark {
@@ -460,7 +437,7 @@ watch(() => props.initialTranslating, (nextState) => {
   height: 9px;
   border: 1px solid #fff;
   border-radius: 50%;
-  background: #22c55e;
+  background: rgba(34, 197, 94, 0.82);
 }
 
 .check-mark::after {
@@ -475,25 +452,19 @@ watch(() => props.initialTranslating, (nextState) => {
   transform: rotate(45deg);
 }
 
+.fr-floating-ball[data-position="right"] .floating-ball-main .check-mark {
+  right: auto;
+  left: -1px;
+}
+
+.fr-floating-ball[data-position="left"] .floating-ball-main .check-mark {
+  right: -1px;
+  left: auto;
+}
+
 .floating-ball-settings svg {
   width: 18px;
   height: 18px;
-}
-
-.shortcut-tooltip {
-  position: absolute;
-  top: 50%;
-  right: calc(100% + 10px);
-  z-index: 2;
-  padding: 5px 8px;
-  border-radius: 6px;
-  background: rgba(17, 24, 39, 0.9);
-  color: #fff;
-  font-size: 12px;
-  white-space: nowrap;
-  pointer-events: none;
-  transform: translateY(-50%);
-  animation: floating-ball-tooltip-in 0.18s ease both;
 }
 
 .dragging {
@@ -508,21 +479,9 @@ watch(() => props.initialTranslating, (nextState) => {
   box-shadow: 0 8px 25px rgba(240, 106, 146, 0.28);
 }
 
-.dragging .floating-ball-tool,
-.static-mode .shortcut-tooltip {
+.dragging .floating-ball-tool {
   visibility: hidden;
   display: none;
-}
-
-@keyframes floating-ball-tooltip-in {
-  from { opacity: 0; transform: translate(4px, -50%); }
-  to { opacity: 1; transform: translate(0, -50%); }
-}
-
-@keyframes floating-ball-pulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.06); }
-  100% { transform: scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -531,11 +490,6 @@ watch(() => props.initialTranslating, (nextState) => {
   .floating-ball-main,
   .floating-ball-tool {
     transition: none;
-  }
-
-  .shortcut-tooltip,
-  .animating .floating-ball-main {
-    animation: none;
   }
 }
 </style>

--- a/src/features/full-page-translation/progress.ts
+++ b/src/features/full-page-translation/progress.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/features/full-page-translation/progress.ts
  * 文件职责：提供全文翻译进度的独立内存状态源，以 sessionId 隔离新旧翻译任务，并向多个 UI 订阅者安全发布发现、完成和失败计数。
- * 主要内容：定义 FullPageTranslationProgress，包含开始、增量更新、结束、快照读取和订阅 API；数值会归一化，通知时复制状态，并隔离单个 listener 的异常。
+ * 主要内容：定义 FullPageTranslationProgress，包含开始、增量更新、结束、活动工作与紧凑状态判定、快照读取和订阅 API；数值会归一化，通知时复制状态，并隔离单个 listener 的异常。
  * 模块边界：该模块不访问 DOM、配置或浏览器存储，也不决定任务调度；content/runtime 负责更新进度，TranslationProgressPanel.vue 只订阅快照，状态仅存活于当前运行上下文。
  */
 export interface FullPageTranslationProgress {
@@ -45,6 +45,21 @@ function notifyProgressListeners(): void {
 
 function normalizeCount(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+/** 只有正在请求或已经进入队列的工作才需要展开进度面板；离屏候选不应让大面板常驻。 */
+export function hasActiveFullPageTranslationWork(
+  value: Pick<FullPageTranslationProgress, 'active' | 'running' | 'queued'>,
+): boolean {
+  return value.active && (normalizeCount(value.running) > 0 || normalizeCount(value.queued) > 0);
+}
+
+/** 悬浮球不可用且会话暂时没有活动工作时，以淡勾选替代常驻的大进度面板。 */
+export function shouldShowCompactFullPageTranslationStatus(
+  value: Pick<FullPageTranslationProgress, 'active' | 'running' | 'queued'>,
+  floatingBallEnabled: boolean,
+): boolean {
+  return !floatingBallEnabled && value.active && !hasActiveFullPageTranslationWork(value);
 }
 
 export function startFullPageTranslationProgress(): number {

--- a/src/features/full-page-translation/ui/TranslationProgressPanel.vue
+++ b/src/features/full-page-translation/ui/TranslationProgressPanel.vue
@@ -1,7 +1,7 @@
 <!--
  * @file src/features/full-page-translation/ui/TranslationProgressPanel.vue
- * 文件职责：展示全文翻译当前进度、完成比例和失败数量，并允许用户临时收起面板，同时跟随扩展主题与系统深浅色偏好。
- * 主要内容：组件订阅 progress 内存状态和配置更新，计算可见性、百分比与状态文案，管理 matchMedia 监听和卸载清理，并以 aria-live 向辅助技术播报进展。
+ * 文件职责：以半透明工作面板和低存在感状态勾选展示全文翻译进度，并允许用户临时收起，同时跟随扩展主题与系统深浅色偏好。
+ * 主要内容：组件订阅 progress 内存状态和配置更新，有请求或排队任务时展示详情；仅剩离屏候选且悬浮球关闭时退化为淡勾选，避免大面板常驻又不丢失会话提示。
  * 模块边界：组件不启动、取消或重试翻译，也不保存业务进度；数据只来自 progress.ts，是否创建 Shadow UI 由 content/progressPanel.ts 决定，样式局限于组件作用域。
  -->
 <template>
@@ -9,42 +9,57 @@
     <aside
       v-if="isVisible"
       class="fr-translation-progress"
-      :class="{ 'fr-dark': isDark, 'fr-static': !animationsEnabled }"
+      :class="{ 'fr-dark': isDark, 'fr-static': !animationsEnabled, 'fr-compact': isCompact }"
       :data-session-id="progress.sessionId"
       :data-running="progress.running"
       :data-remaining="progress.remaining"
       :data-queued="progress.queued"
       :data-offscreen="progress.offscreen"
     >
-      <span class="fr-progress-indicator" aria-hidden="true">
-        <i />
-        <i />
-        <i />
-      </span>
-
       <span
-        class="fr-progress-copy"
+        v-if="isCompact"
+        class="fr-progress-compact-check"
         role="status"
         aria-live="polite"
-        aria-atomic="true"
-        :aria-label="statusLabel"
+        :aria-label="compactStatusLabel"
       >
-        <strong>翻译进度</strong>
-        <span class="fr-progress-counts">
-          <span>进行中 <b>{{ progress.running }}</b></span>
-          <span class="fr-progress-divider" aria-hidden="true" />
-          <span>剩余 <b>{{ progress.remaining }}</b></span>
-        </span>
-        <small v-if="progress.offscreen > 0">
-          {{ progress.offscreen }} 项将在滚动到附近时翻译
-        </small>
+        <svg viewBox="0 0 20 20" aria-hidden="true">
+          <circle cx="10" cy="10" r="9" />
+          <path d="m5.8 10.2 2.5 2.5 5.8-6" />
+        </svg>
       </span>
 
-      <button type="button" aria-label="本次全文翻译不再显示进度面板" title="本次隐藏" @click="dismiss">
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path d="m4 4 8 8m0-8-8 8" />
-        </svg>
-      </button>
+      <template v-else>
+        <span class="fr-progress-indicator" aria-hidden="true">
+          <i />
+          <i />
+          <i />
+        </span>
+
+        <span
+          class="fr-progress-copy"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          :aria-label="statusLabel"
+        >
+          <strong>翻译进度</strong>
+          <span class="fr-progress-counts">
+            <span>进行中 <b>{{ progress.running }}</b></span>
+            <span class="fr-progress-divider" aria-hidden="true" />
+            <span>剩余 <b>{{ progress.remaining }}</b></span>
+          </span>
+          <small v-if="progress.offscreen > 0">
+            {{ progress.offscreen }} 项将在滚动到附近时翻译
+          </small>
+        </span>
+
+        <button type="button" aria-label="本次全文翻译不再显示进度面板" title="本次隐藏" @click="dismiss">
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="m4 4 8 8m0-8-8 8" />
+          </svg>
+        </button>
+      </template>
     </aside>
   </Transition>
 </template>
@@ -53,6 +68,8 @@
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import {
   getFullPageTranslationProgress,
+  hasActiveFullPageTranslationWork,
+  shouldShowCompactFullPageTranslationStatus,
   subscribeFullPageTranslationProgress,
 } from '@/src/features/full-page-translation/progress';
 import {config, subscribeConfig} from '@/src/services/config/store';
@@ -61,6 +78,7 @@ const progress = ref(getFullPageTranslationProgress());
 const dismissedSessionId = ref<number | null>(null);
 const animationsEnabled = ref(config.animations !== false);
 const configuredTheme = ref(config.theme || 'auto');
+const floatingBallEnabled = ref(config.disableFloatingBall !== true);
 const prefersDark = ref(false);
 const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
@@ -71,9 +89,17 @@ const isDark = computed(() => configuredTheme.value === 'dark' || (
   configuredTheme.value === 'auto' && prefersDark.value
 ));
 
-const isVisible = computed(() => progress.value.active &&
-  progress.value.sessionId !== dismissedSessionId.value &&
-  (progress.value.running > 0 || progress.value.remaining > 0));
+const hasActiveWork = computed(() => hasActiveFullPageTranslationWork(progress.value));
+const isCompact = computed(() => shouldShowCompactFullPageTranslationStatus(
+  progress.value,
+  floatingBallEnabled.value,
+));
+const isVisible = computed(() => progress.value.sessionId !== dismissedSessionId.value &&
+  (hasActiveWork.value || isCompact.value));
+
+const compactStatusLabel = computed(() => progress.value.offscreen > 0
+  ? `全文翻译已开启，${progress.value.offscreen} 项将在滚动到附近时翻译`
+  : '全文翻译已开启');
 
 const statusLabel = computed(() => {
   const offscreen = progress.value.offscreen > 0
@@ -99,6 +125,7 @@ onMounted(() => {
   unsubscribeConfig = subscribeConfig((nextConfig) => {
     animationsEnabled.value = nextConfig.animations !== false;
     configuredTheme.value = nextConfig.theme || 'auto';
+    floatingBallEnabled.value = nextConfig.disableFloatingBall !== true;
   });
 });
 
@@ -125,8 +152,8 @@ onBeforeUnmount(() => {
   padding: 11px 10px 11px 12px;
   border: 1px solid rgba(229, 88, 139, 0.24);
   border-radius: 14px;
-  background: rgba(255, 252, 253, 0.96);
-  box-shadow: 0 12px 32px rgba(68, 38, 52, 0.18), 0 2px 8px rgba(68, 38, 52, 0.08);
+  background: rgba(255, 252, 253, 0.84);
+  box-shadow: 0 10px 28px rgba(68, 38, 52, 0.14), 0 2px 7px rgba(68, 38, 52, 0.06);
   color: #3f3540;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
   font-size: 12px;
@@ -147,6 +174,40 @@ onBeforeUnmount(() => {
   border-radius: 10px;
   background: linear-gradient(145deg, #fff0f5, #ffe0eb);
   color: #e84f87;
+}
+
+.fr-translation-progress.fr-compact {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  grid-template-columns: 1fr;
+  gap: 0;
+  place-items: center;
+  border-color: rgba(34, 197, 94, 0.2);
+  border-radius: 50%;
+  background: rgba(240, 253, 244, 0.68);
+  box-shadow: 0 4px 14px rgba(22, 101, 52, 0.1);
+  pointer-events: none;
+}
+
+.fr-progress-compact-check,
+.fr-progress-compact-check svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+.fr-progress-compact-check circle {
+  fill: rgba(34, 197, 94, 0.66);
+}
+
+.fr-progress-compact-check path {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 .fr-progress-indicator i {
@@ -246,9 +307,15 @@ button svg {
 
 .fr-dark {
   border-color: rgba(242, 116, 162, 0.3);
-  background: rgba(38, 31, 39, 0.96);
-  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.34), 0 2px 8px rgba(0, 0, 0, 0.2);
+  background: rgba(38, 31, 39, 0.84);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28), 0 2px 7px rgba(0, 0, 0, 0.16);
   color: #f7edf1;
+}
+
+.fr-dark.fr-compact {
+  border-color: rgba(74, 222, 128, 0.24);
+  background: rgba(20, 45, 30, 0.68);
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.2);
 }
 
 .fr-dark .fr-progress-indicator {

--- a/tests/contentUiRuntime.test.ts
+++ b/tests/contentUiRuntime.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   autoTranslateEnglishPage: vi.fn(),
   isFullPageTranslationActive: vi.fn(),
   restoreOriginalContent: vi.fn(),
+  subscribeFullPageTranslationProgress: vi.fn(),
+  unsubscribeFullPageTranslationProgress: vi.fn(),
 }));
 
 vi.mock('@/src/services/config/store', () => ({
@@ -31,6 +33,7 @@ vi.mock('@/src/features/full-page-translation/public', () => ({
   autoTranslateEnglishPage: mocks.autoTranslateEnglishPage,
   isFullPageTranslationActive: mocks.isFullPageTranslationActive,
   restoreOriginalContent: mocks.restoreOriginalContent,
+  subscribeFullPageTranslationProgress: mocks.subscribeFullPageTranslationProgress,
 }));
 vi.mock('@/src/features/floating-ball/ui/FloatingBall.vue', () => ({default: {name: 'FloatingBall'}}));
 vi.mock('@/src/features/full-page-translation/ui/TranslationProgressPanel.vue', () => ({
@@ -70,11 +73,14 @@ beforeEach(() => {
     mocks.autoTranslateEnglishPage,
     mocks.isFullPageTranslationActive,
     mocks.restoreOriginalContent,
+    mocks.subscribeFullPageTranslationProgress,
+    mocks.unsubscribeFullPageTranslationProgress,
   ]) mock.mockReset();
   mocks.requestConfigSave.mockResolvedValue(undefined);
   mocks.sendMessage.mockResolvedValue({success: true});
   mocks.autoTranslateEnglishPage.mockResolvedValue(undefined);
   mocks.isFullPageTranslationActive.mockReturnValue(false);
+  mocks.subscribeFullPageTranslationProgress.mockReturnValue(mocks.unsubscribeFullPageTranslationProgress);
 });
 
 describe('悬浮球 content runtime', () => {
@@ -89,12 +95,13 @@ describe('悬浮球 content runtime', () => {
 
   it('通过关闭 Shadow DOM 组装交互，并在卸载时清理翻译状态', async () => {
     const toggleTranslation = vi.fn();
-    const mountedUi = ui({toggleTranslation});
+    const setTranslationState = vi.fn();
+    const mountedUi = ui({toggleTranslation, setTranslationState});
     mocks.createVueShadowUi.mockResolvedValue(mountedUi);
     const runtime = await import('@/src/features/floating-ball/content/runtime');
     const context = {name: 'content'} as never;
 
-    await expect(runtime.mountFloatingBall(context)).resolves.toEqual({toggleTranslation});
+    await expect(runtime.mountFloatingBall(context)).resolves.toEqual({toggleTranslation, setTranslationState});
     const [, options] = mocks.createVueShadowUi.mock.calls[0];
     expect(options).toEqual(expect.objectContaining({
       name: 'fluent-read-floating-ball-ui',
@@ -107,6 +114,12 @@ describe('悬浮球 content runtime', () => {
       initialTranslating: false,
     }));
     expect(runtime.mountFloatingBall()).toBeNull();
+    expect(mocks.subscribeFullPageTranslationProgress).toHaveBeenCalledOnce();
+    const progressListener = mocks.subscribeFullPageTranslationProgress.mock.calls[0][0];
+    progressListener({active: true});
+    progressListener({active: false});
+    expect(setTranslationState).toHaveBeenNthCalledWith(1, true);
+    expect(setTranslationState).toHaveBeenNthCalledWith(2, false);
     expect(runtime.toggleFloatingBallTranslation()).toBe(true);
     expect(toggleTranslation).toHaveBeenCalledOnce();
 
@@ -131,6 +144,7 @@ describe('悬浮球 content runtime', () => {
     runtime.unmountFloatingBall();
     runtime.unmountFloatingBall();
     expect(mountedUi.remove).toHaveBeenCalledOnce();
+    expect(mocks.unsubscribeFullPageTranslationProgress).toHaveBeenCalledOnce();
     expect(mocks.restoreOriginalContent).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/floatingUiPresentation.test.ts
+++ b/tests/floatingUiPresentation.test.ts
@@ -1,0 +1,83 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {describe, expect, it} from 'vitest';
+
+function source(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+function cssRule(file: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = file.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`, 'u'));
+  expect(match, `缺少样式规则：${selector}`).not.toBeNull();
+  return match?.[1] ?? '';
+}
+
+function numericDeclaration(rule: string, property: string): number {
+  const match = rule.match(new RegExp(`${property}:\\s*([0-9.]+)`, 'u'));
+  expect(match, `缺少样式属性：${property}`).not.toBeNull();
+  return Number(match?.[1]);
+}
+
+describe('低干扰悬浮 UI', () => {
+  it('全文翻译切换不再自动展开菜单或弹出快捷键提示', () => {
+    const floatingBall = source('src/features/floating-ball/ui/FloatingBall.vue');
+    const toggleTranslation = floatingBall.match(/function toggleTranslation\([^)]*\) \{([\s\S]*?)\n\}/u)?.[1] ?? '';
+    const handleDocumentKeydown = floatingBall.match(/function handleDocumentKeydown\([^)]*\) \{([\s\S]*?)\n\}/u)?.[1] ?? '';
+
+    expect(toggleTranslation).toContain('props.onTranslationToggle(!isTranslating.value)');
+    expect(toggleTranslation).not.toContain('isExpanded.value = true');
+    expect(toggleTranslation).toContain('isExpanded.value = false');
+    expect(toggleTranslation).toContain('event.detail > 0');
+    expect(toggleTranslation).toContain('?.blur()');
+    expect(toggleTranslation).not.toContain('isTranslating.value =');
+    expect(floatingBall).not.toContain('showShortcutTooltip');
+    expect(floatingBall).toContain('defineExpose({ toggleTranslation, setTranslationState })');
+    expect(handleDocumentKeydown).toContain("querySelector<HTMLElement>(':focus')?.blur()");
+    expect(handleDocumentKeydown).toContain('isExpanded.value = false');
+  });
+
+  it('收起态保持半透明，交互态恢复清晰，并把勾选标记留在可见侧', () => {
+    const floatingBall = source('src/features/floating-ball/ui/FloatingBall.vue');
+    const rightCollapsed = cssRule(
+      floatingBall,
+      '.fr-floating-ball:not(.floating-ball-expanded):not(.dragging)[data-position="right"] .floating-ball-main',
+    );
+    const leftCollapsed = cssRule(
+      floatingBall,
+      '.fr-floating-ball:not(.floating-ball-expanded):not(.dragging)[data-position="left"] .floating-ball-main',
+    );
+    const expanded = cssRule(
+      floatingBall,
+      '.fr-floating-ball.floating-ball-expanded .floating-ball-item',
+    );
+
+    expect(numericDeclaration(rightCollapsed, 'opacity')).toBeGreaterThanOrEqual(0.4);
+    expect(numericDeclaration(rightCollapsed, 'opacity')).toBeLessThanOrEqual(0.6);
+    expect(numericDeclaration(leftCollapsed, 'opacity')).toBe(numericDeclaration(rightCollapsed, 'opacity'));
+    expect(numericDeclaration(expanded, 'opacity')).toBe(1);
+    expect(numericDeclaration(cssRule(floatingBall, '.dragging .floating-ball-main'), 'opacity')).toBe(1);
+    expect(cssRule(
+      floatingBall,
+      '.fr-floating-ball[data-position="right"] .floating-ball-main .check-mark',
+    )).toContain('left: -1px');
+    expect(cssRule(
+      floatingBall,
+      '.fr-floating-ball[data-position="left"] .floating-ball-main .check-mark',
+    )).toContain('right: -1px');
+  });
+
+  it('进度面板使用半透明背景，并由活动请求而非离屏候选决定显隐', () => {
+    const panel = source('src/features/full-page-translation/ui/TranslationProgressPanel.vue');
+    const panelRule = cssRule(panel, '.fr-translation-progress');
+    const backgroundAlpha = Number(panelRule.match(/background:\s*rgba\([^;]+,\s*([0-9.]+)\)/u)?.[1]);
+
+    expect(backgroundAlpha).toBeGreaterThanOrEqual(0.7);
+    expect(backgroundAlpha).toBeLessThan(0.9);
+    expect(panel).toContain('hasActiveFullPageTranslationWork(progress.value)');
+    expect(panel).not.toContain('progress.value.remaining > 0');
+    expect(panel).toContain("class=\"fr-progress-compact-check\"");
+    expect(panel).toContain('shouldShowCompactFullPageTranslationStatus(');
+    expect(panel).toContain("'全文翻译已开启'");
+  });
+});

--- a/tests/fullPageTranslationProgress.test.ts
+++ b/tests/fullPageTranslationProgress.test.ts
@@ -3,6 +3,8 @@ import {afterEach, describe, expect, it, vi} from 'vitest';
 import {
   finishFullPageTranslationProgress,
   getFullPageTranslationProgress,
+  hasActiveFullPageTranslationWork,
+  shouldShowCompactFullPageTranslationStatus,
   startFullPageTranslationProgress,
   subscribeFullPageTranslationProgress,
   updateFullPageTranslationProgress,
@@ -14,6 +16,27 @@ afterEach(() => {
 });
 
 describe('全文翻译进度', () => {
+  it('仅把请求中或已排队任务视为需要展开面板的活动工作', () => {
+    const offscreenOnly = {
+      sessionId: 1,
+      active: true,
+      running: 0,
+      remaining: 6,
+      queued: 0,
+      offscreen: 6,
+    };
+    expect(hasActiveFullPageTranslationWork(offscreenOnly)).toBe(false);
+    expect(hasActiveFullPageTranslationWork({active: true, running: 1, queued: 0})).toBe(true);
+    expect(hasActiveFullPageTranslationWork({active: true, running: 0, queued: 2})).toBe(true);
+    expect(hasActiveFullPageTranslationWork({active: false, running: 3, queued: 4})).toBe(false);
+    expect(hasActiveFullPageTranslationWork({active: true, running: Number.NaN, queued: -1})).toBe(false);
+
+    expect(shouldShowCompactFullPageTranslationStatus(offscreenOnly, false)).toBe(true);
+    expect(shouldShowCompactFullPageTranslationStatus(offscreenOnly, true)).toBe(false);
+    expect(shouldShowCompactFullPageTranslationStatus({active: true, running: 1, queued: 0}, false)).toBe(false);
+    expect(shouldShowCompactFullPageTranslationStatus({active: false, running: 0, queued: 0}, false)).toBe(false);
+  });
+
   it('立即提供快照，并发布进行中、队列与离屏任务数量', () => {
     const listener = vi.fn();
     const unsubscribe = subscribeFullPageTranslationProgress(listener);

--- a/tests/test-matrix.json
+++ b/tests/test-matrix.json
@@ -120,6 +120,7 @@
       "tests/documentTranslationBinary.test.ts",
       "tests/free-translation.test.ts",
       "tests/fullPageTranslationIndicators.test.ts",
+      "tests/floatingUiPresentation.test.ts",
       "tests/featureTranslationClients.test.ts",
       "tests/gemini.test.ts",
       "tests/google.test.ts",


### PR DESCRIPTION
## 变更摘要

- 将收起态悬浮球调整为低透明显示，仅在悬停、聚焦、拖拽或主动展开时恢复清晰。
- 使用全文翻译会话的权威状态同步淡色勾选标记，快捷键切换不再自动展开菜单或弹出提示。
- 仅在存在运行中或排队任务时展示进度详情；仅剩离屏候选时，由悬浮球勾选或紧凑勾选承接状态。
- 保持鼠标点击后立即收起、键盘 Escape 焦点清理、拖拽和左右停靠标记可见性。
- 扩展 closed Shadow DOM 浏览器回归，覆盖翻译、恢复、再次翻译、滚动续译和仅进度面板配置。

## 验证

- `pnpm exec vitest run tests/floatingUiPresentation.test.ts tests/contentUiRuntime.test.ts tests/fullPageTranslationProgress.test.ts`：20 项通过
- `pnpm test:audit`：140 个测试文件、1381 个用例，状态正常
- `pnpm test:coverage`：语句、分支、函数、行覆盖率均为 100%
- `pnpm compile`
- `pnpm build`
- `pnpm build:firefox`
- `pnpm test:userscript`
- `node --check scripts/run-full-page-translation-test.cjs`
- 隔离后台 Edge + Chrome MV3 生产构建：全文翻译 → 恢复 → 再次翻译、滚动批次和仅进度面板流程通过；37 次本地 fixture 翻译请求，无意外外部网络请求或控制台错误

## 范围

- 未新增 popup/options 配置入口，保留现有功能开关和默认行为。
- 参考项目仅用于交互模式研究，未复制代码或引入跨仓库依赖。
