### PR TITLE
fix(config): 修复配置保存与订阅并发竞态

### DIFF
--- a/src/app/background/handlers/configPersistence.ts
+++ b/src/app/background/handlers/configPersistence.ts
@@ -1,7 +1,7 @@
 /**
  * @file src/app/background/handlers/configPersistence.ts
  * 文件职责：在后台可信边界接收配置保存请求，规范化客户端身份与序号，并协调配置快照的串行持久化和响应。
- * 主要内容：声明 persistConfig 协议及依赖，校验普通对象、clientId 与非负 sequence，结合 sender 生成回退身份，调用 prepareConfig 与 persistPreparedConfig 后返回已接受的序号。
+ * 主要内容：声明 persistConfig 协议及依赖，校验普通对象、clientId 与非负 sequence，屏蔽同客户端过期序号，共享同序号在途结果并允许失败后重试，最后返回实际提交 revision。
  * 模块边界：这里只处理跨上下文消息和保存编排，不定义 Config 字段、不直接操作 browser.storage，也不负责历史裁剪；校验、凭据拆分和存储事务由注入的配置服务承担。
  */
 import type {BackgroundMessageHandler} from '../messageRouter';
@@ -127,6 +127,8 @@ export function createConfigPersistenceHandler<TConfig>(
 ): BackgroundMessageHandler<ConfigPersistenceContext, ConfigPersistenceMessage, ConfigPersistenceResponse> {
     let persistQueue: Promise<void> = Promise.resolve();
     const latestSequenceByClient = new Map<string, number>();
+    const committedSequenceByClient = new Map<string, number>();
+    const activeSequenceByClient = new Map<string, {sequence: number; result: Promise<number>}>();
     const localCoordinator = createConfigMutationCoordinator();
     const runMutation = dependencies.runMutation || localCoordinator.run;
 
@@ -134,11 +136,24 @@ export function createConfigPersistenceHandler<TConfig>(
         type: CONFIG_PERSIST_MESSAGE_TYPE,
         async handle(message, context) {
             const request = parseConfigPersistenceMessage(message, context, dependencies.isExtensionUrl);
-            const lastSequence = latestSequenceByClient.get(request.clientId) || 0;
-            if (request.sequence && request.sequence <= lastSequence) {
-                return {success: true, revision: dependencies.getCurrentRevision?.() ?? 0};
+            if (request.sequence) {
+                const committedSequence = committedSequenceByClient.get(request.clientId) || 0;
+                if (request.sequence <= committedSequence) {
+                    return {success: true, revision: dependencies.getCurrentRevision?.() ?? 0};
+                }
+
+                const latestSequence = latestSequenceByClient.get(request.clientId) || 0;
+                if (request.sequence < latestSequence) {
+                    return {success: true, revision: dependencies.getCurrentRevision?.() ?? 0};
+                }
+                const active = activeSequenceByClient.get(request.clientId);
+                if (request.sequence === latestSequence && active?.sequence === request.sequence) {
+                    return {success: true, revision: await active.result};
+                }
+                if (request.sequence > latestSequence) {
+                    latestSequenceByClient.set(request.clientId, request.sequence);
+                }
             }
-            if (request.sequence) latestSequenceByClient.set(request.clientId, request.sequence);
 
             const persist = persistQueue
                 .catch(() => undefined)
@@ -163,13 +178,27 @@ export function createConfigPersistenceHandler<TConfig>(
                         request.allowCredentialUpdates,
                     );
                     await dependencies.saveConfig(prepared, {recordHistory: true});
+                    if (request.sequence) {
+                        committedSequenceByClient.set(request.clientId, Math.max(
+                            committedSequenceByClient.get(request.clientId) || 0,
+                            request.sequence,
+                        ));
+                    }
                     // 必须在同一个 mutation 临界区内捕获本次提交 revision；释放队列后
                     // 其他恢复可能立刻推进全局 revision，不能把它误报成本请求的版本。
                     return dependencies.getCurrentRevision?.() ?? 0;
                 }));
             persistQueue = persist.then(() => undefined, () => undefined);
-            const committedRevision = await persist;
-            return {success: true, revision: committedRevision};
+            const active = request.sequence ? {sequence: request.sequence, result: persist} : null;
+            if (active) activeSequenceByClient.set(request.clientId, active);
+            try {
+                const committedRevision = await persist;
+                return {success: true, revision: committedRevision};
+            } finally {
+                if (activeSequenceByClient.get(request.clientId) === active) {
+                    activeSequenceByClient.delete(request.clientId);
+                }
+            }
         },
     };
 }

--- a/src/platform/storage/configStorage.ts
+++ b/src/platform/storage/configStorage.ts
@@ -2,7 +2,7 @@
  * @file src/platform/storage/configStorage.ts
  *
  * 文件职责：为共享配置 store 提供统一持久化端口，在后台连接加密 IndexedDB，在扩展页面与 content 上下文通过受控 runtime 消息代理读取和订阅。
- * 主要内容：声明配置记录键、主记录存在时的 IndexedDB 直接短路、带加密清理标记的后台旧 storage 原子迁移与验证、会话随机密钥材料与旧 Firefox 内存降级、多键原子写入、内存 watch 通知，以及非后台上下文只读远程适配器和变更消息协议。
+ * 主要内容：声明配置记录键、主记录存在时的 IndexedDB 直接短路、带加密清理标记的后台旧 storage 原子迁移与验证、会话随机密钥材料与旧 Firefox 内存降级、多键原子写入、内存 watch 通知，以及能在并发回读中保留变更意图的非后台只读适配器。
  * 模块边界：本文件不理解 Config 字段、不决定凭据授权、不选择真实浏览器运行上下文；configStorageRuntime 负责装配 WXT legacy storage、后台 repository 或远程 runtime，userscript 构建在该边界替换为 GM storage。
  */
 
@@ -418,6 +418,7 @@ export function createRemoteConfigStorage(runtime: ConfigStorageRuntimePort): Co
     const listeners = new Map<string, Set<ConfigStorageListener>>();
     const values = new Map<string, unknown>();
     const latestReadRequests = new Map<string, Promise<SettledConfigStorageRead>>();
+    const pendingNotificationKeys = new Set<string>();
 
     const waitForStableRead = async (
         key: string,
@@ -436,6 +437,9 @@ export function createRemoteConfigStorage(runtime: ConfigStorageRuntimePort): Co
     };
 
     const readItem = async <T>(key: string, notify = false): Promise<T | null> => {
+        // 变更通知是键级意图，不能绑定在某一个具体读请求上。否则随后发起的
+        // 显式 getItem 会成为 latest owner，但因自身 notify=false 而吞掉 watch 更新。
+        if (notify) pendingNotificationKeys.add(key);
         const previous = values.get(key);
         const request = (async (): Promise<SettledConfigStorageRead> => {
             try {
@@ -455,7 +459,9 @@ export function createRemoteConfigStorage(runtime: ConfigStorageRuntimePort): Co
         // 最后发起请求的 owner 可以更新缓存或通知 watch，避免初始化采用陈旧快照。
         if (stable.owner) {
             values.set(key, value);
-            if (notify) listeners.get(key)?.forEach(listener => listener(value, previous));
+            if (pendingNotificationKeys.delete(key)) {
+                listeners.get(key)?.forEach(listener => listener(value, previous));
+            }
         }
         return value as T | null;
     };

--- a/tests/backgroundConfigPersistenceHandler.test.ts
+++ b/tests/backgroundConfigPersistenceHandler.test.ts
@@ -125,6 +125,12 @@ describe('background config persistence handler', () => {
             clientId: 'legacy-client',
             sequence: 2,
         }, {});
+        await expect(handler.handle({
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            config: {marker: 'stale-while-latest-pending'},
+            clientId: 'legacy-client',
+            sequence: 1,
+        }, {})).resolves.toEqual({success: true, revision: 0});
 
         await expect(Promise.all([first, latest])).resolves.toEqual([
             {success: true, revision: 0},
@@ -213,6 +219,75 @@ describe('background config persistence handler', () => {
         await expect(first).rejects.toThrow('first failed');
         await expect(second).resolves.toEqual({success: true, revision: 4});
         expect(saveOrder).toEqual(['first', 'second']);
+    });
+
+    it('带 sequence 的保存失败后允许同序号重试真正落盘', async () => {
+        const saveConfig = vi.fn()
+            .mockRejectedValueOnce(new Error('storage temporarily unavailable'))
+            .mockResolvedValueOnce(undefined);
+        const handler = createConfigPersistenceHandler(createDependencies({saveConfig}));
+        const message = {
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            config: {marker: 'retryable'},
+            clientId: 'options-retry',
+            sequence: 1,
+        } as const;
+
+        await expect(handler.handle(message, {})).rejects.toThrow('storage temporarily unavailable');
+        await expect(handler.handle(message, {})).resolves.toEqual({success: true, revision: 4});
+        expect(saveConfig).toHaveBeenCalledTimes(2);
+    });
+
+    it('同序号在途重试共享原请求结果，不在落盘前误报成功', async () => {
+        let releaseSave!: () => void;
+        const saveGate = new Promise<void>((resolve) => { releaseSave = resolve; });
+        const saveConfig = vi.fn(async () => {
+            await saveGate;
+            throw new Error('shared failure');
+        });
+        const handler = createConfigPersistenceHandler(createDependencies({saveConfig}));
+        const message = {
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            config: {marker: 'deduplicated'},
+            clientId: 'popup-retry',
+            sequence: 1,
+        } as const;
+
+        const first = handler.handle(message, {});
+        await vi.waitFor(() => expect(saveConfig).toHaveBeenCalledOnce());
+        const duplicate = handler.handle(message, {});
+        releaseSave();
+
+        await expect(first).rejects.toThrow('shared failure');
+        await expect(duplicate).rejects.toThrow('shared failure');
+        expect(saveConfig).toHaveBeenCalledOnce();
+    });
+
+    it('未提交的最新序号屏蔽更旧请求，同序号重复共享成功 revision', async () => {
+        let releaseSave!: () => void;
+        const saveGate = new Promise<void>((resolve) => { releaseSave = resolve; });
+        const saveConfig = vi.fn(async () => saveGate);
+        const handler = createConfigPersistenceHandler(createDependencies({saveConfig}));
+        const latestMessage = {
+            type: CONFIG_PERSIST_MESSAGE_TYPE,
+            config: {marker: 'latest-pending'},
+            clientId: 'pending-client',
+            sequence: 2,
+        } as const;
+
+        const latest = handler.handle(latestMessage, {});
+        await vi.waitFor(() => expect(saveConfig).toHaveBeenCalledOnce());
+        await expect(handler.handle({
+            ...latestMessage,
+            config: {marker: 'stale-pending'},
+            sequence: 1,
+        }, {})).resolves.toEqual({success: true, revision: 4});
+        const duplicate = handler.handle(latestMessage, {});
+        releaseSave();
+
+        await expect(latest).resolves.toEqual({success: true, revision: 4});
+        await expect(duplicate).resolves.toEqual({success: true, revision: 4});
+        expect(saveConfig).toHaveBeenCalledOnce();
     });
 
     it.each([

--- a/tests/configStorage.test.ts
+++ b/tests/configStorage.test.ts
@@ -799,6 +799,31 @@ describe('远程配置 storage port', () => {
         await vi.waitFor(() => expect(listener).toHaveBeenLastCalledWith({revision: 4}, {revision: 3}));
     });
 
+    it('变更回读被随后的显式读取取代时仍通知订阅者', async () => {
+        const runtimeListeners: Array<(message: unknown) => void> = [];
+        const pending: Array<(value: unknown) => void> = [];
+        const sendMessage = vi.fn()
+            .mockResolvedValueOnce({success: true, value: {revision: 1}})
+            .mockImplementation(() => new Promise(resolve => pending.push(resolve)));
+        const storage = createRemoteConfigStorage({
+            sendMessage,
+            onMessage: {addListener: listener => runtimeListeners.push(listener)},
+        });
+        await storage.getItem('local:config');
+        const listener = vi.fn();
+        storage.watch('local:config', listener);
+
+        runtimeListeners[0]?.({type: CONFIG_STORAGE_CHANGED_MESSAGE, key: 'local:config'});
+        const explicitRead = storage.getItem<{revision: number}>('local:config');
+        pending[1]?.({success: true, value: {revision: 3}});
+        await expect(explicitRead).resolves.toEqual({revision: 3});
+        pending[0]?.({success: true, value: {revision: 2}});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(listener).toHaveBeenCalledOnce();
+        expect(listener).toHaveBeenCalledWith({revision: 3}, {revision: 1});
+    });
+
     it('初始化旧读取先返回时仍等待变更回读，并把最新快照返回给原调用方', async () => {
         const runtimeListeners: Array<(message: unknown) => void> = [];
         const pending: Array<(value: unknown) => void> = [];


### PR DESCRIPTION
## 摘要

- 修复带 sequence 的配置保存失败后，同序号重试被误报成功但未真正落盘的问题
- 修复同序号在途重复请求提前返回成功、未共享实际保存结果的问题
- 修复远程配置变更回读被后续显式读取取代时丢失 watch 通知的问题
- 补充失败重试、在途去重、过期序号和并发通知回归测试

## 验证

- 并发专项：49/49 通过
- pnpm compile 通过
- pnpm test:regression:all 通过：测试审计、严格覆盖率 100%、Chrome/Firefox/userscript/文档构建全部通过
- 生产 Edge 隐藏隔离浏览器设置中心验证通过，控制台错误为 0
- git diff --check 通过